### PR TITLE
Cleaned up rightKeys on local mock data

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/SingleRight/DelegationAccessCheckResponse/3225.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/SingleRight/DelegationAccessCheckResponse/3225.json
@@ -1,6 +1,6 @@
 [
   {
-    "rightKey": "ttd-am-k6/read",
+    "rightKey": "3225/read",
     "resource": [
       {
         "id": "urn:altinn:servicecode",
@@ -29,7 +29,7 @@
     ]
   },
   {
-    "rightKey": "ttd-am-k6/read",
+    "rightKey": "3225/all-accesses-3325",
     "resource": [
       {
         "id": "urn:altinn:servicecode",
@@ -58,7 +58,7 @@
     ]
   },
   {
-    "rightKey": "ttd-am-k6/write",
+    "rightKey": "3225/write",
     "resource": [
       {
         "id": "urn:altinn:servicecode",
@@ -97,7 +97,7 @@
     ]
   },
   {
-    "rightKey": "ttd-am-k6/sign",
+    "rightKey": "3225/sign",
     "resource": [
       {
         "id": "urn:altinn:servicecode",
@@ -120,7 +120,7 @@
     ]
   },
   {
-    "rightKey": "ttd-am-k6/confirm",
+    "rightKey": "3225/confirm",
     "resource": [
       {
         "id": "urn:altinn:servicecode",
@@ -131,7 +131,7 @@
         "value": "1596"
       }
     ],
-    "action": "task-edit",
+    "action": "confirm",
     "status": "NotDelegable",
     "details": [
       {

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/SingleRight/DelegationAccessCheckResponse/322a.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/SingleRight/DelegationAccessCheckResponse/322a.json
@@ -1,6 +1,6 @@
 [
   {
-    "rightKey": "ttd-am-k6/read",
+    "rightKey": "322a/read",
     "resource": [
       {
         "id": "urn:altinn:servicecode",
@@ -29,7 +29,7 @@
     ]
   },
   {
-    "rightKey": "ttd-am-k6/write",
+    "rightKey": "322a/write",
     "resource": [
       {
         "id": "urn:altinn:servicecode",
@@ -62,7 +62,7 @@
     ]
   },
   {
-    "rightKey": "ttd-am-k6/sign",
+    "rightKey": "322a/sign",
     "resource": [
       {
         "id": "urn:altinn:servicecode",

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/SingleRight/DelegationAccessCheckResponse/a3-app.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/SingleRight/DelegationAccessCheckResponse/a3-app.json
@@ -1,6 +1,6 @@
 [
   {
-    "rightKey": "ttd-am-k6/read",
+    "rightKey": "a3-app/read",
     "resource": [
       {
         "id": "urn:altinn:app",
@@ -29,7 +29,7 @@
     ]
   },
   {
-    "rightKey": "ttd-am-k6/write",
+    "rightKey": "a3-app/write",
     "resource": [
       {
         "id": "urn:altinn:app",
@@ -58,7 +58,7 @@
     ]
   },
   {
-    "rightKey": "ttd-am-k6/sign",
+    "rightKey": "a3-app/sign",
     "resource": [
       {
         "id": "urn:altinn:app",

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/SingleRight/DelegationAccessCheckResponse/appid-502.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/SingleRight/DelegationAccessCheckResponse/appid-502.json
@@ -1,6 +1,6 @@
 [
   {
-    "rightKey": "ttd-am-k6/access",
+    "rightKey": "appid-502/access",
     "resource": [
       {
         "id": "urn:altinn:resource",

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/SingleRight/DelegationAccessCheckResponse/appid-503.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/SingleRight/DelegationAccessCheckResponse/appid-503.json
@@ -1,6 +1,6 @@
 [
   {
-    "rightKey": "ttd-am-k6/read",
+    "rightKey": "appid-503/read",
     "resource": [
       {
         "id": "urn:altinn:resource",
@@ -25,7 +25,7 @@
     ]
   },
   {
-    "rightKey": "ttd-am-k6/write",
+    "rightKey": "appid-503/write",
     "resource": [
       {
         "id": "urn:altinn:resource",
@@ -50,7 +50,7 @@
     ]
   },
   {
-    "rightKey": "ttd-am-k6/sign",
+    "rightKey": "appid-503/sign",
     "resource": [
       {
         "id": "urn:altinn:resource",

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/SingleRight/DelegationAccessCheckResponse/appid-508.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/SingleRight/DelegationAccessCheckResponse/appid-508.json
@@ -1,6 +1,6 @@
 [
   {
-    "rightKey": "ttd-am-k6/read",
+    "rightKey": "appid-508/read",
     "resource": [
       {
         "id": "urn:altinn:resource",
@@ -25,7 +25,7 @@
     ]
   },
   {
-    "rightKey": "ttd-am-k6/write",
+    "rightKey": "appid-508/write",
     "resource": [
       {
         "id": "urn:altinn:resource",
@@ -50,7 +50,7 @@
     ]
   },
   {
-    "rightKey": "ttd-am-k6/sign",
+    "rightKey": "appid-508/sign",
     "resource": [
       {
         "id": "urn:altinn:resource",

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/SingleRight/DelegationAccessCheckResponse/appid-509.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/SingleRight/DelegationAccessCheckResponse/appid-509.json
@@ -1,6 +1,6 @@
 [
   {
-    "rightKey": "ttd-am-k6/read",
+    "rightKey": "appid-509/read",
     "resource": [
       {
         "id": "urn:altinn:resource",
@@ -25,7 +25,7 @@
     ]
   },
   {
-    "rightKey": "ttd-am-k6/write",
+    "rightKey": "appid-509/write",
     "resource": [
       {
         "id": "urn:altinn:resource",
@@ -50,7 +50,7 @@
     ]
   },
   {
-    "rightKey": "ttd-am-k6/sign",
+    "rightKey": "appid-509/sign",
     "resource": [
       {
         "id": "urn:altinn:resource",

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/SingleRight/DelegationAccessCheckResponse/appid-510.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/SingleRight/DelegationAccessCheckResponse/appid-510.json
@@ -1,6 +1,6 @@
 [
   {
-    "rightKey": "ttd-am-k6/read",
+    "rightKey": "appid-510/read",
     "resource": [
       {
         "id": "urn:altinn:resource",
@@ -25,7 +25,7 @@
     ]
   },
   {
-    "rightKey": "ttd-am-k6/write",
+    "rightKey": "appid-510/write",
     "resource": [
       {
         "id": "urn:altinn:resource",
@@ -50,7 +50,7 @@
     ]
   },
   {
-    "rightKey": "ttd-am-k6/sign",
+    "rightKey": "appid-510/sign",
     "resource": [
       {
         "id": "urn:altinn:resource",

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/ResourceControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/ResourceControllerTest.cs
@@ -247,7 +247,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
 
         /// <summary>
         ///     Test case: GetAllResourceOwners, returns a simplified list of resource owners
-        ///     Expected: GetResources returns a list of resource owners in correct language
+        ///     Expected: GetAllResourceOwners returns a list of resource owners in correct language, ordered alphabetically
         /// </summary>
         [Fact]
         public async Task GetAllResourceOwners_validresults()
@@ -255,7 +255,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             // Arrange
             string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(ResourceControllerTest).Assembly.Location).LocalPath);
             string path = Path.Combine(unitTestFolder, "Data", "ExpectedResults", "ResourceRegistry", "resourceOwnersOrgList.json");
-            List<ResourceOwnerFE> expectedResult = Util.GetMockData<List<ResourceOwnerFE>>(path);
+            List<ResourceOwnerFE> expectedResult = Util.GetMockData<List<ResourceOwnerFE>>(path).OrderBy(resorceOwner => resorceOwner.OrganisationName).ToList(); // order alphabetically
 
             string token = PrincipalUtil.GetToken(1337, 501337);
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
@@ -272,6 +272,10 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             }
         }
 
+        /// <summary>
+        ///     Test case: GetResourceOwners, returns a simplified list of resource owners that have resources of type MaskinportenSchema
+        ///     Expected: GetResourceOwners returns a list of resource owners in correct language, with MaskinportenSchema, ordered alphabetically
+        /// </summary>
         [Fact]
         public async Task GetResourceOwners_resourceTypeMaskinPortenSchemAndAltinn2Service()
         {
@@ -287,10 +291,10 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
 
             List<ResourceOwnerFE> expectedResult = new List<ResourceOwnerFE>
             {
-                new ResourceOwnerFE("Skatteetaten", "974761076"),
-                new ResourceOwnerFE("PÅFUNNSETATEN", "985399077"),
                 new ResourceOwnerFE("BLOMSTERFINN", "994598759"),
                 new ResourceOwnerFE("NARNIA", "777777777"),
+                new ResourceOwnerFE("PÅFUNNSETATEN", "985399077"),
+                new ResourceOwnerFE("Skatteetaten", "974761076"),
                 new ResourceOwnerFE("Testdepartementet", "123456789"),
             };
 

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/SingleRight/DelegationAccessCheckResponse/3225.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/SingleRight/DelegationAccessCheckResponse/3225.json
@@ -1,6 +1,6 @@
 [
   {
-    "rightKey": "ttd-am-k6/read",
+    "rightKey": "3225/read",
     "resource": [
       {
         "id": "urn:altinn:servicecode",
@@ -29,7 +29,7 @@
     ]
   },
   {
-    "rightKey": "ttd-am-k6/read",
+    "rightKey": "3225/all-accesses-3325",
     "resource": [
       {
         "id": "urn:altinn:servicecode",
@@ -58,7 +58,7 @@
     ]
   },
   {
-    "rightKey": "ttd-am-k6/write",
+    "rightKey": "3225/write",
     "resource": [
       {
         "id": "urn:altinn:servicecode",
@@ -74,12 +74,22 @@
     "details": [
       {
         "code": "MissingSrrRightAccess",
-        "description": "MissingSrrRightAccess",
+        "description": "",
+        "parameters": {
+        }
+      },
+      {
+        "code": "MissingRoleAccess",
+        "description": "",
         "parameters": {
           "roleRequirementsMatches": [
             {
               "id": "urn:altinn:role",
               "value": "DAGL"
+            },
+            {
+              "id": "urn:altinn:role",
+              "value": "REGN"
             }
           ]
         }
@@ -87,7 +97,7 @@
     ]
   },
   {
-    "rightKey": "ttd-am-k6/sign",
+    "rightKey": "3225/sign",
     "resource": [
       {
         "id": "urn:altinn:servicecode",
@@ -105,18 +115,12 @@
         "code": "MissingSrrRightAccess",
         "description": "MissingSrrRightAccess",
         "parameters": {
-          "roleRequirementsMatches": [
-            {
-              "id": "urn:altinn:role",
-              "value": "DAGL"
-            }
-          ]
         }
       }
     ]
   },
   {
-    "rightKey": "ttd-am-k6/confirm",
+    "rightKey": "3225/confirm",
     "resource": [
       {
         "id": "urn:altinn:servicecode",
@@ -127,7 +131,7 @@
         "value": "1596"
       }
     ],
-    "action": "task-edit",
+    "action": "confirm",
     "status": "NotDelegable",
     "details": [
       {

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/SingleRight/DelegationAccessCheckResponse/a3-app.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/SingleRight/DelegationAccessCheckResponse/a3-app.json
@@ -1,6 +1,6 @@
 [
   {
-    "rightKey": "ttd-am-k6/read",
+    "rightKey": "a3-app/read",
     "resource": [
       {
         "id": "urn:altinn:app",
@@ -29,7 +29,7 @@
     ]
   },
   {
-    "rightKey": "ttd-am-k6/write",
+    "rightKey": "a3-app/write",
     "resource": [
       {
         "id": "urn:altinn:app",
@@ -58,7 +58,7 @@
     ]
   },
   {
-    "rightKey": "ttd-am-k6/sign",
+    "rightKey": "a3-app/sign",
     "resource": [
       {
         "id": "urn:altinn:app",

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/SingleRight/DelegationAccessCheckResponse/appid-503.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/SingleRight/DelegationAccessCheckResponse/appid-503.json
@@ -1,6 +1,6 @@
 [
   {
-    "rightKey": "ttd-am-k6/read",
+    "rightKey": "appid-503/read",
     "resource": [
       {
         "id": "urn:altinn:resource",
@@ -25,7 +25,7 @@
     ]
   },
   {
-    "rightKey": "ttd-am-k6/write",
+    "rightKey": "appid-503/write",
     "resource": [
       {
         "id": "urn:altinn:resource",
@@ -50,7 +50,7 @@
     ]
   },
   {
-    "rightKey": "ttd-am-k6/sign",
+    "rightKey": "appid-503/sign",
     "resource": [
       {
         "id": "urn:altinn:resource",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This is a chore and does not affect the functionality of the solution.
All it does is to clean up some of the faults in the rightKeys of the checkDelegation responses in our mock data to make the mock run more realistically

It also fixes the failing tests in the BFF

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
