### PR TITLE
Feat/responsive design for S2b | ApiDelegationOverviewPaged

### DIFF
--- a/src/components/apiDelegation/given/OverviewPage/OverviewPage.module.css
+++ b/src/components/apiDelegation/given/OverviewPage/OverviewPage.module.css
@@ -1,0 +1,14 @@
+.pageHeaderWrapper{
+    width: auto;
+    display: flex;
+    overflow-wrap: anywhere ;
+}
+
+@media only screen and (max-width: 576px) {
+    .pageHeaderWrapper{
+        background-color: #022f51;
+        height: 160px;
+        flex: none;
+        align-items: center;
+    }
+  }

--- a/src/components/apiDelegation/given/OverviewPage/OverviewPage.tsx
+++ b/src/components/apiDelegation/given/OverviewPage/OverviewPage.tsx
@@ -8,13 +8,17 @@ import { OverviewPageContent } from '../../reusables/OverviewPageContent';
 import { LayoutState } from '../../reusables/LayoutState';
 import { PageContainer } from '../../../reusables/PageContainer';
 
+import classes from './OverviewPage.module.css';
+
 export const OverviewPage = () => {
   const { t } = useTranslation('common');
 
   return (
     <PageContainer>
       <Page>
-        <PageHeader icon={<ApiIcon />}>{t('api_delegation.api_delegations')}</PageHeader>
+        <div className={classes.pageHeaderWrapper}>
+          <PageHeader icon={<ApiIcon />}>{t('api_delegation.api_delegations')}</PageHeader>
+        </div>
         <PageContent>
           <OverviewPageContent layout={LayoutState.Given} />
         </PageContent>

--- a/src/components/apiDelegation/reusables/OverviewPageContent/OverviewPageContent.module.css
+++ b/src/components/apiDelegation/reusables/OverviewPageContent/OverviewPageContent.module.css
@@ -48,3 +48,11 @@
 .infoPanelWrapper{
   overflow-wrap: anywhere;
 }
+
+@media only screen and (max-width: 576px) {
+  .apiSubheading{
+    font-size: 16px;
+    margin-top: 20px;
+    margin-bottom: 0px;
+  }
+}

--- a/src/components/apiDelegation/reusables/OverviewPageContent/OverviewPageContent.module.css
+++ b/src/components/apiDelegation/reusables/OverviewPageContent/OverviewPageContent.module.css
@@ -44,3 +44,7 @@
   font-weight: normal;
   margin-top: -2rem;
 }
+
+.infoPanelWrapper{
+  overflow-wrap: anywhere;
+}

--- a/src/components/apiDelegation/reusables/OverviewPageContent/OverviewPageContent.tsx
+++ b/src/components/apiDelegation/reusables/OverviewPageContent/OverviewPageContent.tsx
@@ -152,9 +152,14 @@ export const OverviewPageContent = ({
             </Button>
           </div>
         )}
-        <Panel title={t('api_delegation.card_title')}>
-          {t('api_delegation.api_panel_content')}
-        </Panel>
+        <div className={classes.infoPanelWrapper}>
+          <Panel
+            title={t('api_delegation.card_title')}
+            forceMobileLayout
+          >
+            {t('api_delegation.api_panel_content')}
+          </Panel>
+        </div>
         <div className={classes.pageContentContainer}>
           <h2 className={classes.apiSubheading}>{accessesHeader}</h2>
           <div className={classes.editButton}>


### PR DESCRIPTION
## Description
Unless we can change font size inside Design System components,
here in Panel and PageHeader components, we run into problems with long words.

Specifically the word "Programmeringsgrensesnitt".

Css for mobile/"315px" size is proposed, as a first approximation.

Assumptions: Design System does provide the prop size="small" for the
Page component, but I assume that the resulting view is unacceptable.

## Related Issue(s)
- #41 

