### PR TITLE
Add resource references to the maskinporten delegation model

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/Delegation/Frontend/MaskinportenSchemaDelegationFE.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/Delegation/Frontend/MaskinportenSchemaDelegationFE.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text.Json.Serialization;
 using Altinn.AccessManagement.UI.Core.Enums;
+using Altinn.AccessManagement.UI.Core.Models.ResourceRegistry;
 
 namespace Altinn.AccessManagement.UI.Core.Models.Delegation.Frontend
 {
@@ -98,5 +99,10 @@ namespace Altinn.AccessManagement.UI.Core.Models.Delegation.Frontend
         /// Description explaining the rights a recipient will receive if given access to the resource
         /// </summary>
         public string RightDescription { get; set; }
+
+        /// <summary>
+        /// ResourceReference
+        /// </summary>
+        public List<ResourceReference> ResourceReferences { get; set; }
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/MaskinportenSchemaService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/MaskinportenSchemaService.cs
@@ -89,6 +89,7 @@ namespace Altinn.AccessManagement.UI.Core.Services
                     delegationFE.ResourceOwnerName = resource.HasCompetentAuthority.Name.GetValueOrDefault(languageCode, "nb");
                     delegationFE.ResourceDescription = resource.Description.GetValueOrDefault(languageCode, "nb");
                     delegationFE.RightDescription = resource.RightDescription.GetValueOrDefault(languageCode, "nb");
+                    delegationFE.ResourceReferences = resource.ResourceReferences;
                 }
 
                 result.Add(delegationFE);


### PR DESCRIPTION
## Description
Added the resource reference list from the resource to the maskinporten delegation model so it can be displayed by the ui.

## Related Issue(s)
- #384

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] All tests run green
