### PR TITLE
Turn off UseMockData AT22

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.AT22.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.AT22.json
@@ -10,7 +10,7 @@
   "GeneralSettings": {
     "FrontendBaseUrl": "https://am.ui.at22.altinn.cloud",
     "Hostname": "at22.altinn.cloud",
-    "UseMockData": true
+    "UseMockData": false
   },
   "KeyVaultSettings": {
     "SecretUri": "https://altinn-at22-am-kv.vault.azure.net/"


### PR DESCRIPTION
## Description
Changes to the database in access-management needs to be tested in AT22 requiring the UI to run on the actual backend APIs and not mock data
