### PR TITLE
Read language cookie from altinnPersistentContext

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Helpers/ProfileHelper.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Helpers/ProfileHelper.cs
@@ -48,10 +48,8 @@ namespace Altinn.AccessManagement.UI.Core.Helpers
                         return "no_nb";
                 }
             }
-            else
-            {
-                return "no_nb";
-            }
+            
+            return "no_nb";
         }
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/HomeController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/HomeController.cs
@@ -94,13 +94,39 @@ namespace Altinn.AccessManagement.UI.Controllers
             int userId = AuthenticationHelper.GetUserId(_httpContextAccessor.HttpContext);
             UserProfile user = await _profileService.GetUserProfile(userId);
             AntiforgeryTokenSet tokens = _antiforgery.GetAndStoreTokens(HttpContext);
-            string languageCode = ProfileHelper.GetStandardLanguageCodeForUser(user);
+            string languageCode = GetLanguageFromAltinnPersistence();
+            if (languageCode == string.Empty)
+            {
+                languageCode = ProfileHelper.GetStandardLanguageCodeForUser(user);
+            }
 
             HttpContext.Response.Cookies.Append("i18next", languageCode, new CookieOptions
             {
                 // Make this cookie readable by Javascript.
                 HttpOnly = false,
             });
+        }
+        
+        private string GetLanguageFromAltinnPersistence()
+        {
+            var cookieValue = HttpContext.Request.Cookies["altinnPersistentContext"];
+
+            if (cookieValue.Contains("UL1033"))
+            {
+                return "en";
+            }
+
+            if (cookieValue.Contains("UL1044"))
+            {
+                return "no_nb";
+            }
+
+            if (cookieValue.Contains("UL2068"))
+            {
+                return "no_nn";
+            }
+            
+            return string.Empty;
         }
 
         private async Task<bool> ShouldShowAppView()

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/HomeController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/HomeController.cs
@@ -94,7 +94,7 @@ namespace Altinn.AccessManagement.UI.Controllers
             int userId = AuthenticationHelper.GetUserId(_httpContextAccessor.HttpContext);
             UserProfile user = await _profileService.GetUserProfile(userId);
             AntiforgeryTokenSet tokens = _antiforgery.GetAndStoreTokens(HttpContext);
-            string languageCode = GetLanguageFromAltinnPersistence();
+            string languageCode = GetAltinnPersistenceCookieValue();
             if (languageCode == string.Empty)
             {
                 languageCode = ProfileHelper.GetStandardLanguageCodeForUser(user);
@@ -107,7 +107,7 @@ namespace Altinn.AccessManagement.UI.Controllers
             });
         }
         
-        private string GetLanguageFromAltinnPersistence()
+        private string GetAltinnPersistenceCookieValue()
         {
             var cookieValue = HttpContext.Request.Cookies["altinnPersistentContext"];
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds code that tries to read language from AltinnPersistence cookie first.

## Related Issue(s)
- #733

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
