### PR TITLE
Fix for delegable API resources not being filtered to the user selected language

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/ResourceController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/ResourceController.cs
@@ -51,7 +51,7 @@ namespace Altinn.AccessManagement.UI.Controllers
         {
             int userId = AuthenticationHelper.GetUserId(_httpContextAccessor.HttpContext);
             UserProfile userProfile = await _profileService.GetUserProfile(userId);
-            string languageCode = userProfile?.ProfileSettingPreference?.Language ?? "nb";
+            string languageCode = ProfileHelper.GetLanguageCodeForUser(userProfile);
 
             return await _rap.GetResources(ResourceType.MaskinportenSchema, languageCode);
         }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/ResourceController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/ResourceController.cs
@@ -1,10 +1,10 @@
 ﻿using Altinn.AccessManagement.UI.Core.Enums;
 using Altinn.AccessManagement.UI.Core.Helpers;
-using Altinn.AccessManagement.UI.Core.Models.ResourceRegistry;
 using Altinn.AccessManagement.UI.Core.Models.ResourceRegistry.Frontend;
 using Altinn.AccessManagement.UI.Core.Services.Interfaces;
 using Altinn.AccessManagement.UI.Filters;
 using Altinn.Platform.Profile.Models;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Altinn.AccessManagement.UI.Controllers
@@ -43,19 +43,17 @@ namespace Altinn.AccessManagement.UI.Controllers
         /// <summary>
         /// Get list of maskinprotenschema resources
         /// </summary>
-        /// <param name="party">the partyid</param>
-        /// <returns></returns>
+        /// <returns>List of API service resources</returns>
         [HttpGet]
-        [Route("accessmanagement/api/v1/{party}/resources/maskinportenschema")]
-        public async Task<ActionResult<List<ServiceResourceFE>>> Get([FromRoute] int party)
+        [Authorize]
+        [Route("accessmanagement/api/v1/resources/maskinportenschema")]
+        public async Task<ActionResult<List<ServiceResourceFE>>> Get()
         {
-            string languageCode = "nb";
+            int userId = AuthenticationHelper.GetUserId(_httpContextAccessor.HttpContext);
+            UserProfile userProfile = await _profileService.GetUserProfile(userId);
+            string languageCode = userProfile?.ProfileSettingPreference?.Language ?? "nb";
 
-            //int userId = AuthenticationHelper.GetUserId(_httpContextAccessor.HttpContext);
-            //UserProfile userProfile = await _profileService.GetUserProfile(userId);
-            //string languageCode = ProfileHelper.GetLanguageCodeForUser(userProfile);
-            List<ServiceResourceFE> resources = await _rap.GetResources(ResourceType.MaskinportenSchema, languageCode);
-            return resources;
+            return await _rap.GetResources(ResourceType.MaskinportenSchema, languageCode);
         }
     }
 }

--- a/src/rtk/features/apiDelegation/delegableApi/delegableApiSlice.ts
+++ b/src/rtk/features/apiDelegation/delegableApi/delegableApiSlice.ts
@@ -66,9 +66,8 @@ const mapToDelegableApi = (obj: DelegableApiDto, orgName: string) => {
 };
 
 export const fetchDelegableApis = createAsyncThunk('delegableApi/fetchDelegableApis', async () => {
-  const altinnPartyId = getCookie('AltinnPartyId');
   return await axios
-    .get(`/accessmanagement/api/v1/${altinnPartyId}/resources/maskinportenschema`)
+    .get(`/accessmanagement/api/v1/resources/maskinportenschema`)
     .then((response) => response.data)
     .catch((error) => {
       console.error(error);


### PR DESCRIPTION
## Description
- Makes user authentication required for the endpoint in order to get users selected language from profile
- Removes having to set {Party} in path as support for filtered result based on reportee access is not supported

## Related Issue(s)
- #303

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
