### PR TITLE
Fixed dropping recipient name

### DIFF
--- a/src/features/singleRight/delegate/ChooseServicePage/ChooseServicePage.tsx
+++ b/src/features/singleRight/delegate/ChooseServicePage/ChooseServicePage.tsx
@@ -31,8 +31,6 @@ export const ChooseServicePage = () => {
   const dispatch = useAppDispatch();
   const [urlParams] = useSearchParams();
   const [popoverOpen, setPopoverOpen] = useState(false);
-  const [userUUID, setUserUUID] = useState<string | null>(null);
-  const [partyUUID, setPartyUUID] = useState<string | null>(null);
   const buttonRef = useRef<HTMLButtonElement | null>(null);
   const delegableChosenServices = useAppSelector((state) =>
     state.singleRightsSlice.servicesWithStatus.filter(
@@ -42,11 +40,12 @@ export const ChooseServicePage = () => {
 
   useLayoutEffect(() => {
     void dispatch(resetProcessedDelegations());
-    setUserUUID(urlParams.get('userUUID'));
-    setPartyUUID(urlParams.get('partyUUID'));
   }, []);
 
-  const [recipientName, recipientError, isLoading] = useFetchNameFromUUID(userUUID, partyUUID);
+  const [recipientName, recipientError, isLoading] = useFetchNameFromUUID(
+    urlParams.get('userUUID'),
+    urlParams.get('partyUUID'),
+  );
 
   const onAdd = (serviceResource: ServiceResource) => {
     const dto: DelegationAccessCheckDto = {
@@ -89,8 +88,8 @@ export const ChooseServicePage = () => {
         <PageContent>
           {!isLoading && recipientError ? (
             <RecipientErrorAlert
-              userUUID={userUUID}
-              partyUUID={partyUUID}
+              userUUID={urlParams.get('userUUID')}
+              partyUUID={urlParams.get('partyUUID')}
             />
           ) : (
             <>

--- a/src/features/singleRight/delegate/ReceiptPage/ActionBarSection/ActionBarSection.tsx
+++ b/src/features/singleRight/delegate/ReceiptPage/ActionBarSection/ActionBarSection.tsx
@@ -3,6 +3,7 @@ import { ErrorMessage, Ingress, Paragraph } from '@digdir/design-system-react';
 import * as React from 'react';
 import { ExclamationmarkTriangleIcon } from '@navikt/aksel-icons';
 import { useState, useEffect } from 'react';
+import cn from 'classnames';
 
 import { useAppSelector } from '@/rtk/app/hooks';
 import type { Right, ProcessedDelegation } from '@/rtk/features/singleRights/singleRightsSlice';
@@ -114,10 +115,10 @@ export const ActionBarSection = ({ recipientName }: ActionBarSectionProps) => {
         );
       };
 
-      const successfulDelegationParagraph = () => {
+      const successfulDelegationParagraph = (extraSpacing: boolean) => {
         return (
           <Ingress
-            className={classes.successText}
+            className={cn(extraSpacing && classes.successText)}
             spacing
             level={2}
           >
@@ -130,7 +131,8 @@ export const ActionBarSection = ({ recipientName }: ActionBarSectionProps) => {
         actionBar: (
           <div key={`receipt-action-bar-${index}`}>
             {index === mostFailedIndex && mostFailedDelegations > 0 && failedDelegationIngress()}
-            {index === firstSuccesfulIndex && successfulDelegationParagraph()}
+            {index === firstSuccesfulIndex &&
+              successfulDelegationParagraph(mostFailedDelegations > 0)}
             <ActionBar
               title={pd.meta.serviceDto.serviceTitle}
               subtitle={pd.meta.serviceDto.serviceOwner}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR introduces skipping unnessesary calls to lookup souch as calls with invalid uuid (before uuid has been fetched from url) and calls whose data is not needed (lookup of person when recipient is a praty and lookup of party when recipient is a person).

It also fixes the main bug in #740 by triggering data logic in the fetching hook straight away (instead of on an update) which is nessesary in the cases where data is fetch from cache and thus happens immediately.
(Plus it adds a change to styling on receipt page for the case where all delegations are successfull and no extra padding is needed over the success message)

## Related Issue(s)
- #740 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
