### PR TITLE
Fix: redirect to login-page when token has timed out

### DIFF
--- a/src/resources/Token/RefreshToken.tsx
+++ b/src/resources/Token/RefreshToken.tsx
@@ -15,12 +15,41 @@ export const RefreshToken = () => {
       return await axios
         .get('accessmanagement/api/v1/authentication/refresh')
         .then((response) => response.data)
-        .catch((error) => {
-          !import.meta.env.DEV && (window.location.pathname = '/');
-          console.error(error);
+        .catch((refreshError) => {
+          // Most likely due to expired token so we redirect to login
+          try {
+            window.location.href = getEnvironmentLoginUrl();
+          } catch (error) {
+            console.error(refreshError, error);
+          }
         });
     }
   }
+
+  const getEnvironmentLoginUrl = () => {
+    // Split on dots. We expect the format to be https://am.ui.{env}.altinn{.cloud?}/etc/etc
+    const domainSplitted: string[] = window.location.host.split('.');
+    let encodedGoToUrl = '';
+    if (domainSplitted.length === 5) {
+      encodedGoToUrl = encodeURIComponent(
+        `https://${domainSplitted[2]}.${domainSplitted[3]}.${domainSplitted[4]}/ui/Profile`,
+      ); // Return user to Profile after login
+      return (
+        `https://platform.${domainSplitted[2]}.${domainSplitted[3]}.${domainSplitted[4]}` +
+        `/authentication/api/v1/authentication?goto=${encodedGoToUrl}`
+      );
+    }
+    if (domainSplitted.length === 4) {
+      encodedGoToUrl = encodeURIComponent(
+        `https://${domainSplitted[2]}.${domainSplitted[3]}/ui/Profile`,
+      ); // Return user to Profile after login
+      return (
+        `https://platform.${domainSplitted[2]}.${domainSplitted[3]}` +
+        `/authentication/api/v1/authentication?goto=${encodedGoToUrl}`
+      );
+    }
+    throw new Error('Unknown domain');
+  };
 
   React.useEffect(() => {
     const setUpEventListeners = () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Instead of redirecting to a page that does not exist on token timeout, redirect to the login page and then to Profile

## Related Issue(s)
- [Issue 384 in access-management](https://github.com/Altinn/altinn-access-management/issues/384)

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
