### PR TITLE
New local list component as a wrapper for the Designsystem List

### DIFF
--- a/src/components/BorderedList/BorderedList.module.css
+++ b/src/components/BorderedList/BorderedList.module.css
@@ -1,5 +1,5 @@
 .borderedList {
-  --borderStyle: none;
+  --borderStyle: dashed;
   margin-bottom: 0.5rem;
   padding-left: 0;
   border-top-color: #bcc7cc;

--- a/src/components/BorderedList/BorderedList.module.css
+++ b/src/components/BorderedList/BorderedList.module.css
@@ -1,0 +1,16 @@
+.borderedList {
+  --borderStyle: none;
+  margin-bottom: 0.5rem;
+  padding-left: 0;
+  border-top-color: #bcc7cc;
+  border-top-width: 1px;
+  border-top-style: var(--borderStyle);
+}
+
+.dashed {
+  --borderStyle: dashed;
+}
+
+.solid {
+  --borderStyle: solid;
+}

--- a/src/components/BorderedList/BorderedList.tsx
+++ b/src/components/BorderedList/BorderedList.tsx
@@ -1,0 +1,30 @@
+import type { ListProps } from '@digdir/design-system-react';
+import { List } from '@digdir/design-system-react';
+import cn from 'classnames';
+import * as React from 'react';
+
+import classes from './BorderedList.module.css';
+
+export type BorderedListProps = {
+  /**
+   * Style of the border separating the items
+   */
+  borderStyle?: 'solid' | 'dashed';
+} & ListProps;
+
+export const BorderedList = ({
+  borderStyle = 'dashed',
+  children,
+  className,
+  ...rest
+}: BorderedListProps) => {
+  return (
+    <List
+      className={cn(classes.borderedList, { [classes[borderStyle]]: borderStyle }, className)}
+      style={{ paddingLeft: 0 }}
+      {...rest}
+    >
+      {children}
+    </List>
+  );
+};

--- a/src/components/BorderedList/BorderedListItem/BorderedListItem.module.css
+++ b/src/components/BorderedList/BorderedListItem/BorderedListItem.module.css
@@ -1,0 +1,14 @@
+.borderedListItem {
+  --borderStyle: none;
+  border-bottom-color: #bcc7cc;
+  border-bottom-width: 1px;
+  border-bottom-style: var(--borderStyle);
+}
+
+.dashed {
+  --borderStyle: dashed;
+}
+
+.solid {
+  --borderStyle: solid;
+}

--- a/src/components/BorderedList/BorderedListItem/BorderedListItem.module.css
+++ b/src/components/BorderedList/BorderedListItem/BorderedListItem.module.css
@@ -1,8 +1,9 @@
 .borderedListItem {
-  --borderStyle: none;
+  --borderStyle: dashed;
   border-bottom-color: #bcc7cc;
   border-bottom-width: 1px;
   border-bottom-style: var(--borderStyle);
+  list-style: none;
 }
 
 .dashed {

--- a/src/components/BorderedList/BorderedListItem/BorderedListItem.tsx
+++ b/src/components/BorderedList/BorderedListItem/BorderedListItem.tsx
@@ -1,0 +1,31 @@
+import type { ListItemProps } from '@digdir/design-system-react';
+import { List } from '@digdir/design-system-react';
+import cn from 'classnames';
+import * as React from 'react';
+
+import classes from './BorderedListItem.module.css';
+
+export type BorderedListItemProps = {
+  /**
+   * Style of the border separating the items
+   */
+  borderStyle?: 'solid' | 'dashed';
+} & ListItemProps;
+
+export const BorderedListItem = ({
+  borderStyle = 'dashed',
+  children,
+  ...rest
+}: BorderedListItemProps) => {
+  return (
+    <List.Item
+      className={cn(classes.borderedListItem, { [classes[borderStyle]]: borderStyle })}
+      style={{ listStyle: 'none', marginBottom: 0 }}
+      {...rest}
+    >
+      {children}
+    </List.Item>
+  );
+};
+
+BorderedListItem.displayName = 'BorderedList.Item';

--- a/src/components/BorderedList/BorderedListItem/BorderedListItem.tsx
+++ b/src/components/BorderedList/BorderedListItem/BorderedListItem.tsx
@@ -20,7 +20,7 @@ export const BorderedListItem = ({
   return (
     <List.Item
       className={cn(classes.borderedListItem, { [classes[borderStyle]]: borderStyle })}
-      style={{ listStyle: 'none', marginBottom: 0 }}
+      style={{ marginBottom: 0 }}
       {...rest}
     >
       {children}

--- a/src/components/BorderedList/index.ts
+++ b/src/components/BorderedList/index.ts
@@ -1,0 +1,15 @@
+import { BorderedList as BorderedListRoot } from './BorderedList';
+import { BorderedListItem } from './BorderedListItem/BorderedListItem';
+
+export type { BorderedListProps } from './BorderedList';
+export type { BorderedListItemProps } from './BorderedListItem/BorderedListItem';
+
+type BorderedListComponent = typeof BorderedListRoot & {
+  Item: typeof BorderedListItem;
+};
+
+const BorderedList = BorderedListRoot as BorderedListComponent;
+
+BorderedList.Item = BorderedListItem;
+
+export { BorderedList, BorderedListItem };

--- a/src/components/CompactDeletableListItem/CompactDeletableListItem.module.css
+++ b/src/components/CompactDeletableListItem/CompactDeletableListItem.module.css
@@ -57,6 +57,8 @@
 
 .listItemIcon {
   margin-right: 10px;
+  display: flex;
+  justify-content: center;
 }
 
 .middleText {

--- a/src/components/CompactDeletableListItem/CompactDeletableListItem.tsx
+++ b/src/components/CompactDeletableListItem/CompactDeletableListItem.tsx
@@ -1,10 +1,12 @@
 /* eslint-disable @typescript-eslint/restrict-plus-operands */
-import { Button, ListItem } from '@digdir/design-system-react';
+import { Button } from '@digdir/design-system-react';
 import { SvgIcon } from '@altinn/altinn-design-system';
 import { useTranslation } from 'react-i18next';
 import cn from 'classnames';
 import * as React from 'react';
 import { MinusCircleIcon } from '@navikt/aksel-icons';
+
+import { BorderedList } from '../BorderedList';
 
 import classes from './CompactDeletableListItem.module.css';
 
@@ -30,7 +32,7 @@ export const CompactDeletableListItem = ({
   const { t } = useTranslation('common');
 
   return (
-    <ListItem>
+    <BorderedList.Item borderStyle='dashed'>
       <div
         className={classes.compactListItem}
         data-testid='compact-list-item'
@@ -82,6 +84,6 @@ export const CompactDeletableListItem = ({
           </div>
         </div>
       </div>
-    </ListItem>
+    </BorderedList.Item>
   );
 };

--- a/src/components/DeletableListItem/DeletableListItem.test.cy.tsx
+++ b/src/components/DeletableListItem/DeletableListItem.test.cy.tsx
@@ -1,11 +1,10 @@
 import { Provider } from 'react-redux';
 import { mount } from 'cypress/react18';
-import { List } from '@digdir/design-system-react';
 import * as React from 'react';
 
 import type { OverviewOrg } from '@/rtk/features/apiDelegation/overviewOrg/overviewOrgSlice';
 import store from '@/rtk/app/store';
-import { DeletableListItem } from '@/components';
+import { DeletableListItem, BorderedList } from '@/components';
 
 Cypress.Commands.add('mount', (component, options = {}) => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -36,14 +35,14 @@ describe('DeletableListItem', () => {
     };
 
     cy.mount(
-      <List>
+      <BorderedList>
         <DeletableListItem
           softDeleteCallback={() => null}
           softRestoreCallback={() => null}
           item={overviewOrg.apiList[0]}
           isEditable={true}
         />
-      </List>,
+      </BorderedList>,
     );
     cy.findByRole('button', { name: /delete/i }).should('exist');
   });
@@ -67,14 +66,14 @@ describe('DeletableListItem', () => {
     };
 
     cy.mount(
-      <List>
+      <BorderedList>
         <DeletableListItem
           softDeleteCallback={() => null}
           softRestoreCallback={() => null}
           item={overviewOrg.apiList[0]}
           isEditable={false}
         />
-      </List>,
+      </BorderedList>,
     );
     cy.findByRole('button', { name: /delete/i }).should('not.exist');
   });
@@ -98,14 +97,14 @@ describe('DeletableListItem', () => {
     };
 
     cy.mount(
-      <List>
+      <BorderedList>
         <DeletableListItem
           softDeleteCallback={() => null}
           softRestoreCallback={() => null}
           item={overviewOrg.apiList[0]}
           isEditable={true}
         />
-      </List>,
+      </BorderedList>,
     );
 
     cy.get('[data-testid="list-item-texts"]').should(
@@ -141,14 +140,14 @@ describe('DeletableListItem', () => {
     const softDeleteSpy = cy.spy(softDelete).as('softDeleteSpy');
 
     cy.mount(
-      <List>
+      <BorderedList>
         <DeletableListItem
           softDeleteCallback={softDeleteSpy}
           softRestoreCallback={() => null}
           item={overviewOrg.apiList[0]}
           isEditable={true}
         />
-      </List>,
+      </BorderedList>,
     );
 
     cy.findByRole('button', { name: /delete/i }).click();
@@ -180,14 +179,14 @@ describe('DeletableListItem', () => {
     const softRestoreSpy = cy.spy(softRestore).as('softRestoreSpy');
 
     cy.mount(
-      <List>
+      <BorderedList>
         <DeletableListItem
           softDeleteCallback={() => null}
           softRestoreCallback={softRestoreSpy}
           item={overviewOrg.apiList[0]}
           isEditable={true}
         />
-      </List>,
+      </BorderedList>,
     );
 
     cy.findByRole('button', { name: /undo/i }).click();

--- a/src/components/DeletableListItem/DeletableListItem.tsx
+++ b/src/components/DeletableListItem/DeletableListItem.tsx
@@ -1,4 +1,4 @@
-import { Button, ListItem } from '@digdir/design-system-react';
+import { Button } from '@digdir/design-system-react';
 import cn from 'classnames';
 import { useTranslation } from 'react-i18next';
 import * as React from 'react';
@@ -7,6 +7,7 @@ import { MinusCircleIcon, ArrowUndoIcon } from '@navikt/aksel-icons';
 import type { ApiListItem } from '@/rtk/features/apiDelegation/overviewOrg/overviewOrgSlice';
 import { useMediaQuery } from '@/resources/hooks';
 
+import { BorderedList } from '../BorderedList';
 import ScopeList from '../ScopeList/ScopeList';
 
 import classes from './DeletableListItem.module.css';
@@ -58,7 +59,7 @@ export const DeletableListItem = ({
   );
 
   return (
-    <ListItem>
+    <BorderedList.Item borderStyle='solid'>
       <div className={classes.listItem}>
         <div
           data-testid='list-item-texts'
@@ -80,6 +81,6 @@ export const DeletableListItem = ({
         </div>
         {isEditable && isEditableActions}
       </div>
-    </ListItem>
+    </BorderedList.Item>
   );
 };

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -13,3 +13,4 @@ export { Dialog, DialogContent, type DialogProps } from './Dialog';
 export { ProgressModal } from './ProgressModal/ProgressModal';
 export { GroupElements } from './GroupElements/GroupElements';
 export { RestartPrompter } from './RestartPrompter/RestartPrompter';
+export * from './BorderedList';

--- a/src/features/apiDelegation/components/OverviewPageContent/OrgDelegationActionBar/OrgDelegationActionBar.module.css
+++ b/src/features/apiDelegation/components/OverviewPageContent/OrgDelegationActionBar/OrgDelegationActionBar.module.css
@@ -15,7 +15,7 @@
 }
 
 .actionBarContent {
-  padding-right: 10px;
+  padding: 10px 0 10px 10px;
 }
 
 .actionBarText__softDelete {

--- a/src/features/apiDelegation/components/OverviewPageContent/OrgDelegationActionBar/OrgDelegationActionBar.tsx
+++ b/src/features/apiDelegation/components/OverviewPageContent/OrgDelegationActionBar/OrgDelegationActionBar.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Button, List } from '@digdir/design-system-react';
+import { Button } from '@digdir/design-system-react';
 import cn from 'classnames';
 import { useTranslation } from 'react-i18next';
 import * as React from 'react';
@@ -8,7 +8,7 @@ import { MinusCircleIcon, ArrowUndoIcon, PlusCircleIcon } from '@navikt/aksel-ic
 import type { OverviewOrg } from '@/rtk/features/apiDelegation/overviewOrg/overviewOrgSlice';
 import { softDelete, softRestore } from '@/rtk/features/apiDelegation/overviewOrg/overviewOrgSlice';
 import { useAppDispatch } from '@/rtk/app/hooks';
-import { DeletableListItem, ActionBar } from '@/components';
+import { DeletableListItem, ActionBar, BorderedList } from '@/components';
 import { useMediaQuery } from '@/resources/hooks';
 
 import classes from './OrgDelegationActionBar.module.css';
@@ -135,7 +135,7 @@ export const OrgDelegationActionBar = ({
       }
     >
       <div className={classes.actionBarContent}>
-        <List borderStyle={'solid'}>{listItems}</List>
+        <BorderedList borderStyle={'solid'}>{listItems}</BorderedList>
       </div>
     </ActionBar>
   );

--- a/src/features/apiDelegation/offered/ChooseApiPage/ChooseApiPage.tsx
+++ b/src/features/apiDelegation/offered/ChooseApiPage/ChooseApiPage.tsx
@@ -1,5 +1,5 @@
 import { SearchField } from '@altinn/altinn-design-system';
-import { Button, List, Spinner } from '@digdir/design-system-react';
+import { Button, Spinner } from '@digdir/design-system-react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FilterIcon, Buldings3Icon } from '@navikt/aksel-icons';
@@ -14,6 +14,8 @@ import {
   ErrorPanel,
   GroupElements,
   RestartPrompter,
+  DelegationActionBar,
+  BorderedList,
 } from '@/components';
 import { useAppDispatch, useAppSelector } from '@/rtk/app/hooks';
 import { ApiDelegationPath } from '@/routes/paths';
@@ -32,7 +34,6 @@ import {
 } from '@/rtk/features/apiDelegation/delegableApi/delegableApiSlice';
 import type { DelegableApi } from '@/rtk/features/apiDelegation/delegableApi/delegableApiSlice';
 import { Filter, type FilterOption } from '@/components/Filter';
-import { DelegationActionBar } from '@/components/DelegationActionBar';
 
 import classes from './ChooseApiPage.module.css';
 
@@ -167,7 +168,7 @@ export const ChooseApiPage = () => {
           ) : (
             <div>
               <h3>{t('api_delegation.chosen_orgs')}:</h3>
-              <List borderStyle={'dashed'}>{chosenDelegableOrgs}</List>
+              <BorderedList borderStyle={'dashed'}>{chosenDelegableOrgs}</BorderedList>
             </div>
           )}
           <h3 className={classes.chooseApiSecondHeader}>

--- a/src/features/apiDelegation/offered/ConfirmationPage/ConfirmationPage.module.css
+++ b/src/features/apiDelegation/offered/ConfirmationPage/ConfirmationPage.module.css
@@ -51,6 +51,7 @@
   margin-top: 2.5rem;
 }
 
-.list {
-  margin-bottom: 40px !important;
+.listContainer {
+  margin-top: 15px;
+  margin-bottom: 30px;
 }

--- a/src/features/apiDelegation/offered/ConfirmationPage/ConfirmationPage.module.css
+++ b/src/features/apiDelegation/offered/ConfirmationPage/ConfirmationPage.module.css
@@ -51,6 +51,6 @@
   margin-top: 2.5rem;
 }
 
-.listContainer {
-  margin-bottom: 40px;
+.list {
+  margin-bottom: 40px !important;
 }

--- a/src/features/apiDelegation/offered/ConfirmationPage/ConfirmationPage.tsx
+++ b/src/features/apiDelegation/offered/ConfirmationPage/ConfirmationPage.tsx
@@ -70,33 +70,37 @@ export const ConfirmationPage = () => {
 
   const delegableApiList = () => {
     return (
-      <BorderedList className={classes.list}>
-        {chosenApis?.map((api: DelegableApi | ApiDelegation, index: Key) => (
-          <CompactDeletableListItem
-            key={index}
-            startIcon={<CogIcon />}
-            removeCallback={chosenApis.length > 1 ? () => dispatch(softRemoveApi(api)) : null}
-            leftText={api.apiName}
-            middleText={api.orgName}
-          ></CompactDeletableListItem>
-        ))}
-      </BorderedList>
+      <div className={classes.listContainer}>
+        <BorderedList className={classes.list}>
+          {chosenApis?.map((api: DelegableApi | ApiDelegation, index: Key) => (
+            <CompactDeletableListItem
+              key={index}
+              startIcon={<CogIcon />}
+              removeCallback={chosenApis.length > 1 ? () => dispatch(softRemoveApi(api)) : null}
+              leftText={api.apiName}
+              middleText={api.orgName}
+            ></CompactDeletableListItem>
+          ))}
+        </BorderedList>
+      </div>
     );
   };
 
   const delegableOrgList = () => {
     return (
-      <BorderedList className={classes.list}>
-        {chosenOrgs?.map((org: DelegableOrg, index: Key | null | undefined) => (
-          <CompactDeletableListItem
-            key={index}
-            startIcon={<Buldings3Icon />}
-            removeCallback={chosenOrgs.length > 1 ? () => dispatch(softRemoveOrg(org)) : null}
-            leftText={org.orgName}
-            middleText={t('api_delegation.org_nr') + ' ' + org.orgNr}
-          ></CompactDeletableListItem>
-        ))}
-      </BorderedList>
+      <div className={classes.listContainer}>
+        <BorderedList>
+          {chosenOrgs?.map((org: DelegableOrg, index: Key | null | undefined) => (
+            <CompactDeletableListItem
+              key={index}
+              startIcon={<Buldings3Icon />}
+              removeCallback={chosenOrgs.length > 1 ? () => dispatch(softRemoveOrg(org)) : null}
+              leftText={org.orgName}
+              middleText={t('api_delegation.org_nr') + ' ' + org.orgNr}
+            ></CompactDeletableListItem>
+          ))}
+        </BorderedList>
+      </div>
     );
   };
 

--- a/src/features/apiDelegation/offered/ConfirmationPage/ConfirmationPage.tsx
+++ b/src/features/apiDelegation/offered/ConfirmationPage/ConfirmationPage.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import type { Key } from 'react';
 import { useEffect, useState } from 'react';
 import { Buldings3Icon, CogIcon } from '@navikt/aksel-icons';
-import { Button, Heading, List, Paragraph, Spinner } from '@digdir/design-system-react';
+import { Button, Heading, Paragraph, Spinner } from '@digdir/design-system-react';
 
 import { useAppDispatch, useAppSelector } from '@/rtk/app/hooks';
 import { ApiDelegationPath } from '@/routes/paths';
@@ -17,6 +17,7 @@ import {
   PageContent,
   PageHeader,
   RestartPrompter,
+  BorderedList,
 } from '@/components';
 import type {
   ApiDelegation,
@@ -69,25 +70,23 @@ export const ConfirmationPage = () => {
 
   const delegableApiList = () => {
     return (
-      <div className={classes.listContainer}>
-        <List borderStyle='dashed'>
-          {chosenApis?.map((api: DelegableApi | ApiDelegation, index: Key) => (
-            <CompactDeletableListItem
-              key={index}
-              startIcon={<CogIcon />}
-              removeCallback={chosenApis.length > 1 ? () => dispatch(softRemoveApi(api)) : null}
-              leftText={api.apiName}
-              middleText={api.orgName}
-            ></CompactDeletableListItem>
-          ))}
-        </List>
-      </div>
+      <BorderedList className={classes.list}>
+        {chosenApis?.map((api: DelegableApi | ApiDelegation, index: Key) => (
+          <CompactDeletableListItem
+            key={index}
+            startIcon={<CogIcon />}
+            removeCallback={chosenApis.length > 1 ? () => dispatch(softRemoveApi(api)) : null}
+            leftText={api.apiName}
+            middleText={api.orgName}
+          ></CompactDeletableListItem>
+        ))}
+      </BorderedList>
     );
   };
 
   const delegableOrgList = () => {
     return (
-      <List borderStyle='dashed'>
+      <BorderedList className={classes.list}>
         {chosenOrgs?.map((org: DelegableOrg, index: Key | null | undefined) => (
           <CompactDeletableListItem
             key={index}
@@ -97,7 +96,7 @@ export const ConfirmationPage = () => {
             middleText={t('api_delegation.org_nr') + ' ' + org.orgNr}
           ></CompactDeletableListItem>
         ))}
-      </List>
+      </BorderedList>
     );
   };
 

--- a/src/features/apiDelegation/offered/ReceiptPage/ReceiptPage.module.css
+++ b/src/features/apiDelegation/offered/ReceiptPage/ReceiptPage.module.css
@@ -1,3 +1,3 @@
-.listContainer {
-  margin-bottom: 40px;
+.list {
+  margin-bottom: 40px !important;
 }

--- a/src/features/apiDelegation/offered/ReceiptPage/ReceiptPage.tsx
+++ b/src/features/apiDelegation/offered/ReceiptPage/ReceiptPage.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import type { Key } from 'react';
 import * as React from 'react';
-import { Button, Heading, List, Paragraph } from '@digdir/design-system-react';
+import { Button, Heading, Paragraph } from '@digdir/design-system-react';
 import { useNavigate } from 'react-router-dom';
 
 import { useAppDispatch, useAppSelector } from '@/rtk/app/hooks';
@@ -15,6 +15,7 @@ import {
   PageContent,
   CompactDeletableListItem,
   RestartPrompter,
+  BorderedList,
 } from '@/components';
 import { ListTextColor } from '@/components/CompactDeletableListItem/CompactDeletableListItem';
 import type { ApiDelegation } from '@/rtk/features/apiDelegation/delegationRequest/delegationRequestSlice';
@@ -44,20 +45,18 @@ export const ReceiptPage = () => {
         >
           {t('api_delegation.failed_delegations')}
         </Heading>
-        <div className={classes.listContainer}>
-          <List borderStyle='dashed'>
-            {failedApiDelegations?.map(
-              (apiDelegation: ApiDelegation, index: Key | null | undefined) => (
-                <CompactDeletableListItem
-                  key={index}
-                  contentColor={ListTextColor.error}
-                  middleText={apiDelegation.apiName}
-                  leftText={apiDelegation.orgName}
-                ></CompactDeletableListItem>
-              ),
-            )}
-          </List>
-        </div>
+        <BorderedList className={classes.list}>
+          {failedApiDelegations?.map(
+            (apiDelegation: ApiDelegation, index: Key | null | undefined) => (
+              <CompactDeletableListItem
+                key={index}
+                contentColor={ListTextColor.error}
+                middleText={apiDelegation.apiName}
+                leftText={apiDelegation.orgName}
+              ></CompactDeletableListItem>
+            ),
+          )}
+        </BorderedList>
       </>
     );
   };
@@ -72,7 +71,7 @@ export const ReceiptPage = () => {
         >
           {t('api_delegation.succesful_delegations')}
         </Heading>
-        <List borderStyle='dashed'>
+        <BorderedList className={classes.list}>
           {successfulApiDelegations?.map(
             (apiDelegation: ApiDelegation, index: Key | null | undefined) => (
               <CompactDeletableListItem
@@ -82,7 +81,7 @@ export const ReceiptPage = () => {
               ></CompactDeletableListItem>
             ),
           )}
-        </List>
+        </BorderedList>
       </>
     );
   };

--- a/src/features/singleRight/components/SearchSection/SearchSection.tsx
+++ b/src/features/singleRight/components/SearchSection/SearchSection.tsx
@@ -102,7 +102,7 @@ export const SearchSection = ({ onAdd, onUndo }: SearchSectionParams) => {
         <div className={classes.spinner}>
           <Spinner
             title={t('common.loading')}
-            size='1xLarge'
+            size='xlarge'
             variant='interaction'
           />
         </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This bug resulted from an update in the design system, which changed the List components styling and removed the option of bordered separation of list items.

This PR reintroduces this option by adding a wrapping component, that wraps the design system List in a component BorderedList, to provide the same styling as previously.


## Related Issue(s)
- #625 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
