### PR TITLE
removed aria-label and added aria-hidden to filter button chevron

### DIFF
--- a/src/components/Filter/FilterButton.tsx
+++ b/src/components/Filter/FilterButton.tsx
@@ -71,7 +71,7 @@ export const FilterButton = forwardRef<HTMLButtonElement, FilterButtonProps>(
           <SvgIcon
             svgIconComponent={<ChevronDownIcon />}
             className={cn(classes.icon, classes.chevron, { [classes.open]: isOpen })}
-            aria-label={isOpen ? 'Close' : 'Open'}
+            aria-hidden
           />
         </button>
       </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Screen readers read the chevron out loud as open or closed when reading the label for the filer button, something that didn't quite work when the filter button is also used to label the dialog box it opens

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
