### PR TITLE
Bugfix/568 userinfobar not supporting equal names

### DIFF
--- a/src/components/UserInfoBar/UserInfoBar.module.css
+++ b/src/components/UserInfoBar/UserInfoBar.module.css
@@ -22,6 +22,7 @@
   margin-left: 1rem;
   text-align: right;
   word-break: break-word;
+  font-size: 12px;
 }
 
 .companyIconContainer {

--- a/src/components/UserInfoBar/UserInfoBar.module.css
+++ b/src/components/UserInfoBar/UserInfoBar.module.css
@@ -26,7 +26,15 @@
 }
 
 .companyIconContainer {
+  display: flex;
   align-self: center;
+  flex-direction: column;
+}
+
+.userInfoTextContainer {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 
 @media only screen and (max-width: 576px) {

--- a/src/components/UserInfoBar/UserInfoBar.tsx
+++ b/src/components/UserInfoBar/UserInfoBar.tsx
@@ -31,8 +31,10 @@ export const UserInfoBar = () => {
         </div>
         <div className={classes.userInfoContent}>
           <div>
-            {userInfoName && <h5 className={classes.userInfoText}>{userInfoName}</h5>}
-            {reporteeName && <h5 className={classes.userInfoText}>for {reporteeName}</h5>}
+            {userInfoName && <p className={classes.userInfoText}>{userInfoName}</p>}
+            {userInfoName !== reporteeName && reporteeName && (
+              <p className={classes.userInfoText}>for {reporteeName}</p>
+            )}
           </div>
           <div className={classes.companyIconContainer}>
             <SvgIcon

--- a/src/components/UserInfoBar/UserInfoBar.tsx
+++ b/src/components/UserInfoBar/UserInfoBar.tsx
@@ -30,7 +30,7 @@ export const UserInfoBar = () => {
           <AltinnLogo />
         </div>
         <div className={classes.userInfoContent}>
-          <div>
+          <div className={classes.userInfoTextContainer}>
             {userInfoName && <p className={classes.userInfoText}>{userInfoName}</p>}
             {userInfoName !== reporteeName && reporteeName && (
               <p className={classes.userInfoText}>for {reporteeName}</p>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove reportee name in UserinfoBar when reporteename and userInfoName is equal

## Related Issue(s)
- #568 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
