### PR TITLE
Added informative text when user has no active delegations to display

### DIFF
--- a/src/components/apiDelegation/reusables/OverviewPageContent/OverviewPageContent.module.css
+++ b/src/components/apiDelegation/reusables/OverviewPageContent/OverviewPageContent.module.css
@@ -8,7 +8,7 @@
     margin-top: 0rem;
   }
 
-  .pageContentContainer {
+  .activeDelegationsHeader {
     margin-top: 0.1rem;
   }
 
@@ -26,8 +26,10 @@
     margin-bottom: 3rem;
   }
 
-  .pageContentContainer {
+  .activeDelegationsHeader {
     margin-top: 2rem;
+    display: flex;
+    align-items: center;
   }
 
   .saveSection{
@@ -42,15 +44,15 @@
     flex: 1;
   }
 
-  .pageContentContainer {
-    display: flex;
-    align-items: center;
-  }
 
-  .accordion{
+  .activeDelegations{
     overflow-y: auto;
     max-height: 500px;
   }
+}
+
+.noActiveDelegations {
+  margin-top: 1.5rem;
 }
 
 .spinnerContainer{
@@ -85,6 +87,6 @@
   margin-top: 2rem;
 }
 
-.accordion{
+.activeDelegations{
   min-height: 100px;
 }

--- a/src/components/apiDelegation/reusables/OverviewPageContent/OverviewPageContent.tsx
+++ b/src/components/apiDelegation/reusables/OverviewPageContent/OverviewPageContent.tsx
@@ -58,6 +58,7 @@ export const OverviewPageContent = ({
   let fetchData: () => any;
   let overviewText: string;
   let accessesHeader: string;
+  let noDelegationsInfoText: string;
 
   useEffect(() => {
     if (loading) {
@@ -74,11 +75,13 @@ export const OverviewPageContent = ({
       fetchData = async () => await dispatch(fetchOverviewOrgsOffered());
       overviewText = t('api_delegation.api_overview_text');
       accessesHeader = t('api_delegation.you_have_delegated_accesses');
+      noDelegationsInfoText = t('api_delegation.no_offered_delegations');
       break;
     case LayoutState.Received:
       fetchData = async () => await dispatch(fetchOverviewOrgsReceived());
       overviewText = t('api_delegation.api_received_overview_text');
       accessesHeader = t('api_delegation.you_have_received_accesses');
+      noDelegationsInfoText = t('api_delegation.no_received_delegations');
       break;
   }
 
@@ -132,7 +135,7 @@ export const OverviewPageContent = ({
     setIsEditable(false);
   };
 
-  const accordions = () => {
+  const activeDelegations = () => {
     if (error) {
       return (
         <div className={classes.errorPanel}>
@@ -156,6 +159,8 @@ export const OverviewPageContent = ({
           />
         </div>
       );
+    } else if (overviewOrgs.length < 1) {
+      return <h3 className={classes.noActiveDelegations}>{noDelegationsInfoText}</h3>;
     }
     return overviewOrgs.map((org) => (
       <OrgDelegationAccordion
@@ -199,7 +204,7 @@ export const OverviewPageContent = ({
         </Panel>
         <div>
           {overviewOrgs.length > 0 && (
-            <div className={classes.pageContentContainer}>
+            <div className={classes.activeDelegationsHeader}>
               {isSm ? (
                 <h3 className={classes.apiSubheading}>{accessesHeader}</h3>
               ) : (
@@ -229,7 +234,7 @@ export const OverviewPageContent = ({
             </div>
           )}
         </div>
-        <div className={classes.accordion}>{accordions()}</div>
+        <div className={classes.activeDelegations}>{activeDelegations()}</div>
         {isEditable && (
           <div className={classes.saveSection}>
             <Button

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -74,6 +74,8 @@
     "receipt_page_main_button": "To API-overview",
     "failed_delegations": "These API delegations went wrong and were therefore not assigned",
     "succesful_delegations": "These API delegations were successful",
+    "no_offered_delegations": "Your organisation hasn't delegated any APIs",
+    "no_received_delegations": "Your organisation hasn't received any API delegations",
     "not_found_site_type": "Error 404",
     "not_found_site_header": "Oops! You have tried to reach a page we do not know",
     "not_found_site_upper_text": "We do not know where you really intended to go, but perhaps you can find what you are looking for on some of these pages:",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -73,6 +73,8 @@
     "delegations_not_registered": "Valgene dine ble ikke registrert. Vennligst start delegerings\u00adprosessen på nytt.",
     "failed_delegations": "Disse api-delegeringene gikk galt og ble derfor ikke tildelt",
     "succesful_delegations": "Disse api-delegeringene ble gitt",
+    "no_offered_delegations": "Din virksomhet har ikke delegert noen API-tilganger",
+    "no_received_delegations": "Din virksomhet har ikke blitt tildelt noen API-tilganger",
     "not_found_site_error_type": "Feil 404",
     "not_found_site_header": "Oi! Du har prøvd å komme til en side vi ikke vet om",
     "not_found_site_upper_text": "Vi vet ikke hvor du egentlig skulle, men kanskje du kan finne det du leter etter på noen av disse sidene:",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -72,6 +72,8 @@
     "delegations_not_registered": "Vala dine vart ikkje registrerte. Vennlegast start delegeringsprosessen på nytt.",
     "failed_delegations": "Desse API-delegeringene gjekk gale og vart derfor ikkje tildelte",
     "succesful_delegations": "Desse API-delegeringene vart tildelte",
+    "no_offered_delegations": "Virksemda di har ikkje delegert nokre API-tilganger",
+    "no_received_delegations": "Virksemda di har ikkje blitt tildelt nokre API-tilganger",
     "not_found_site_error_type": "Feil 404",
     "not_found_site_header": "Oi! Du har freista å komme til ei side vi ikkje veit om",
     "not_found_site_upper_text": "Vi veit ikkje kvar du i røynda skulle, men kanskje du kan finne det du leitar etter på nokre av desse sidene:",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The user is now informed that the organisation has no received/offered api delegations when that is the case.
PR also include some minor clean-up in naming

## Related Issue(s)
- [issue in access-management repo](https://github.com/Altinn/altinn-access-management/issues/393)

### Visualization
![image](https://user-images.githubusercontent.com/22012997/231199169-d44ce8de-cc17-45f6-aa11-4bb70f4b1295.png)


## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
