### PR TITLE
ActionBar header is now only a button if it has an onClick function

### DIFF
--- a/src/components/ActionBar/ActionBar.module.css
+++ b/src/components/ActionBar/ActionBar.module.css
@@ -66,13 +66,15 @@
 
 .actionBarHeader {
   --component-actionbar_header_title-color-background: none;
-  font-family: inherit;
+  display: flex;
+  align-items: center;
+  padding: 1px 4px 1px 9px;
   flex: 1 1 auto;
   border-style: none;
   text-align: var(--component-actionbar_header_title-text-align);
   background-color: var(--component-actionbar_header_title-color-background);
+  font-family: inherit;
   font-size: var(--font_size-300);
-  margin-left: 5px;
   line-height: 16px;
   word-break: break-word;
 }

--- a/src/components/ActionBar/ActionBar.test.cy.tsx
+++ b/src/components/ActionBar/ActionBar.test.cy.tsx
@@ -38,7 +38,7 @@ const nonExpandableActionBar = (props: Partial<ActionBarProps> = {}) => (
 describe('ActionBar', () => {
   it('Should render correctly when all props are set and it is expandable', () => {
     const actionButton = <Button>Action</Button>;
-    cy.mount(expandableActionBar({ actions: actionButton, open: true }));
+    cy.mount(expandableActionBar({ actions: actionButton, open: true, onClick: cy.stub }));
     cy.get('[data-testid="action-bar-icon"]').should('exist');
     cy.get('button').should('contain', 'Title');
     cy.get('button').should('contain', 'Subtitle');
@@ -51,9 +51,9 @@ describe('ActionBar', () => {
     const actionButton = <Button>Action</Button>;
     cy.mount(nonExpandableActionBar({ actions: actionButton }));
     cy.get('[data-testid="action-bar-icon"]').should('not.exist');
-    cy.get('button').should('contain', 'Title');
-    cy.get('button').should('contain', 'Subtitle');
-    cy.get('div').should('contain', 'AdditionalText');
+    cy.contains('Title');
+    cy.contains('Subtitle');
+    cy.contains('AdditionalText');
     cy.get('button').should('contain', 'Action');
     cy.get('div').should('not.contain', 'Content');
   });
@@ -139,14 +139,14 @@ describe('ActionBar', () => {
     cy.get('@handleClickSpy').should('not.have.been.called');
   });
 
-  it('should have aria-expanded=false when open=false and not show content', () => {
-    cy.mount(expandableActionBar({ open: false }));
+  it('should have aria-expanded=false and not show content when expandable and open=false', () => {
+    cy.mount(expandableActionBar({ open: false, onClick: cy.stub }));
     cy.get('div').should('not.contain', 'Content');
     cy.get('[data-testid="action-bar"]').should('have.attr', 'aria-expanded', 'false');
   });
 
-  it('should have aria-expanded=true when open=true and show content', () => {
-    cy.mount(expandableActionBar({ open: true }));
+  it('should have aria-expanded=true and not show content when expandable and open=true', () => {
+    cy.mount(expandableActionBar({ open: true, onClick: cy.stub }));
     cy.get('div').should('contain', 'Content');
     cy.get('[data-testid="action-bar"]').should('have.attr', 'aria-expanded', 'true');
   });

--- a/src/components/ActionBar/ActionBar.tsx
+++ b/src/components/ActionBar/ActionBar.tsx
@@ -60,17 +60,15 @@ export const ActionBar = ({
               <ActionBarIcon />
             </div>
           )}
-          {children ? (
+          {onClick ? (
             <button
-              className={cn(classes.actionBarHeader, {
-                [classes.clickable]: onClick,
-              })}
+              className={cn(classes.actionBarHeader, classes.clickable)}
               type='button'
               onClick={onClick}
               id={headerId}
               data-testid='action-bar'
-              aria-expanded={open}
-              aria-controls={contentId}
+              aria-expanded={open ?? undefined}
+              aria-controls={children ? contentId : undefined}
             >
               <div className={classes.actionBarTexts}>
                 <div className={classes.title}>{title}</div>
@@ -78,21 +76,16 @@ export const ActionBar = ({
               </div>
             </button>
           ) : (
-            <button
-              className={cn(classes.actionBarHeader, {
-                [classes.clickable]: onClick,
-              })}
-              type='button'
-              onClick={onClick}
+            <div
+              className={classes.actionBarHeader}
               id={headerId}
               data-testid='action-bar'
-              aria-controls={contentId}
             >
               <div className={classes.actionBarTexts}>
                 <div className={classes.title}>{title}</div>
                 <div className={classes.subtitle}>{subtitle}</div>
               </div>
-            </button>
+            </div>
           )}
           {additionalText && (
             <button

--- a/src/components/ActionBar/ActionBar.tsx
+++ b/src/components/ActionBar/ActionBar.tsx
@@ -53,7 +53,6 @@ export const ActionBar = ({
             [classes.clickable]: onClick,
           })}
           tabIndex={-1}
-          onClick={onClick}
         >
           {children && (
             <div className={cn(classes.actionBarIcon)}>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
ActionBar header is now only a button if it has an onClick function
When there is no onClick, the header does not get focus, as is the standard of non-action elements.

## Related Issue(s)
- #366 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
