### PR TITLE
Temporary fix for eslint (using v9.0.0): disable flat config

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -18,8 +18,6 @@ module.exports = {
     'eslint:recommended',
     'plugin:react/recommended',
     'plugin:prettier/recommended',
-    'plugin:import/recommended',
-    'plugin:import/typescript',
     'plugin:@typescript-eslint/recommended',
     'plugin:jsx-a11y/recommended',
     'plugin:react/recommended',

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,7 @@
     "eslint.validate": [
       "javascript"
     ],
+    "eslint.useFlatConfig": false,
     "workbench.colorCustomizations": {
       "activityBar.activeBackground": "#65c89b",
       "activityBar.background": "#65c89b",


### PR DESCRIPTION
## Description

eslint v9.0.0 has a breaking change in that it expects a new format and filename for the config file. Our current .eslintrc.cjs file is currently ignored in v9.0.0 (https://eslint.org/docs/latest/use/configure/configuration-files). This PR aims to disable flat config so we can continue using the current .eslintrc.csj file. However, one of the plugins we use does not support eslint v9.0.0 and unless the rules are removed, eslint will crash when it attempts to scan our code. See https://github.com/import-js/eslint-plugin-import/issues/2948

Changes:
- Added config to disable eslint flat config
- Removed eslint rules 'plugin:import/recommended' and 'plugin:import/typescript'



## Related Issue(s)
- this PR

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
