### PR TITLE
Bugfix: calls to useAppSelector should return the same result

### DIFF
--- a/src/features/singleRight/delegate/ChooseServicePage/ChooseServicePage.tsx
+++ b/src/features/singleRight/delegate/ChooseServicePage/ChooseServicePage.tsx
@@ -35,10 +35,9 @@ export const ChooseServicePage = () => {
   const dispatch = useAppDispatch();
   const [urlParams] = useSearchParams();
   useDocumentTitle(t('single_rights.page_title'));
-  const delegableChosenServices = useAppSelector((state) =>
-    state.singleRightsSlice.servicesWithStatus.filter(
-      (s) => s.status === ServiceStatus.Delegable || s.status === ServiceStatus.PartiallyDelegable,
-    ),
+  const servicesWithStatus = useAppSelector((state) => state.singleRightsSlice.servicesWithStatus);
+  const delegableChosenServices = servicesWithStatus.filter(
+    (s) => s.status === ServiceStatus.Delegable || s.status === ServiceStatus.PartiallyDelegable,
   );
 
   useLayoutEffect(() => {

--- a/src/features/singleRight/request/ChooseServicePage/ChooseServicePage.tsx
+++ b/src/features/singleRight/request/ChooseServicePage/ChooseServicePage.tsx
@@ -21,6 +21,7 @@ import { ResourceCollectionBar } from '../../components/ResourceCollectionBar';
 import { NavigationSection } from '../../components/NavigationSection/NavigationSection';
 import classes from './ChooseServicePage.module.css';
 import { useGetUserInfoQuery, useGetReporteeQuery } from '@/rtk/features/userInfo/userInfoApi';
+import { Ingress } from '@digdir/designsystemet-react';
 
 export const ChooseServicePage = () => {
   const { t } = useTranslation();
@@ -32,10 +33,9 @@ export const ChooseServicePage = () => {
 
   const requestee = reporteeData?.name || userData?.name || '';
 
-  const delegableChosenServices = useAppSelector((state) =>
-    state.singleRightsSlice.servicesWithStatus.filter(
-      (s) => s.status === ServiceStatus.Delegable || s.status === ServiceStatus.PartiallyDelegable,
-    ),
+  const servicesWithStatus = useAppSelector((state) => state.singleRightsSlice.servicesWithStatus);
+  const delegableChosenServices = servicesWithStatus.filter(
+    (s) => s.status === ServiceStatus.Delegable || s.status === ServiceStatus.PartiallyDelegable,
   );
 
   const onAdd = (serviceResource: ServiceResource) => {


### PR DESCRIPTION
## Description

Any manipulation of data should be done outside `useAppSelector` call, so the call to `useAppSelector` will always return the same data based on the same input

## Related Issue(s)
- #860 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
