### PR TITLE
Fix rendering service delegations when service has long name

### DIFF
--- a/src/features/singleRight/components/ResourceActionBar/ResourceActionBar.module.css
+++ b/src/features/singleRight/components/ResourceActionBar/ResourceActionBar.module.css
@@ -29,3 +29,7 @@
   padding-right: 12px;
   color: var(--fds-semantic-text-neutral-subtle) !important;
 }
+
+.actionBarButtonText {
+  white-space: nowrap;
+}

--- a/src/features/singleRight/components/ResourceActionBar/ResourceActionBar.tsx
+++ b/src/features/singleRight/components/ResourceActionBar/ResourceActionBar.tsx
@@ -83,6 +83,7 @@ export const ResourceActionBar = ({
         onAddClick?.();
       }}
       icon={compact}
+      className={classes.actionBarButtonText}
     >
       {!compact && (status === ServiceStatus.HTTPError ? t('common.try_again') : t('common.add'))}
       <PlusCircleIcon


### PR DESCRIPTION
Fix rendering service delegations when service has long name

## Description
Add styling to handle long service-names in service list in single-rights deligations  

## Related Issue(s)
- https://github.com/Altinn/altinn-access-management-frontend/issues/786

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
