### PR TITLE
Fix: Confirm button on cancel is too large

### DIFF
--- a/src/features/singleRight/components/NavigationSection/NavigationSection.tsx
+++ b/src/features/singleRight/components/NavigationSection/NavigationSection.tsx
@@ -1,6 +1,7 @@
 import { Button, Popover, Paragraph } from '@digdir/designsystemet-react';
 import { t } from 'i18next';
-import React, { HTMLAttributes, useState } from 'react';
+import type { HTMLAttributes } from 'react';
+import React, { useState } from 'react';
 
 import { useMediaQuery } from '@/resources/hooks';
 
@@ -72,8 +73,9 @@ export const NavigationSection = ({
               onClick={() => setPopoverOpen(false)}
               color={'danger'}
               variant={'tertiary'}
+              fullWidth
             >
-              {t('single_rights.no_continue_delegating')}
+              {t('single_rights.no_stay_here')}
             </Button>
           </div>
         </Popover.Content>

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -182,7 +182,7 @@
     "action_bar_adjust_rights_text": "If you want to limit the delegable accesses you can click the buttons below to remove them.",
     "delegable_apis": "Delegable APIs",
     "cancel_popover_text": "Chosen services won't be delegated. Are you sure you want to cancel?",
-    "no_continue_delegating": "No, continue delegating",
+    "no_stay_here": "No, stay here",
     "add_more_services": "Add more services",
     "ceo_or_main_admin_can_help": "CEO or main administrator can help you with this.",
     "one_or_more_rights_is_undelegable": "One or more rights on this service cant be delegated because of {{reason}}",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -181,7 +181,7 @@
     "these_rights_were_not_delegated": "Disse rettighetene kunne ikke delegeres:",
     "these_rights_were_delegated": "Disse rettighetene ble delegert til mottaker:",
     "cancel_popover_text": "Valgte tjenester vil ikke bli delegert. Er du sikker på at du vil avslutte?",
-    "no_continue_delegating": "Nei, fortsett å delegere",
+    "no_stay_here": "Nei, bli her",
     "add_more_services": "Legg til flere tjenester",
     "ceo_or_main_admin_can_help": "Daglig leder eller hovedadministrator kan hjelpe deg med dette.",
     "one_or_more_rights_is_undelegable": "En eller flere av rettighetene på denne tjenesten blir ikke delegert fordi {{reason}}",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -180,7 +180,7 @@
     "action_bar_adjust_rights_text": "Dersom du vil avgrense tilgangen til ein rett, kan du klikke på knappane nedanfor for å fjerne tilgangen.",
     "processing_delegations": "Prosesserer delegeringar",
     "cancel_popover_text": "Valde tenester vil ikkje bli delegert. Er du sikker på at du vil avslutte?",
-    "no_continue_delegating": "Nei, hald fram med å delegere",
+    "no_stay_here": "Nei, bli her",
     "add_more_services": "Legg til fleire tenester",
     "ceo_or_main_admin_can_help": "Dagleg leiar eller hovudadministrator kan hjelpe deg med dette.",
     "one_or_more_rights_is_undelegable": "Ein eller fleire av rettane på denne tenesta blir ikkje delegert fordi {{reason}}",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
![image](https://github.com/user-attachments/assets/bb75faf4-f0f8-404e-9cf4-a2d70e620980)

## Description
<!--- Describe your changes in detail -->
Fixes the bug by reducing the amount of text in the tertiary button - allowing them to be the same size without it looking strange

## Related Issue(s)
- Fixes #1003 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
