### PR TITLE
Specify port 80 in Dockerfile after .NET 8 upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ WORKDIR /app
 # ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
 #     DOTNET_RUNNING_IN_CONTAINER=true
 ENV ASPNETCORE_ENVIRONMENT = Development
+ENV ASPNETCORE_HTTP_PORTS = 80
 RUN apk add --no-cache icu-libs krb5-libs libgcc libintl libssl1.1 libstdc++ zlib
 
 COPY --from=generate-accessmanagement-backend /app_output .


### PR DESCRIPTION
Specify port 80 in Dockerfile after .NET 8 upgrade

## Description
Connection to replicas fail after .NET 8 upgrade.
Assumed to be because of the following breaking change in .NET 8 images:

`The default ASP.NET Core port configured in .NET container images has been updated from port 80 to 8080.`

Updated Dockerfile to specify port 80 using new environment variable ASPNETCORE_HTTP_PORTS
## Related Issue(s)
- #649

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
