### PR TITLE
Altinn apps now only displays one action: 'Access'

### DIFF
--- a/src/components/UserInfoBar/UserInfoBar.tsx
+++ b/src/components/UserInfoBar/UserInfoBar.tsx
@@ -17,8 +17,10 @@ export const UserInfoBar = () => {
   const dispatch = useAppDispatch();
 
   useEffect(() => {
-    if (userLoading || reporteeLoading) {
+    if (userLoading) {
       void dispatch(fetchUserInfo());
+    }
+    if (reporteeLoading) {
       void dispatch(fetchReportee());
     }
   }, []);

--- a/src/dataObjects/dtos/singleRights/DelegationInputDto.tsx
+++ b/src/dataObjects/dtos/singleRights/DelegationInputDto.tsx
@@ -7,10 +7,12 @@ export interface DelegationInputDto {
 export class ServiceDto {
   serviceTitle: string;
   serviceOwner: string;
+  serviceType: string;
 
-  constructor(serviceTitle: string, serviceOwner: string) {
+  constructor(serviceTitle: string, serviceOwner: string, serviceType: string) {
     this.serviceTitle = serviceTitle;
     this.serviceOwner = serviceOwner;
+    this.serviceType = serviceType;
   }
 }
 

--- a/src/features/singleRight/delegate/ChooseRightsPage/ChooseRightsPage.tsx
+++ b/src/features/singleRight/delegate/ChooseRightsPage/ChooseRightsPage.tsx
@@ -42,6 +42,7 @@ type Service = {
   rightDescription: string;
   status: string;
   title: string;
+  type: string;
   serviceOwner: string;
   rights: ChipRight[];
 };
@@ -102,6 +103,7 @@ export const ChooseRightsPage = () => {
         title: service.service?.title ?? '',
         serviceOwner: service.service?.resourceOwnerName ?? '',
         rights: rights,
+        type: service.service?.resourceType ?? '',
       };
     });
   };
@@ -156,7 +158,11 @@ export const ChooseRightsPage = () => {
       key={service.serviceIdentifier}
       title={service.title}
       subtitle={service.serviceOwner}
-      color={service.status === ServiceStatus.Delegable ? 'success' : 'warning'}
+      color={
+        service.status === ServiceStatus.Delegable || service.type === 'AltinnApp'
+          ? 'success'
+          : 'warning'
+      }
       onRemoveClick={() => {
         onRemove(service.serviceIdentifier);
       }}
@@ -169,6 +175,7 @@ export const ChooseRightsPage = () => {
         serviceIdentifier={service.serviceIdentifier}
         serviceDescription={service.description}
         rightDescription={service.rightDescription}
+        serviceType={service.type}
       />
     </RightsActionBar>
   ));
@@ -241,7 +248,7 @@ export const ChooseRightsPage = () => {
           // TODO: make adjustments to codeline below when we get GUID from altinn2
           To: [new IdValuePair('urn:altinn:organizationnumber', '313523497')],
           Rights: rightsToDelegate,
-          serviceDto: new ServiceDto(service.title, service.serviceOwner),
+          serviceDto: new ServiceDto(service.title, service.serviceOwner, service.type),
         };
 
         return dispatch(delegate(delegationInput));

--- a/src/features/singleRight/delegate/ChooseRightsPage/RightsActionBarContent/RightsActionBarContent.tsx
+++ b/src/features/singleRight/delegate/ChooseRightsPage/RightsActionBarContent/RightsActionBarContent.tsx
@@ -38,6 +38,9 @@ export interface RightsActionBarContentProps {
 
   /** Unique identifier for the service the rights adhere to */
   serviceIdentifier: string;
+
+  /** The type of service */
+  serviceType: string;
 }
 
 export const RightsActionBarContent = ({
@@ -46,10 +49,13 @@ export const RightsActionBarContent = ({
   serviceDescription,
   rightDescription,
   serviceIdentifier,
+  serviceType,
 }: RightsActionBarContentProps) => {
   const { t } = useTranslation('common');
-  const hasUndelegableRights = rights.some((r) => r.delegable === false);
+  const hasUndelegableRights =
+    rights.some((r) => r.delegable === false) && serviceType !== 'AltinnApp';
   const [errorList, setErrorList] = useState<string[]>([]);
+  const [altinnAppAccess, setAltinnAppAccess] = useState(true);
 
   const createErrorList = () => {
     const errors: string[] = [];
@@ -72,34 +78,55 @@ export const RightsActionBarContent = ({
     createErrorList();
   }, [rights]);
 
+  const toggleAllDelegableRights = () => {
+    rights.forEach((right: ChipRight) => {
+      if (right.delegable) {
+        toggleRight(serviceIdentifier, right.action);
+      }
+    });
+    setAltinnAppAccess(!altinnAppAccess);
+  };
+
   const serviceResourceContent = (
     <>
       <Paragraph>{serviceDescription}</Paragraph>
       <Paragraph>{rightDescription}</Paragraph>
       <Paragraph>{t('single_rights.action_bar_adjust_rights_text')}</Paragraph>
       <div className={classes.chipContainer}>
-        {rights
-          .filter((right: ChipRight) => right.delegable === true)
-          .map((right: ChipRight, index: number) => {
-            const actionText = Object.values(LocalizedAction).includes(
-              right.action as LocalizedAction,
-            )
-              ? t(`common.${right.action}`)
-              : right.action;
-            return (
-              <div key={index}>
-                <Chip.Toggle
-                  checkmark
-                  selected={right.checked}
-                  onClick={() => {
-                    toggleRight(serviceIdentifier, right.action);
-                  }}
-                >
-                  {actionText}
-                </Chip.Toggle>
-              </div>
-            );
-          })}
+        {serviceType === 'AltinnApp' ? (
+          <div>
+            <Chip.Toggle
+              checkmark
+              selected={altinnAppAccess}
+              onClick={toggleAllDelegableRights}
+            >
+              {t('common.access')}
+            </Chip.Toggle>
+          </div>
+        ) : (
+          rights
+            .filter((right: ChipRight) => right.delegable === true)
+            .map((right: ChipRight, index: number) => {
+              const actionText = Object.values(LocalizedAction).includes(
+                right.action as LocalizedAction,
+              )
+                ? t(`common.${right.action}`)
+                : right.action;
+              return (
+                <div key={index}>
+                  <Chip.Toggle
+                    checkmark
+                    selected={right.checked}
+                    onClick={() => {
+                      toggleRight(serviceIdentifier, right.action);
+                    }}
+                  >
+                    {actionText}
+                  </Chip.Toggle>
+                </div>
+              );
+            })
+        )}
       </div>
     </>
   );

--- a/src/features/singleRight/delegate/ReceiptPage/ActionBarSection/ActionBarSection.tsx
+++ b/src/features/singleRight/delegate/ReceiptPage/ActionBarSection/ActionBarSection.tsx
@@ -133,6 +133,7 @@ export const ActionBarSection = () => {
                 successfulDelegations={successfulDelegations}
                 isRejectedDelegation={isRejectedDelegation}
                 index={index}
+                serviceType={pd.meta.serviceDto.serviceType}
               />
             </ActionBar>
           </div>

--- a/src/features/singleRight/delegate/ReceiptPage/ReceiptActionBarContent/ReceiptActionBarContent.tsx
+++ b/src/features/singleRight/delegate/ReceiptPage/ReceiptActionBarContent/ReceiptActionBarContent.tsx
@@ -19,6 +19,9 @@ export interface ReceiptActionBarContent {
 
   /** Outer index used to create unique keys */
   index: number;
+
+  /** The type of service */
+  serviceType: string;
 }
 
 /**
@@ -38,6 +41,7 @@ export const ReceiptActionBarContent = ({
   successfulDelegations,
   isRejectedDelegation,
   index,
+  serviceType,
 }: ReceiptActionBarContent) => {
   const { t } = useTranslation();
 
@@ -91,22 +95,31 @@ export const ReceiptActionBarContent = ({
         </Heading>
         <div className={classes.chipContainer}>
           <Chip.Group size='small'>
-            {successfulDelegations?.map((right: Right, innerIndex) => {
-              const chipText = Object.values(LocalizedAction).includes(
-                right.action as LocalizedAction,
-              )
-                ? t(`common.${right.action}`)
-                : right.action;
-              return (
-                <Chip.Toggle
-                  selected={true}
-                  checkmark
-                  key={`successful-${index}-${innerIndex}`}
-                >
-                  {chipText}
-                </Chip.Toggle>
-              );
-            })}
+            {serviceType === 'AltinnApp' ? (
+              <Chip.Toggle
+                selected={true}
+                checkmark
+              >
+                {t('common.access')}
+              </Chip.Toggle>
+            ) : (
+              successfulDelegations?.map((right: Right, innerIndex) => {
+                const chipText = Object.values(LocalizedAction).includes(
+                  right.action as LocalizedAction,
+                )
+                  ? t(`common.${right.action}`)
+                  : right.action;
+                return (
+                  <Chip.Toggle
+                    selected={true}
+                    checkmark
+                    key={`successful-${index}-${innerIndex}`}
+                  >
+                    {chipText}
+                  </Chip.Toggle>
+                );
+              })
+            )}
           </Chip.Group>
         </div>
       </div>

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -36,7 +36,7 @@
     "sign": "Sign",
     "delete": "Delete",
     "instantiate": "Instantiate",
-    "access": "Access to the whole service",
+    "access": "Access",
     "failed": "Failed",
     "failed_lowercase": "failed",
     "finished": "Finished",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -35,7 +35,7 @@
     "sign": "Signere",
     "delete": "Slett",
     "instantiate": "Instansier",
-    "access": "Tilgang til hele tjenesten",
+    "access": "Tilgang",
     "failed": "Feilet",
     "failed_lowercase": "feilet",
     "finished": "Ferdig",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -35,7 +35,7 @@
     "sign": "Signera",
     "delete": "Slett",
     "instantiate": "Instansier",
-    "access": "Tilgang til heile tenesta",
+    "access": "Tilgang",
     "failed": "Feila",
     "failed_lowercase": "feila",
     "finished": "Ferdig",

--- a/src/rtk/features/singleRights/singleRightsApi.ts
+++ b/src/rtk/features/singleRights/singleRightsApi.ts
@@ -17,6 +17,7 @@ export interface ServiceResource {
   description?: string;
   resourceReferences: resourceReference[];
   authorizationReference: IdValuePair[];
+  resourceType: string;
 }
 
 export interface ResourceOwner {

--- a/src/rtk/features/singleRights/singleRightsSlice.ts
+++ b/src/rtk/features/singleRights/singleRightsSlice.ts
@@ -36,7 +36,7 @@ export interface DelegationAccessCheckDto {
 export interface Right {
   rightKey?: string;
   resource: IdValuePair[];
-  action?: string;
+  action: string;
   status?: string;
   details?: Details[];
   reduxStatus?: ReduxStatusResponse;
@@ -90,6 +90,7 @@ const createSerializedMeta = (meta: DelegationInputDto) => {
   const serviceDto = {
     serviceTitle: meta.serviceDto.serviceTitle,
     serviceOwner: meta.serviceDto.serviceOwner,
+    serviceType: meta.serviceDto.serviceType,
   };
 
   return {
@@ -101,8 +102,8 @@ const createSerializedMeta = (meta: DelegationInputDto) => {
 
 const createDelegationResponseData = (
   resourceId: string,
+  action: string,
   resourceValue?: string,
-  action?: string,
   status?: string,
   reduxStatus?: ReduxStatusResponse,
   detailsCode?: string,
@@ -270,6 +271,7 @@ const singleRightSlice = createSlice({
             const delegationResponseList: Right[] = [
               {
                 resource: [{ id: serviceID }],
+                action: '',
                 status: ServiceStatus.HTTPError,
                 details: [
                   {
@@ -324,8 +326,8 @@ const singleRightSlice = createSlice({
         bffResponseList.push(
           createDelegationResponseData(
             delegationInput.Rights[0].Resource[0].id,
-            delegationInput.Rights[0].Resource[0].value,
             delegationInput.Rights[0].Action,
+            delegationInput.Rights[0].Resource[0].value,
             BFFDelegatedStatus.NotDelegated,
             ReduxStatusResponse.Rejected,
             action.error.code,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Services of type AltinnApps only deisplays one single action, 'Access', on both rights page and receipt.
If some actions cannot be delegated or failed during delegation, these actions are not displayed in an alert and the user is not informed that all rights were not/will not be delegated unless no actions can be/were delegated.
During delegation, all rights that can be delegated will be delegated even though they were not specifically listed to the user.

This is a temporary solution that will last until the resource registry offers us a way to display sub-resources/tasks on apps.

## Related Issue(s)
- #619

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
