### PR TITLE
Failing resources displayed in the wrong order

### DIFF
--- a/src/components/ActionBar/ActionBar.tsx
+++ b/src/components/ActionBar/ActionBar.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useId, useState, forwardRef } from 'react';
+import { useId, useState, forwardRef, useEffect } from 'react';
 
 import type { ClickHandler } from './Context';
 import { ActionBarContext } from './Context';
@@ -97,6 +97,11 @@ export const ActionBar = forwardRef<HTMLDivElement, ActionBarProps>(
 
     const [internalOpen, setInternalOpen] = useState<boolean>(defaultOpen);
     const isOpen = open ?? internalOpen;
+
+    // Update internalopen if there are external changes to default
+    useEffect(() => {
+      setInternalOpen(defaultOpen);
+    }, [defaultOpen]);
 
     let toggleOpen: ClickHandler | undefined;
     if (!children) {

--- a/src/features/singleRight/delegate/ReceiptPage/ActionBarSection/ActionBarSection.tsx
+++ b/src/features/singleRight/delegate/ReceiptPage/ActionBarSection/ActionBarSection.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { ErrorMessage, Ingress, Paragraph } from '@digdir/design-system-react';
 import * as React from 'react';
 import { ExclamationmarkTriangleIcon } from '@navikt/aksel-icons';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 import { useAppSelector } from '@/rtk/app/hooks';
 import type { Right, ProcessedDelegation } from '@/rtk/features/singleRights/singleRightsSlice';
@@ -31,18 +31,24 @@ export const ActionBarSection = () => {
   });
 
   // logic for finding the delegation with the most failed Delegations
-  delegations.forEach((pd: ProcessedDelegation, index) => {
-    const failedDelegations = pd.bffResponseList?.filter(
-      (data: Right) => data.status !== BFFDelegatedStatus.Delegated,
-    );
+  useEffect(() => {
+    let currentMostFailedDelegations = mostFailedDelegations;
+    let currentMostFailedIndex = mostFailedIndex;
+    delegations.forEach((pd: ProcessedDelegation, index) => {
+      const failedDelegations = pd.bffResponseList?.filter(
+        (data: Right) => data.status !== BFFDelegatedStatus.Delegated,
+      );
 
-    const numFailedDelegations = failedDelegations?.length || 0;
+      const numFailedDelegations = failedDelegations?.length || 0;
 
-    if (numFailedDelegations > mostFailedDelegations) {
-      setMostFailedDelegations(numFailedDelegations);
-      setMostFailedIndex(index);
-    }
-  });
+      if (numFailedDelegations > currentMostFailedDelegations) {
+        currentMostFailedIndex = index;
+        currentMostFailedDelegations = numFailedDelegations;
+      }
+    });
+    setMostFailedDelegations(currentMostFailedDelegations);
+    setMostFailedIndex(currentMostFailedIndex);
+  }, []);
 
   const actionBars = delegations
     .map((pd: ProcessedDelegation, index: number) => {

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -153,7 +153,7 @@
     "alert_partially_delegable_header": "You don't have access to delegate the whole service",
     "you_cant_delegate_these_rights": "You can't delegate these rights:",
     "processing_delegations": "Processing delegations",
-    "woops_something_went_wrong": "Woops, something  wen wrong with one or more services. These are marked in red. You can try again later.",
+    "woops_something_went_wrong_ingress": "Woops, something  wen wrong with one or more services. These are marked in red. You can try again later.",
     "all_failed_techncal_problem": "A technical problem has arised delegating this service. We recommend that you start a new delegation and try one more time. If the problem persists we ask you to contact user service on phone number 75 00 60 00. We're sorry!",
     "woops_something_went_wrong_alert": "Woops! Something went wrong",
     "some_failed_technical_problem": "Because of a technical error all rights weren't delegated. We recommend that you retry delegating the service by going to the delegation page.",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -152,7 +152,7 @@
     "chosen_services": "Valgte tjenester",
     "alert_partially_delegable_header": "Du får ikkje delegert heile tenesta",
     "you_cant_delegate_these_rights": "Desse rettane kan du ikkje delegera:",
-    "woops_something_went_wrong": "Oi, her var det noko som gjekk gale med ein eller fleire tenester. Desse er raude. Du kan prøva igjen seinare",
+    "woops_something_went_wrong_ingress": "Oi, her var det noko som gjekk gale med ein eller fleire tenester. Desse er raude. Du kan prøva igjen seinare",
     "all_failed_techncal_problem_paragraph": "Eit teknisk problem har oppstått ved delegering av tenestene. Me tilrår at du startar delegeringsprosessen på nytt ved å gå til delegeringssida. Viss problemet held fram ber me deg kontakta brukarservice på telefon 75 00 60 00. Me beklagar!",
     "woops_something_went_wrong_alert": "Oi! Noe gikk galt.",
     "some_failed_technical_problem": "Pga. Av en teknisk feil ble ikke alle rettighetene på tjenesten delegert. Vi anbefaler at du forsøker å delegere tjenesten på nytt.",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This bug was triggered when all failing delegations were returned as HTTP-errors, causing the error count to be 1 (as in the whole service) for every service. This revealed a flaw in the logic set up in the receipt page where two states were not updated correctly because of the limited scope inside of a forEach loop.
The loop relied on these states to decide which resource had the most 'failures' and thus would be displayed first (with default open). Since forEach binds the function passed to it, it limits the scope and will not get updated state values with each new iteration. This caused the loop to fire an update with every iteration which ended up marking the last entry in the list as the one to display first.

But since the list of delegations is then sorted separately (and every delegation failed with equal number) this stored index did not match the sorting of the delegations, causing the bug.

This is now fixed.

## Related Issue(s)
- #658 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
