### PR TITLE
Chore/remove eslint config standard

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -14,7 +14,6 @@ module.exports = {
   },
   extends: [
     'plugin:react/recommended',
-    'standard-with-typescript',
     'eslint:recommended',
     'plugin:react/recommended',
     'plugin:prettier/recommended',

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   video: false,
   screenshotOnRunFailure: false,
   e2e: {
-    setupNodeEvents(on, config) {
+    setupNodeEvents() {
       // implement node event listeners here
     },
     baseUrl: 'http://localhost:5173',

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "@vitejs/plugin-react": "^4.0.0",
     "eslint": "^8.45.0",
     "eslint-config-prettier": "^9.0.0",
-    "eslint-config-standard-with-typescript": "^37.0.0",
     "eslint-import-resolver-typescript": "^3.5.5",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-n": "^16.0.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@navikt/aksel-icons": "^5.0.3",
     "@reduxjs/toolkit": "^1.9.5",
     "@tanstack/react-query": "^4.32.6",
+    "@typescript-eslint/parser": "^6.6.0",
     "axios": "^1.3.4",
     "classnames": "^2.3.2",
     "cypress": "12.17.4",

--- a/src/components/ActionBar/ActionBarContent.tsx
+++ b/src/components/ActionBar/ActionBarContent.tsx
@@ -6,7 +6,7 @@ import classes from './ActionBarContent.module.css';
 import { useActionBarContext } from './Context';
 import { type ActionBarProps } from './ActionBar';
 
-export interface ActionBarContentProps extends Pick<ActionBarProps, 'children'> {}
+export type ActionBarContentProps = Pick<ActionBarProps, 'children'>;
 
 export const ActionBarContent = forwardRef<HTMLDivElement, ActionBarContentProps>(
   ({ children }, ref) => {

--- a/src/components/ActionBar/ActionBarHeader.tsx
+++ b/src/components/ActionBar/ActionBarHeader.tsx
@@ -11,11 +11,10 @@ import { ActionBarIcon } from './ActionBarIcon';
 import { ActionBarActions } from './ActionBarActions';
 import { type ActionBarProps } from './ActionBar';
 
-export interface ActionBarHeaderProps
-  extends Pick<
-    ActionBarProps,
-    'headingLevel' | 'title' | 'subtitle' | 'additionalText' | 'actions'
-  > {}
+export type ActionBarHeaderProps = Pick<
+  ActionBarProps,
+  'headingLevel' | 'title' | 'subtitle' | 'additionalText' | 'actions'
+>;
 
 export const ActionBarHeader = forwardRef<HTMLHeadingElement, ActionBarHeaderProps>(
   ({ additionalText, headingLevel, subtitle, title, actions }, ref) => {

--- a/src/components/Filter/Filter.test.cy.tsx
+++ b/src/components/Filter/Filter.test.cy.tsx
@@ -83,7 +83,7 @@ describe(
     });
 
     it('displays apply button as disabled and unclickable until user has made a change', () => {
-      const onApply = (value: string[]) => cy.stub();
+      const onApply = () => cy.stub();
       const onApplySpy = cy.spy(onApply).as('onApplySpy');
       mount(
         <Filter
@@ -127,7 +127,7 @@ describe(
     });
 
     it('applies the chosen options by calling onApply with the chosen values', () => {
-      const onApply = (value: string[]) => cy.stub();
+      const onApply = () => cy.stub();
       const onApplySpy = cy.spy(onApply).as('onApplySpy');
       mount(
         <Filter
@@ -147,7 +147,7 @@ describe(
     });
 
     it('can be opened, navigated, applied with changes by using keybord', () => {
-      const onApply = (value: string[]) => cy.stub();
+      const onApply = () => cy.stub();
       const onApplySpy = cy.spy(onApply).as('onApplySpy');
       mount(
         <Filter
@@ -179,7 +179,7 @@ describe(
     });
 
     it('resets the chosen values when user clicks reset', () => {
-      const onApply = (value: string[]) => cy.stub();
+      const onApply = () => cy.stub();
       const onApplySpy = cy.spy(onApply).as('onApplySpy');
       mount(
         <Filter
@@ -227,7 +227,7 @@ describe(
     });
 
     it('calls onApply if closed without clicking apply', () => {
-      const onApply = (value: string[]) => cy.stub();
+      const onApply = () => cy.stub();
       const onApplySpy = cy.spy(onApply).as('onApplySpy');
       mount(
         <Filter

--- a/src/components/Filter/OptionDisplay.tsx
+++ b/src/components/Filter/OptionDisplay.tsx
@@ -68,7 +68,7 @@ export const OptionDisplay = ({
     }
   }, [options]);
 
-  const changeHandler = (newValues: string[], addedValue?: string) => {
+  const changeHandler = (newValues: string[]) => {
     setSelectedValues(newValues);
     onValueChange?.(newValues);
   };
@@ -77,7 +77,7 @@ export const OptionDisplay = ({
     if (selectedValues?.includes(selectedValue)) {
       changeHandler(selectedValues.filter((v) => v !== selectedValue));
     } else {
-      changeHandler([...selectedValues, selectedValue], selectedValue);
+      changeHandler([...selectedValues, selectedValue]);
     }
   };
 
@@ -85,7 +85,7 @@ export const OptionDisplay = ({
     setSortedOptions(optionSearch(options, searchString));
   };
 
-  const checkboxes = sortedOptions.map((option, index) => {
+  const checkboxes = sortedOptions.map((option) => {
     const isSelected = selectedValues?.includes(option.value);
     return (
       <button

--- a/src/features/apiDelegation/offered/ChooseOrgPage/ChooseOrgPage.tsx
+++ b/src/features/apiDelegation/offered/ChooseOrgPage/ChooseOrgPage.tsx
@@ -102,7 +102,7 @@ export const ChooseOrgPage = () => {
     }
   }
 
-  const delegableOrgItems = delegableOrgs.map((org: DelegableOrg, index: Key) => {
+  const delegableOrgItems = delegableOrgs.map((org: DelegableOrg) => {
     return (
       <div
         className={classes.actionBarWrapper}

--- a/src/rtk/features/apiDelegation/delegableApi/delegableApiSlice.ts
+++ b/src/rtk/features/apiDelegation/delegableApi/delegableApiSlice.ts
@@ -166,7 +166,7 @@ const delegableApiSlice = createSlice({
 
         state.presentedApiList = prioritizedApiList
           .sort((a, b) => (a.priority < b.priority ? 1 : -1))
-          .map(({ priority, ...otherAttr }) => otherAttr);
+          .map(({ ...otherAttr }) => otherAttr);
       } else {
         state.presentedApiList = delegableApiSearchPool;
       }

--- a/src/rtk/features/apiDelegation/delegationRequest/delegationRequestSlice.ts
+++ b/src/rtk/features/apiDelegation/delegationRequest/delegationRequestSlice.ts
@@ -66,7 +66,7 @@ export const postApiDelegation = createAsyncThunk(
           },
         ],
       })
-      .then((response) => {
+      .then(() => {
         return delegation;
       })
       .catch((error) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1634,6 +1634,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/parser@npm:^6.6.0":
+  version: 6.6.0
+  resolution: "@typescript-eslint/parser@npm:6.6.0"
+  dependencies:
+    "@typescript-eslint/scope-manager": 6.6.0
+    "@typescript-eslint/types": 6.6.0
+    "@typescript-eslint/typescript-estree": 6.6.0
+    "@typescript-eslint/visitor-keys": 6.6.0
+    debug: ^4.3.4
+  peerDependencies:
+    eslint: ^7.0.0 || ^8.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: b2d0082b6acc1a85997ebbb60fc73a43f3fe5e5028cb4130938a2cffddc94872c8e0d00a1742be8f8b755bc1994d43b55b7e4660dc88946744094ff2aca4ffd3
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/scope-manager@npm:5.62.0":
   version: 5.62.0
   resolution: "@typescript-eslint/scope-manager@npm:5.62.0"
@@ -1641,6 +1659,16 @@ __metadata:
     "@typescript-eslint/types": 5.62.0
     "@typescript-eslint/visitor-keys": 5.62.0
   checksum: 6062d6b797fe1ce4d275bb0d17204c827494af59b5eaf09d8a78cdd39dadddb31074dded4297aaf5d0f839016d601032857698b0e4516c86a41207de606e9573
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/scope-manager@npm:6.6.0":
+  version: 6.6.0
+  resolution: "@typescript-eslint/scope-manager@npm:6.6.0"
+  dependencies:
+    "@typescript-eslint/types": 6.6.0
+    "@typescript-eslint/visitor-keys": 6.6.0
+  checksum: 18b552fee98894c4f35e9f3d71a276f266ad4e2d7c6b9bb32a9b25caa36cc3768928676972b4e78308098ad53fa8dc6626a82810f17d51c667ce959da3ac11bc
   languageName: node
   linkType: hard
 
@@ -1675,6 +1703,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/types@npm:6.6.0":
+  version: 6.6.0
+  resolution: "@typescript-eslint/types@npm:6.6.0"
+  checksum: d0642ad52e904062a4ac75ac4e6cc51d81ec6030f8830e230df476e69786d3232d45ca0c9ce011add9ede13f0eba4ab7f1eaf679954c6602cf4f43e1ba002be9
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/typescript-estree@npm:5.62.0, @typescript-eslint/typescript-estree@npm:^5.55.0":
   version: 5.62.0
   resolution: "@typescript-eslint/typescript-estree@npm:5.62.0"
@@ -1690,6 +1725,24 @@ __metadata:
     typescript:
       optional: true
   checksum: 3624520abb5807ed8f57b1197e61c7b1ed770c56dfcaca66372d584ff50175225798bccb701f7ef129d62c5989070e1ee3a0aa2d84e56d9524dcf011a2bb1a52
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/typescript-estree@npm:6.6.0":
+  version: 6.6.0
+  resolution: "@typescript-eslint/typescript-estree@npm:6.6.0"
+  dependencies:
+    "@typescript-eslint/types": 6.6.0
+    "@typescript-eslint/visitor-keys": 6.6.0
+    debug: ^4.3.4
+    globby: ^11.1.0
+    is-glob: ^4.0.3
+    semver: ^7.5.4
+    ts-api-utils: ^1.0.1
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 100620bc5865dc9d2551c6be520a34b931bc70eca144c5ab0e275b81e57aa92f24a9d3a57f332d98b96e4581cf7e87211c3196d964f4951c7a2508105e3bd3f5
   languageName: node
   linkType: hard
 
@@ -1749,6 +1802,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/visitor-keys@npm:6.6.0":
+  version: 6.6.0
+  resolution: "@typescript-eslint/visitor-keys@npm:6.6.0"
+  dependencies:
+    "@typescript-eslint/types": 6.6.0
+    eslint-visitor-keys: ^3.4.1
+  checksum: 28171124c5c7d5d10c04c204530508f1488214f2af5eb7e64a5f1cc410c64f02676c04be087adcfd0deb5566f5bb7337b208afcb249719614634c38bcc3da897
+  languageName: node
+  linkType: hard
+
 "@vitejs/plugin-react@npm:^4.0.0":
   version: 4.0.4
   resolution: "@vitejs/plugin-react@npm:4.0.4"
@@ -1785,6 +1848,7 @@ __metadata:
     "@types/react-dom": ^18.0.11
     "@types/redux-logger": ^3.0.9
     "@typescript-eslint/eslint-plugin": ^5.56.0
+    "@typescript-eslint/parser": ^6.6.0
     "@vitejs/plugin-react": ^4.0.0
     axios: ^1.3.4
     classnames: ^2.3.2
@@ -7469,7 +7533,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.0.0, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.5.3":
+"semver@npm:^7.0.0, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.5.3, semver@npm:^7.5.4":
   version: 7.5.4
   resolution: "semver@npm:7.5.4"
   dependencies:
@@ -7983,6 +8047,15 @@ __metadata:
     universalify: ^0.2.0
     url-parse: ^1.5.3
   checksum: c9226afff36492a52118432611af083d1d8493a53ff41ec4ea48e5b583aec744b989e4280bcf476c910ec1525a89a4a0f1cae81c08b18fb2ec3a9b3a72b91dcc
+  languageName: node
+  linkType: hard
+
+"ts-api-utils@npm:^1.0.1":
+  version: 1.0.2
+  resolution: "ts-api-utils@npm:1.0.2"
+  peerDependencies:
+    typescript: ">=4.2.0"
+  checksum: 6375e12ba90b6cbe73f564405248da14c52aa44b62b386e1cbbb1da2640265dd33e99d3e019688dffa874e365cf596b161ccd49351e90638be825c2639697640
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1634,23 +1634,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:^5.52.0":
-  version: 5.62.0
-  resolution: "@typescript-eslint/parser@npm:5.62.0"
-  dependencies:
-    "@typescript-eslint/scope-manager": 5.62.0
-    "@typescript-eslint/types": 5.62.0
-    "@typescript-eslint/typescript-estree": 5.62.0
-    debug: ^4.3.4
-  peerDependencies:
-    eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: d168f4c7f21a7a63f47002e2d319bcbb6173597af5c60c1cf2de046b46c76b4930a093619e69faf2d30214c29ab27b54dcf1efc7046a6a6bd6f37f59a990e752
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/scope-manager@npm:5.62.0":
   version: 5.62.0
   resolution: "@typescript-eslint/scope-manager@npm:5.62.0"
@@ -1809,7 +1792,6 @@ __metadata:
     cypress-real-events: ^1.10.0
     eslint: ^8.45.0
     eslint-config-prettier: ^9.0.0
-    eslint-config-standard-with-typescript: ^37.0.0
     eslint-import-resolver-typescript: ^3.5.5
     eslint-plugin-import: ^2.27.5
     eslint-plugin-jsx-a11y: ^6.7.1
@@ -3640,35 +3622,6 @@ __metadata:
   bin:
     eslint-config-prettier: bin/cli.js
   checksum: 362e991b6cb343f79362bada2d97c202e5303e6865888918a7445c555fb75e4c078b01278e90be98aa98ae22f8597d8e93d48314bec6824f540f7efcab3ce451
-  languageName: node
-  linkType: hard
-
-"eslint-config-standard-with-typescript@npm:^37.0.0":
-  version: 37.0.0
-  resolution: "eslint-config-standard-with-typescript@npm:37.0.0"
-  dependencies:
-    "@typescript-eslint/parser": ^5.52.0
-    eslint-config-standard: 17.1.0
-  peerDependencies:
-    "@typescript-eslint/eslint-plugin": ^5.52.0
-    eslint: ^8.0.1
-    eslint-plugin-import: ^2.25.2
-    eslint-plugin-n: "^15.0.0 || ^16.0.0 "
-    eslint-plugin-promise: ^6.0.0
-    typescript: "*"
-  checksum: 2aecb2be793d62484b4797f484c575edd887ef0ad9c7d8bc30f4adf22d59f3cbe37f1f4e3fb9a35a243a99b7686c3130de81df982d18b0870403062c817c7475
-  languageName: node
-  linkType: hard
-
-"eslint-config-standard@npm:17.1.0":
-  version: 17.1.0
-  resolution: "eslint-config-standard@npm:17.1.0"
-  peerDependencies:
-    eslint: ^8.0.1
-    eslint-plugin-import: ^2.25.2
-    eslint-plugin-n: "^15.0.0 || ^16.0.0 "
-    eslint-plugin-promise: ^6.0.0
-  checksum: 8ed14ffe424b8a7e67b85e44f75c46dc4c6954f7c474c871c56fb0daf40b6b2a7af2db55102b12a440158b2be898e1fb8333b05e3dbeaeaef066fdbc863eaa88
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

1. This PR replaces buggy eslint-config-standard package with typescript-eslint/parser
2. Also fixes lint errors that the new parser linted for us.

## Related Issue(s)
- #511 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
