### PR TITLE
Clear Access Cache for recipient after new single right access delegation(s)

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/ClientInterfaces/ISingleRightClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/ClientInterfaces/ISingleRightClient.cs
@@ -32,5 +32,22 @@ namespace Altinn.AccessManagement.UI.Core.ClientInterfaces
         /// </param>
         /// <returns></returns>
         Task<HttpResponseMessage> CreateDelegation(string party, DelegationInput delegation);
+
+        /// <summary>
+        ///     Clears cashed accesses of the user
+        /// </summary>
+        /// <param name="party">
+        ///     The party from which the rights have been given (delegator)
+        /// </param>
+        /// <param name="user">
+        ///     The uuid identifier of the user (delegation recipient) to clear access cashe on
+        ///     Example: 
+        ///     {
+        ///     "type": "urn:altinn:person:uuid",
+        ///     "value": "00000000-0000-0000-0000-000000000000"
+        ///     }
+        /// </param>
+        /// <returns></returns>
+        Task<HttpResponseMessage> ClearAccessCasheOnUser(string party, BaseAttribute user);
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/Common/BaseAttribute.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/Common/BaseAttribute.cs
@@ -1,0 +1,25 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace Altinn.AccessManagement.UI.Core.Models
+{
+    /// <summary>
+    /// This model describes an attribute, like a resource, a user, a party or an action. The attribute is defined by its type (usually a urn) and it's value.
+    /// </summary>
+    public class BaseAttribute
+    {
+        /// <summary>
+        /// Defines the type of the attribute (how to evaluate the value)
+        /// </summary>
+        [Required]
+        [JsonPropertyName("type")]
+        public required string Type { get; set; }
+
+        /// <summary>
+        /// Defines the value of the attribute
+        /// </summary>
+        [Required]
+        [JsonPropertyName("value")]
+        public required string Value { get; set; }
+    }
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/Interfaces/ISingleRightService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/Interfaces/ISingleRightService.cs
@@ -30,5 +30,17 @@ namespace Altinn.AccessManagement.UI.Core.Services.Interfaces
         /// </param>
         /// <returns></returns>
         Task<HttpResponseMessage> CreateDelegation(string party, DelegationInput delegation);
+
+        /// <summary>
+        ///     Clears cashed acesses of a user
+        /// </summary>
+        /// <param name="party">
+        ///     The party from which the rights have been given (delegator)
+        /// </param>
+        /// <param name="user">
+        ///     The uuid identifier of the user (delegation recipient) to clear access cashe on
+        /// </param>
+        /// <returns></returns>
+        Task<HttpResponseMessage> ClearAccessCasheOnUser(string party, BaseAttribute user);
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/SingleRightService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/SingleRightService.cs
@@ -12,7 +12,7 @@ namespace Altinn.AccessManagement.UI.Core.Services
         private readonly ISingleRightClient _singleRightClient;
 
         /// <summary>
-        ///     Initializes a new instance of the <see cref="SingleRightMockClient" /> class
+        ///     Initializes a new instance of the <see cref="SingleRightService" /> class
         /// </summary>
         public SingleRightService(ISingleRightClient singleRightClient)
         {
@@ -29,6 +29,12 @@ namespace Altinn.AccessManagement.UI.Core.Services
         public async Task<HttpResponseMessage> CreateDelegation(string party, DelegationInput delegation)
         {
             return await _singleRightClient.CreateDelegation(party, delegation);
+        }
+
+        /// <inheritdoc />
+        public async Task<HttpResponseMessage> ClearAccessCasheOnUser(string party, BaseAttribute user)
+        {
+            return await _singleRightClient.ClearAccessCasheOnUser(party, user);
         }
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/SingleRightClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/SingleRightClient.cs
@@ -72,5 +72,15 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
             HttpResponseMessage response = await _client.PostAsync(token, endpointUrl, requestBody);
             return response;
         }
+
+        /// <inheritdoc />
+        public async Task<HttpResponseMessage> ClearAccessCasheOnUser(string party, BaseAttribute user)
+        {
+            string endpointUrl = $"internal/{party}/accesscache/clear";
+            string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
+            StringContent requestBody = new StringContent(JsonSerializer.Serialize(user, _serializerOptions), Encoding.UTF8, "application/json");
+            HttpResponseMessage response = await _client.PutAsync(token, endpointUrl, requestBody);
+            return response;
+        }
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/SingleRightClientMock.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/SingleRightClientMock.cs
@@ -1,8 +1,12 @@
 using System.Net;
+using System.Text;
 using Altinn.AccessManagement.UI.Core.ClientInterfaces;
 using Altinn.AccessManagement.UI.Core.Models;
 using Altinn.AccessManagement.UI.Core.Models.SingleRight;
 using Altinn.AccessManagement.UI.Mocks.Utils;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace Altinn.AccessManagement.UI.Mocks.Mocks
 {
@@ -34,6 +38,13 @@ namespace Altinn.AccessManagement.UI.Mocks.Mocks
             string dataPath = Path.Combine(localPath, "Data", "SingleRight", "CreateDelegation");
 
             return await GetMockedHttpResponse(dataPath, resourceFileName);
+        }
+
+        /// <inheritdoc />
+        public Task<HttpResponseMessage> ClearAccessCasheOnUser(string party, BaseAttribute user)
+        {
+            return Task.FromResult(new HttpResponseMessage
+            { StatusCode = HttpStatusCode.OK });
         }
 
         private static string GetMockDataFilename(List<IdValuePair> resourceReference)

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/SingleRightControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/SingleRightControllerTest.cs
@@ -439,6 +439,43 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             Assert.Equal(HttpStatusCode.BadRequest, httpResponse.StatusCode);
         }
 
+        /// <summary>
+        ///     Test case: ClearAccessCashe accepts correct input and returns ok
+        ///     Expected: ClearAccessCashe returns OK
+        /// </summary>
+        [Fact]
+        public async Task ClearAccessCashe_returnsOk()
+        {
+            // Arrange
+            string partyId = "999 999 999";
+            string userUUID = "5c0656db-cf51-43a4-bd64-6a91c8caacfb";
+
+            List<IdValuePair> resource = new List<IdValuePair>
+            {
+                new IdValuePair
+                {
+                    Id = "urn:altinn:resource",
+                    Value = "Nonexistent",
+
+                },
+            };
+
+            BaseAttribute user = new BaseAttribute
+            {
+                    Type = "urn:altinn:person:uuid",
+                    Value = userUUID,
+            };
+
+            string jsonDto = JsonSerializer.Serialize(user);
+            HttpContent content = new StringContent(jsonDto, Encoding.UTF8, "application/json");
+
+            // Act
+            HttpResponseMessage httpResponse = await _client.PutAsync($"accessmanagement/api/v1/singleright/{partyId}/accesscache/clear", content);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, httpResponse.StatusCode);
+        }
+
         private int CountMatches(List<DelegationResponseData> actualResponses, string expectedResponseFileName)
         {
             string path = Path.Combine(mockFolder, "Data", "SingleRight", "DelegationAccessCheckResponse", expectedResponseFileName);

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/SingleRightController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/SingleRightController.cs
@@ -106,5 +106,33 @@ namespace Altinn.AccessManagement.UI.Controllers
                 return new ObjectResult(ProblemDetailsFactory.CreateProblemDetails(HttpContext));
             }
         }
+
+        /// <summary>
+        ///     Endpoint for clearing cash on accesses of the given user on behalf of the provided party
+        /// </summary>
+        /// <response code="400">Bad Request</response>
+        /// <response code="500">Internal Server Error</response>
+        [HttpPut]
+        [Authorize]
+        [Route("{party}/accesscache/clear")]
+        public async Task<IActionResult> ClearAccessCashe([FromRoute] string party, [FromBody] BaseAttribute user)
+        {
+            try
+            {
+                HttpResponseMessage response = await _singleRightService.ClearAccessCasheOnUser(party, user);
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    return new ObjectResult(ProblemDetailsFactory.CreateProblemDetails(HttpContext, (int)response.StatusCode, detail: $"Could not complete the request. Reason: {response.ReasonPhrase}"));
+                }
+
+                return Ok();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Unexpected exception occurred during delegation of resource:" + ex.Message);
+                return new ObjectResult(ProblemDetailsFactory.CreateProblemDetails(HttpContext));
+            }
+        }
     }
 }

--- a/src/dataObjects/dtos/BaseAttribute.tsx
+++ b/src/dataObjects/dtos/BaseAttribute.tsx
@@ -1,0 +1,10 @@
+// This model describes an attribute, like a resource, a user, a party or an action. The attribute is defined by its type (usually a urn) and it's value.
+export class BaseAttribute {
+  type: string;
+  value: string;
+
+  constructor(type: string, value: string) {
+    this.type = type;
+    this.value = value;
+  }
+}

--- a/src/features/singleRight/delegate/ChooseRightsPage/ChooseRightsPage.tsx
+++ b/src/features/singleRight/delegate/ChooseRightsPage/ChooseRightsPage.tsx
@@ -29,6 +29,9 @@ import {
   ServiceDto,
 } from '@/dataObjects/dtos/resourceDelegation';
 import { IdValuePair } from '@/dataObjects/dtos/IdValuePair';
+import { useClearAccessCasheMutation } from '@/rtk/features/singleRights/singleRightsApi';
+import { getCookie } from '@/resources/Cookie/CookieMethods';
+import { BaseAttribute } from '@/dataObjects/dtos/BaseAttribute';
 
 import { RecipientErrorAlert } from '../../components/RecipientErrorAlert/RecipientErrorAlert';
 
@@ -66,6 +69,7 @@ export const ChooseRightsPage = () => {
   const processedDelegationsRatio = (): number =>
     Math.round((processedDelegations.length / delegationCount) * 100);
   const buttonRef = useRef<HTMLButtonElement | null>(null);
+  const [clearAccessCashe] = useClearAccessCasheMutation();
 
   const {
     name: recipientName,
@@ -246,6 +250,7 @@ export const ChooseRightsPage = () => {
   };
 
   const postDelegations = () => {
+    const partyId = getCookie('AltinnPartyId');
     const userUUID = urlParams.get('userUUID');
     const partyUUID = urlParams.get('partyUUID');
     let recipient: IdValuePair[];
@@ -259,30 +264,38 @@ export const ChooseRightsPage = () => {
     } else if (partyUUID) {
       // Recipient is an organization
       recipient = [new IdValuePair('urn:altinn:organization:uuid', partyUUID)];
+    } else {
+      throw new Error('Neither userUUID nor partyUUID are defined');
     }
 
     // TODO: OBS! This is a temporary solution for sequential delegations, which is needed due to a weakness in Altinn 2. When this is fixed, we can go back to paralell delegations
     // Post delegations synchroneously using recursive method
     const syncPostDelegations = (servicesToPost: Service[]) => {
-      const service = servicesToPost[0];
-      const rightsToDelegate = service.rights
-        .filter((right: ChipRight) => right.checked)
-        .map((right: ChipRight) => new DelegationRequestDto(right.resourceReference, right.action));
-
-      if (rightsToDelegate.length > 0) {
-        const delegationInput: DelegationInputDto = {
-          To: recipient,
-          Rights: rightsToDelegate,
-          serviceDto: new ServiceDto(service.title, service.serviceOwner, service.type),
-        };
-
-        dispatch(delegate(delegationInput)).then(() => {
-          if (servicesToPost.length > 1) {
-            syncPostDelegations(servicesToPost.slice(1));
-          }
+      if (servicesToPost.length === 0) {
+        // End recursion
+        clearAccessCashe({
+          party: partyId,
+          user: new BaseAttribute(recipient[0].id, recipient[0].value), // In time BaseAttriute will take over from IdValuePair. But until then we need to use both,
         });
       } else {
-        if (servicesToPost.length > 1) {
+        const service = servicesToPost[0];
+        const rightsToDelegate = service.rights
+          .filter((right: ChipRight) => right.checked)
+          .map(
+            (right: ChipRight) => new DelegationRequestDto(right.resourceReference, right.action),
+          );
+
+        if (rightsToDelegate.length > 0) {
+          const delegationInput: DelegationInputDto = {
+            To: recipient,
+            Rights: rightsToDelegate,
+            serviceDto: new ServiceDto(service.title, service.serviceOwner, service.type),
+          };
+
+          dispatch(delegate(delegationInput)).then(() => {
+            syncPostDelegations(servicesToPost.slice(1));
+          });
+        } else {
           syncPostDelegations(servicesToPost.slice(1));
         }
       }

--- a/src/rtk/features/singleRights/singleRightsApi.ts
+++ b/src/rtk/features/singleRights/singleRightsApi.ts
@@ -2,6 +2,7 @@ import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 
 import type { IdValuePair } from '@/dataObjects/dtos/IdValuePair';
 import { getCookie } from '@/resources/Cookie/CookieMethods';
+import type { BaseAttribute } from '@/dataObjects/dtos/BaseAttribute';
 
 import type { ResourceOwner } from '../resourceOwner/resourceOwnerApi';
 
@@ -41,12 +42,9 @@ export const singleRightsApi = createApi({
   reducerPath: 'singleRightsApi',
   baseQuery: fetchBaseQuery({
     baseUrl,
-    prepareHeaders: (headers: Headers): Headers => {
-      const token = getCookie('XSRF-TOKEN');
-      if (typeof token === 'string') {
-        headers.set('X-XSRF-TOKEN', token);
-      }
-
+    prepareHeaders: (headers) => {
+      headers.set('content-type', 'application/json; charset=utf-8');
+      headers.set('X-XSRF-TOKEN', getCookie('XSRF-TOKEN'));
       return headers;
     },
   }),
@@ -64,9 +62,22 @@ export const singleRightsApi = createApi({
     getResourceOwners: builder.query<ResourceOwner[], void>({
       query: () => 'resources/resourceowners',
     }),
+    clearAccessCashe: builder.mutation<void, { party: string; user: BaseAttribute }>({
+      query({ party, user }) {
+        return {
+          url: `singleright/${party}/accesscache/clear`,
+          method: 'PUT',
+          body: JSON.stringify(user),
+        };
+      },
+    }),
   }),
 });
 
-export const { useGetPaginatedSearchQuery, useGetResourceOwnersQuery } = singleRightsApi;
+export const {
+  useGetPaginatedSearchQuery,
+  useGetResourceOwnersQuery,
+  useClearAccessCasheMutation,
+} = singleRightsApi;
 
 export const { endpoints, reducerPath, reducer, middleware } = singleRightsApi;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds
- New endpoint in BBF for calling the new cache clearing endpoint in backend
- Calling of this BFF endpoint in frontend after all delegations have been performed
- Added new model BaseAttribute which will eventually replace IdValuePair as the main model for defining single attributes

## Related Issue(s)
- #826 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
