### PR TITLE
Import localization texts from relative path to enable versioning in browser cache

### DIFF
--- a/src/features/apiDelegation/components/OverviewPageContent/OverviewPageContent.tsx
+++ b/src/features/apiDelegation/components/OverviewPageContent/OverviewPageContent.tsx
@@ -180,7 +180,7 @@ export const OverviewPageContent = ({
             fullWidth={isSm}
             size='medium'
           >
-            <PlusIcon fontSize={getButtonIconSize(true)} /> {t('api_delegation.delegate_new_org')}
+            <PlusIcon fontSize={getButtonIconSize(true)} /> {t('api_delegation.delegate_new_api')}
           </Button>
         </div>
       )}

--- a/src/resources/LoadLocalizations/LoadLocalizations.tsx
+++ b/src/resources/LoadLocalizations/LoadLocalizations.tsx
@@ -9,27 +9,22 @@ interface Props {
 }
 
 const LoadLocalizations = ({ children }: Props) => {
-  const getBackupLanguage = () => {
+  const getLanguageFile = async () => {
     const value = getCookie('i18next');
-    if (value === 'no_nn' || value === 'en') {
-      return value;
+    if (value === 'no_nn') {
+      return [await import('../../localizations/no_nn.json'), 'no_nn'] as const;
+    } else if (value === 'en') {
+      return [await import('../../localizations/en.json'), 'en'] as const;
     } else {
-      return 'no_nb';
+      return [await import('../../localizations/no_nb.json'), 'no_nb'] as const;
     }
   };
-
-  const backupLang = getBackupLanguage();
-  const envUrl = import.meta.env.DEV ? 'src/' : 'accessmanagement/';
-  const baseUrl = import.meta.env.BASE_URL + envUrl;
-  const localizationsFilePath = `${baseUrl}localizations/${backupLang}.json`;
-  const localizationsFileUrl = new URL(localizationsFilePath, import.meta.url).href;
 
   useQuery(
     ['Localizations'],
     async () => {
-      const data = await fetch(localizationsFileUrl);
-      const resource = await data.json();
-      return i18next.addResourceBundle(backupLang, 'common', resource);
+      const [data, language] = await getLanguageFile();
+      return i18next.addResourceBundle(language, 'common', data.default);
     },
     {
       staleTime: Infinity,


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

using import instead of fetch imports the files from relative path as a module instead of a call to give a hashed versioning to the built text file, fixing the issue of the browser caching the files even after new builds have been deployed.

## Related Issue(s)
- #877 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
