### PR TITLE
Link back to A2 on finish button

### DIFF
--- a/src/components/PageContainer/PageContainer.tsx
+++ b/src/components/PageContainer/PageContainer.tsx
@@ -2,8 +2,7 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { XMarkIcon } from '@navikt/aksel-icons';
 
-import { GeneralPath } from '@/routes/paths';
-import { getCookie } from '@/resources/Cookie/CookieMethods';
+import { redirectToProfile } from '@/resources/utils';
 
 import { UserInfoBar } from '../UserInfoBar/UserInfoBar';
 
@@ -15,12 +14,6 @@ export interface PageContainerProps {
 
 export const PageContainer = ({ children }: PageContainerProps) => {
   const { t } = useTranslation('common');
-
-  const redirectToProfile = () => {
-    const cleanHostname = window.location.hostname.replace('am.ui.', '');
-    window.location.href =
-      'https://' + cleanHostname + '/' + GeneralPath.Profile + '?R=' + getCookie('AltinnPartyId');
-  };
 
   return (
     <div className={classes.pageMargin}>

--- a/src/features/singleRight/delegate/ChooseRightsPage/ChooseRightsPage.tsx
+++ b/src/features/singleRight/delegate/ChooseRightsPage/ChooseRightsPage.tsx
@@ -16,7 +16,7 @@ import {
 } from '@/components';
 import { useAppDispatch, useAppSelector } from '@/rtk/app/hooks';
 import { SingleRightPath } from '@/routes/paths';
-import { useFetchNameFromUUID, useMediaQuery } from '@/resources/hooks';
+import { useFetchRecipientInfo, useMediaQuery } from '@/resources/hooks';
 import {
   removeServiceResource,
   delegate,
@@ -67,10 +67,11 @@ export const ChooseRightsPage = () => {
     Math.round((processedDelegations.length / delegationCount) * 100);
   const buttonRef = useRef<HTMLButtonElement | null>(null);
 
-  const [recipientName, recipientError, isLoading] = useFetchNameFromUUID(
-    urlParams.get('userUUID'),
-    urlParams.get('partyUUID'),
-  );
+  const {
+    name: recipientName,
+    error: recipientError,
+    isLoading,
+  } = useFetchRecipientInfo(urlParams.get('userUUID'), urlParams.get('partyUUID'));
 
   const initializeDelegableServices = () => {
     const delegable = servicesWithStatus.filter(

--- a/src/features/singleRight/delegate/ChooseServicePage/ChooseServicePage.tsx
+++ b/src/features/singleRight/delegate/ChooseServicePage/ChooseServicePage.tsx
@@ -17,8 +17,8 @@ import {
   resetProcessedDelegations,
   ServiceStatus,
 } from '@/rtk/features/singleRights/singleRightsSlice';
-import { GeneralPath, SingleRightPath } from '@/routes/paths';
-import { getCookie } from '@/resources/Cookie/CookieMethods';
+import { SingleRightPath } from '@/routes/paths';
+import { redirectToSevicesAvailableForUser } from '@/resources/utils';
 
 import { SearchSection } from '../../components/SearchSection';
 import { ResourceCollectionBar } from '../../components/ResourceCollectionBar';
@@ -45,6 +45,8 @@ export const ChooseServicePage = () => {
   const {
     name: recipientName,
     error: recipientError,
+    userID,
+    partyID,
     isLoading,
   } = useFetchRecipientInfo(urlParams.get('userUUID'), urlParams.get('partyUUID'));
 
@@ -59,24 +61,6 @@ export const ChooseServicePage = () => {
 
   const onRemove = (identifier: string | undefined) => {
     void dispatch(removeServiceResource(identifier));
-  };
-
-  const onCancel = () => {
-    const cleanHostname = window.location.hostname.replace('am.ui.', '');
-    const partyId = getCookie('AltinnPartyId');
-    const encodedUrl = `ui/AccessManagement/ServicesAvailableForActor?userID=&amp;partyID=${partyId}`;
-
-    window.location.href =
-      'https://' +
-      cleanHostname +
-      '/' +
-      String(GeneralPath.Altinn2SingleRights) +
-      '?userID=' +
-      getCookie('AltinnUserId') +
-      '&amp;' +
-      'partyID=' +
-      getCookie('AltinnPartyId') +
-      encodeURIComponent(encodedUrl);
   };
 
   return (
@@ -130,7 +114,7 @@ export const ChooseServicePage = () => {
                   onClick={
                     delegableChosenServices.length > 0
                       ? () => setPopoverOpen(!popoverOpen)
-                      : onCancel
+                      : () => redirectToSevicesAvailableForUser(userID, partyID)
                   }
                   ref={buttonRef}
                 >
@@ -147,7 +131,7 @@ export const ChooseServicePage = () => {
                     <Paragraph>{t('single_rights.cancel_popover_text')}</Paragraph>
                     <GroupElements>
                       <Button
-                        onClick={onCancel}
+                        onClick={() => redirectToSevicesAvailableForUser(userID, partyID)}
                         color={'danger'}
                         variant={'primary'}
                         fullWidth

--- a/src/features/singleRight/delegate/ChooseServicePage/ChooseServicePage.tsx
+++ b/src/features/singleRight/delegate/ChooseServicePage/ChooseServicePage.tsx
@@ -7,7 +7,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useLayoutEffect, useRef, useState } from 'react';
 
 import { Page, PageHeader, PageContent, PageContainer, GroupElements } from '@/components';
-import { useMediaQuery, useFetchNameFromUUID } from '@/resources/hooks';
+import { useMediaQuery, useFetchRecipientInfo } from '@/resources/hooks';
 import { type ServiceResource } from '@/rtk/features/singleRights/singleRightsApi';
 import { useAppDispatch, useAppSelector } from '@/rtk/app/hooks';
 import {
@@ -42,10 +42,11 @@ export const ChooseServicePage = () => {
     void dispatch(resetProcessedDelegations());
   }, []);
 
-  const [recipientName, recipientError, isLoading] = useFetchNameFromUUID(
-    urlParams.get('userUUID'),
-    urlParams.get('partyUUID'),
-  );
+  const {
+    name: recipientName,
+    error: recipientError,
+    isLoading,
+  } = useFetchRecipientInfo(urlParams.get('userUUID'), urlParams.get('partyUUID'));
 
   const onAdd = (serviceResource: ServiceResource) => {
     const dto: DelegationAccessCheckDto = {

--- a/src/features/singleRight/delegate/ReceiptPage/ReceiptPage.tsx
+++ b/src/features/singleRight/delegate/ReceiptPage/ReceiptPage.tsx
@@ -5,12 +5,13 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import { PersonIcon } from '@navikt/aksel-icons';
 import { useEffect } from 'react';
 
-import { SingleRightPath } from '@/routes/paths';
+import { GeneralPath, SingleRightPath } from '@/routes/paths';
 import { Page, PageContainer, PageContent, PageHeader, RestartPrompter } from '@/components';
-import { useFetchNameFromUUID, useMediaQuery } from '@/resources/hooks';
+import { useFetchRecipientInfo, useMediaQuery } from '@/resources/hooks';
 import { useAppDispatch, useAppSelector } from '@/rtk/app/hooks';
 import { resetServicesWithStatus } from '@/rtk/features/singleRights/singleRightsSlice';
 import { GroupElements } from '@/components/GroupElements/GroupElements';
+import { getCookie } from '@/resources/Cookie/CookieMethods';
 
 import classes from './ReceiptPage.module.css';
 import { ActionBarSection } from './ActionBarSection/ActionBarSection';
@@ -25,14 +26,20 @@ export const ReceiptPage = () => {
     (state) => state.singleRightsSlice.processedDelegations,
   );
 
-  const [recipientName] = useFetchNameFromUUID(
-    urlParams.get('userUUID'),
-    urlParams.get('partyUUID'),
-  );
+  const {
+    name: recipientName,
+    userID,
+    partyID,
+  } = useFetchRecipientInfo(urlParams.get('userUUID'), urlParams.get('partyUUID'));
 
   useEffect(() => {
     void dispatch(resetServicesWithStatus());
   }, []);
+
+  const redirectToProfile = () => {
+    const cleanHostname = window.location.hostname.replace('am.ui.', '');
+    window.location.href = `https://${cleanHostname}/${GeneralPath.Profile}?R=${getCookie('AltinnPartyId')}&lm=${encodeURIComponent(`/ui/AccessManagement/ServicesAvailableForActor/?userID=${userID ? userID : 0}&partyID=${partyID}`)}`;
+  };
 
   return (
     <PageContainer>
@@ -56,6 +63,7 @@ export const ReceiptPage = () => {
               </div>
               <GroupElements>
                 <Button
+                  onClick={redirectToProfile}
                   color={'first'}
                   fullWidth
                 >

--- a/src/features/singleRight/delegate/ReceiptPage/ReceiptPage.tsx
+++ b/src/features/singleRight/delegate/ReceiptPage/ReceiptPage.tsx
@@ -5,13 +5,13 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import { PersonIcon } from '@navikt/aksel-icons';
 import { useEffect } from 'react';
 
-import { GeneralPath, SingleRightPath } from '@/routes/paths';
+import { SingleRightPath } from '@/routes/paths';
 import { Page, PageContainer, PageContent, PageHeader, RestartPrompter } from '@/components';
 import { useFetchRecipientInfo, useMediaQuery } from '@/resources/hooks';
 import { useAppDispatch, useAppSelector } from '@/rtk/app/hooks';
 import { resetServicesWithStatus } from '@/rtk/features/singleRights/singleRightsSlice';
 import { GroupElements } from '@/components/GroupElements/GroupElements';
-import { getCookie } from '@/resources/Cookie/CookieMethods';
+import { redirectToSevicesAvailableForUser } from '@/resources/utils';
 
 import classes from './ReceiptPage.module.css';
 import { ActionBarSection } from './ActionBarSection/ActionBarSection';
@@ -36,11 +36,6 @@ export const ReceiptPage = () => {
     void dispatch(resetServicesWithStatus());
   }, []);
 
-  const redirectToProfile = () => {
-    const cleanHostname = window.location.hostname.replace('am.ui.', '');
-    window.location.href = `https://${cleanHostname}/${GeneralPath.Profile}?R=${getCookie('AltinnPartyId')}&lm=${encodeURIComponent(`/ui/AccessManagement/ServicesAvailableForActor/?userID=${userID ? userID : 0}&partyID=${partyID}`)}`;
-  };
-
   return (
     <PageContainer>
       <Page
@@ -63,7 +58,7 @@ export const ReceiptPage = () => {
               </div>
               <GroupElements>
                 <Button
-                  onClick={redirectToProfile}
+                  onClick={() => redirectToSevicesAvailableForUser(userID, partyID)}
                   color={'first'}
                   fullWidth
                 >

--- a/src/resources/hooks/index.ts
+++ b/src/resources/hooks/index.ts
@@ -1,4 +1,4 @@
 export { useMediaQuery } from './useMediaQuery';
 export { usePrevious } from './usePrevious';
 export { useUpdate } from './useUpdate';
-export { useFetchNameFromUUID } from './useFetchNameFromUUID';
+export { useFetchRecipientInfo } from './useFetchRecipientInfo';

--- a/src/resources/hooks/useFetchRecipientInfo.tsx
+++ b/src/resources/hooks/useFetchRecipientInfo.tsx
@@ -22,7 +22,7 @@ export const useFetchRecipientInfo = (
 
   const [recipientName, setRecipientName] = useState<string | undefined>(undefined);
   const [userID, setUserID] = useState('');
-  const [partyID, setParyID] = useState('');
+  const [partyID, setPartyID] = useState('');
   const [error, setError] = useState(false);
 
   const {
@@ -44,7 +44,7 @@ export const useFetchRecipientInfo = (
         setError(true);
       } else {
         setUserID(user.userId);
-        setParyID(String(user.party.partyId));
+        setPartyID(String(user.party.partyId));
         switch (user?.userType) {
           case UserType.SSNIdentified:
             // Recipient is a person
@@ -66,7 +66,7 @@ export const useFetchRecipientInfo = (
         setError(true);
       } else {
         setError(false);
-        setParyID(String(party.partyId));
+        setPartyID(String(party.partyId));
         setRecipientName(`${party?.name}, ${t('common.org_nr')} ${party?.orgNumber}`);
       }
     } else if (!isLoading) {

--- a/src/resources/hooks/useFetchRecipientInfo.tsx
+++ b/src/resources/hooks/useFetchRecipientInfo.tsx
@@ -8,13 +8,21 @@ import {
 } from '@/rtk/features/lookup/lookupApi';
 
 // Used for fetching recipient name from userUUID or partyUUID
-export const useFetchNameFromUUID = (
+export const useFetchRecipientInfo = (
   userUUID: string | null,
   partyUUID: string | null,
-): [name: string | undefined, error: boolean, isLoading: boolean] => {
+): {
+  name: string | undefined;
+  userID: string;
+  partyID: string;
+  error: boolean;
+  isLoading: boolean;
+} => {
   const { t } = useTranslation('common');
 
   const [recipientName, setRecipientName] = useState<string | undefined>(undefined);
+  const [userID, setUserID] = useState('');
+  const [partyID, setParyID] = useState('');
   const [error, setError] = useState(false);
 
   const {
@@ -32,9 +40,11 @@ export const useFetchNameFromUUID = (
 
   useEffect(() => {
     if (userUUID && !getUserIsLoading) {
-      if (getUserError) {
+      if (getUserError || !user) {
         setError(true);
       } else {
+        setUserID(user.userId);
+        setParyID(String(user.party.partyId));
         switch (user?.userType) {
           case UserType.SSNIdentified:
             // Recipient is a person
@@ -52,10 +62,11 @@ export const useFetchNameFromUUID = (
         }
       }
     } else if (partyUUID && !getPartyIsLoading) {
-      if (getPartyError) {
+      if (getPartyError || !party) {
         setError(true);
       } else {
         setError(false);
+        setParyID(String(party.partyId));
         setRecipientName(`${party?.name}, ${t('common.org_nr')} ${party?.orgNumber}`);
       }
     } else if (!isLoading) {
@@ -64,5 +75,5 @@ export const useFetchNameFromUUID = (
     }
   }, [user, party, getUserIsLoading, getPartyIsLoading, getUserError, getPartyError]);
 
-  return [recipientName, error, isLoading];
+  return { name: recipientName, userID, partyID, error, isLoading };
 };

--- a/src/resources/utils/index.ts
+++ b/src/resources/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './arrayUtils';
 export * from './debounce';
+export * from './redirectUtils';

--- a/src/resources/utils/redirectUtils.ts
+++ b/src/resources/utils/redirectUtils.ts
@@ -1,0 +1,14 @@
+import { GeneralPath } from '@/routes/paths';
+
+import { getCookie } from '../Cookie/CookieMethods';
+
+export const redirectToSevicesAvailableForUser = (userID: string, partyID: string) => {
+  const cleanHostname = window.location.hostname.replace('am.ui.', '');
+  window.location.href = `https://${cleanHostname}/${GeneralPath.Profile}?R=${getCookie('AltinnPartyId')}&lm=${encodeURIComponent(`/ui/AccessManagement/ServicesAvailableForActor/?userID=${userID ? userID : 0}&partyID=${partyID}`)}`;
+};
+
+export const redirectToProfile = () => {
+  const cleanHostname = window.location.hostname.replace('am.ui.', '');
+  window.location.href =
+    'https://' + cleanHostname + '/' + GeneralPath.Profile + '?R=' + getCookie('AltinnPartyId');
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR adds linking back to the A2 module overviewing the accesses given to the relevant receiver.
In order to do this, userid and partyId for the receiver is needed, thus the hook fetching the recipient name is expanded to also fetch recipient userID and partyID

## Related Issue(s)
- #753 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
