### PR TITLE
Remove double slash from FrontendBaseUrl causing "bluescreen"

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.AT21.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.AT21.json
@@ -8,7 +8,7 @@
     "OpenIdWellKnownEndpoint": "https://platform.at21.altinn.cloud/authentication/api/v1/openid/"
   },
   "GeneralSettings": {
-    "FrontendBaseUrl": "https://am.ui.at21.altinn.cloud/",
+    "FrontendBaseUrl": "https://am.ui.at21.altinn.cloud",
     "Hostname": "at21.altinn.cloud"
   }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.AT22.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.AT22.json
@@ -8,7 +8,7 @@
     "OpenIdWellKnownEndpoint": "https://platform.at22.altinn.cloud/authentication/api/v1/openid/"
   },
   "GeneralSettings": {
-    "FrontendBaseUrl": "https://am.ui.at22.altinn.cloud/",
+    "FrontendBaseUrl": "https://am.ui.at22.altinn.cloud",
     "Hostname": "at22.altinn.cloud"
   }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.AT23.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.AT23.json
@@ -8,7 +8,7 @@
     "OpenIdWellKnownEndpoint": "https://platform.at23.altinn.cloud/authentication/api/v1/openid/"
   },
   "GeneralSettings": {
-    "FrontendBaseUrl": "https://am.ui.at23.altinn.cloud/",
+    "FrontendBaseUrl": "https://am.ui.at23.altinn.cloud",
     "Hostname": "at23.altinn.cloud"
   }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.AT24.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.AT24.json
@@ -8,7 +8,7 @@
     "OpenIdWellKnownEndpoint": "https://platform.at24.altinn.cloud/authentication/api/v1/openid/"
   },
   "GeneralSettings": {
-    "FrontendBaseUrl": "https://am.ui.at24.altinn.cloud/",
+    "FrontendBaseUrl": "https://am.ui.at24.altinn.cloud",
     "Hostname": "at24.altinn.cloud"
   }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.Prod.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.Prod.json
@@ -8,7 +8,7 @@
     "OpenIdWellKnownEndpoint": "https://platform.altinn.no/authentication/api/v1/openid/"
   },
   "GeneralSettings": {
-    "FrontendBaseUrl": "https://am.ui.altinn.no/",
+    "FrontendBaseUrl": "https://am.ui.altinn.no",
     "Hostname": "altinn.no"
   }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.TT02.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.TT02.json
@@ -8,7 +8,7 @@
     "OpenIdWellKnownEndpoint": "https://platform.tt02.altinn.no/authentication/api/v1/openid/"
   },
   "GeneralSettings": {
-    "FrontendBaseUrl": "https://am.ui.tt02.altinn.no/",
+    "FrontendBaseUrl": "https://am.ui.tt02.altinn.no",
     "Hostname": "tt02.altinn.no"
   }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.YT01.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.YT01.json
@@ -8,7 +8,7 @@
     "OpenIdWellKnownEndpoint": "https://platform.yt01.altinn.cloud/authentication/api/v1/openid/"
   },
   "GeneralSettings": {
-    "FrontendBaseUrl": "https://am.ui.yt01.altinn.cloud/",
+    "FrontendBaseUrl": "https://am.ui.yt01.altinn.cloud",
     "Hostname": "yt01.altinn.cloud"
   }
 }


### PR DESCRIPTION
## Description
Remove double slash from FrontendBaseUrl causing "bluescreen"

## Related Issue(s)
- #298

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
