### PR TITLE
Feat/users/994 one language call to rule them all

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Helpers/LanguageHelper.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Helpers/LanguageHelper.cs
@@ -7,7 +7,6 @@ namespace Altinn.AccessManagement.UI.Core.Helpers
     /// </summary>
     public static class LanguageHelper
     {
-
         // Lanugage mappings between Altinn 2, backend standard and frontend standard.
         private static readonly List<(string Altinn2Standard, string BackendStandard, string FrontendStandard)> LanguageMappings = new List<(string, string, string)>
         {

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Helpers/LanguageHelper.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Helpers/LanguageHelper.cs
@@ -22,7 +22,7 @@ namespace Altinn.AccessManagement.UI.Core.Helpers
         /// <returns>The backend standard language code.</returns>
         public static string GetBackendStandardLanguage(string languageCode)
         {
-            return LanguageMappings.FirstOrDefault(m => languageCode.Contains(m.Altinn2Standard) || m.FrontendStandard == languageCode).BackendStandard;
+            return LanguageMappings.Find(m => languageCode.Contains(m.Altinn2Standard) || m.FrontendStandard == languageCode).BackendStandard;
         }
 
         /// <summary>
@@ -32,7 +32,7 @@ namespace Altinn.AccessManagement.UI.Core.Helpers
         /// <returns>The frontend standard language code.</returns>
         public static string GetFrontendStandardLanguage(string languageCode)
         {
-            return LanguageMappings.FirstOrDefault(m => languageCode.Contains(m.Altinn2Standard) || m.BackendStandard == languageCode).FrontendStandard;
+            return LanguageMappings.Find(m => languageCode.Contains(m.Altinn2Standard) || m.BackendStandard == languageCode).FrontendStandard;
         }
 
         /// <summary>

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Helpers/LanguageHelper.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Helpers/LanguageHelper.cs
@@ -1,16 +1,14 @@
-﻿using Altinn.AccessManagement.UI.Core.Services.Interfaces;
-using Altinn.Platform.Profile.Models;
-using Microsoft.AspNetCore.Http;
+﻿using Microsoft.AspNetCore.Http;
 
 namespace Altinn.AccessManagement.UI.Core.Helpers
 {
     /// <summary>
-    /// Helper class for authentication.
+    /// Helper class for user language.
     /// </summary>
-    public static class ProfileHelper
+    public static class LanguageHelper
     {
 
-        // Tuple type for language mappings
+        // Lanugage mappings between Altinn 2, backend standard and frontend standard.
         private static readonly List<(string Altinn2Standard, string BackendStandard, string FrontendStandard)> LanguageMappings = new List<(string, string, string)>
         {
             ("UL=1044", "nb", "no_nb"), // Norwegian Bokmål

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/HomeControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/HomeControllerTest.cs
@@ -1,6 +1,8 @@
 ﻿using Altinn.AccessManagement.UI.Controllers;
 using Altinn.AccessManagement.UI.Mocks.Utils;
 using Altinn.AccessManagement.UI.Tests.Utils;
+using Microsoft.AspNetCore.Http;
+using Moq;
 using System.Net;
 using System.Net.Http.Headers;
 
@@ -83,6 +85,9 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         public async Task GetHome_OK_WithAuthCookie()
         {
             string token = PrincipalUtil.GetAccessToken("sbl.authorization");
+            
+            var cookiesMock = new Mock<IRequestCookieCollection>();
+            cookiesMock.Setup(c => c["altinnPersistentContext"]).Returns("UL=1033");
 
             HttpClient client = SetupUtils.GetTestClient(_factory, false);
             var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "accessmanagement/");
@@ -93,6 +98,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             _ = await response.Content.ReadAsStringAsync();
             IEnumerable<string> cookieHeaders = response.Headers.GetValues("Set-Cookie");
 
+        
             // Verify that 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Equal(3, cookieHeaders.Count());
@@ -100,6 +106,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             Assert.StartsWith("XSR", cookieHeaders.ElementAt(1));
             Assert.StartsWith("selectedLanguage", cookieHeaders.ElementAt(2));
         }
+
 
         /// <summary>
         /// Test case : Authenticate with a invalid cookie

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/HomeControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/HomeControllerTest.cs
@@ -49,7 +49,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             Assert.Equal(3, cookieHeaders.Count());
             Assert.StartsWith("AS-", cookieHeaders.ElementAt(0));
             Assert.StartsWith("XSR", cookieHeaders.ElementAt(1));
-            Assert.StartsWith("i18next", cookieHeaders.ElementAt(2));
+            Assert.StartsWith("selectedLanguage", cookieHeaders.ElementAt(2));
             Assert.StartsWith("deny", xframeHeaders.ElementAt(0));
             Assert.StartsWith("nosniff", contentTypeHeaders.ElementAt(0));
             Assert.StartsWith("0", xxsProtectionHeaders.ElementAt(0));
@@ -98,7 +98,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             Assert.Equal(3, cookieHeaders.Count());
             Assert.StartsWith("AS-", cookieHeaders.ElementAt(0));
             Assert.StartsWith("XSR", cookieHeaders.ElementAt(1));
-            Assert.StartsWith("i18next", cookieHeaders.ElementAt(2));
+            Assert.StartsWith("selectedLanguage", cookieHeaders.ElementAt(2));
         }
 
         /// <summary>

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Helpers/LangugageHelperTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Helpers/LangugageHelperTest.cs
@@ -1,0 +1,122 @@
+using Altinn.AccessManagement.UI.Core.Helpers;
+using Microsoft.AspNetCore.Http;
+using Moq;
+
+
+[Collection("LanguageHelper Tests")]
+public class LanguageHelperTests
+{
+    [Fact]
+    public void GetAltinnPersistenceCookieValueFrontendStandard_ShouldReturnExpectedValue()
+    {
+        // Arrange
+        var cookieValue = "UL=2068";
+        var expectedValue = "no_nn";
+
+        var httpContextMock = new Mock<HttpContext>();
+        var requestMock = new Mock<HttpRequest>();
+        var cookiesMock = new Mock<IRequestCookieCollection>();
+
+        cookiesMock.Setup(c => c["altinnPersistentContext"]).Returns(cookieValue);
+        requestMock.Setup(r => r.Cookies).Returns(cookiesMock.Object);
+        httpContextMock.Setup(h => h.Request).Returns(requestMock.Object);
+
+        // Act
+        var result = LanguageHelper.GetAltinnPersistenceCookieValueFrontendStandard(httpContextMock.Object);
+
+        // Assert
+        Assert.Equal(expectedValue, result);
+    }
+
+    [Fact]
+    public void GetAltinnPersistenceCookieValueFrontendStandard_ShouldReturnEmptyString_WhenCookieIsNull()
+    {
+        // Arrange
+        var httpContextMock = new Mock<HttpContext>();
+        var requestMock = new Mock<HttpRequest>();
+        var cookiesMock = new Mock<IRequestCookieCollection>();
+
+        cookiesMock.Setup(c => c["altinnPersistentContext"]).Returns((string)null);
+        requestMock.Setup(r => r.Cookies).Returns(cookiesMock.Object);
+        httpContextMock.Setup(h => h.Request).Returns(requestMock.Object);
+
+        // Act
+        var result = LanguageHelper.GetAltinnPersistenceCookieValueFrontendStandard(httpContextMock.Object);
+
+        // Assert
+        Assert.Equal(string.Empty, result);
+    }
+
+     [Fact]
+    public void GetSelectedLanguageCookieValueBackendStandard_ShouldReturnExpectedValue()
+    {
+        // Arrange
+        var cookieValue = "UL=2068";
+        var expectedValue = "nn"; // Replace with the expected value from GetBackendStandardLanguage
+
+        var httpContextMock = new Mock<HttpContext>();
+        var requestMock = new Mock<HttpRequest>();
+        var cookiesMock = new Mock<IRequestCookieCollection>();
+
+        cookiesMock.Setup(c => c["selectedLanguage"]).Returns(cookieValue);
+        requestMock.Setup(r => r.Cookies).Returns(cookiesMock.Object);
+        httpContextMock.Setup(h => h.Request).Returns(requestMock.Object);
+
+        // Act
+        var result = LanguageHelper.GetSelectedLanguageCookieValueBackendStandard(httpContextMock.Object);
+
+        // Assert
+        Assert.Equal(expectedValue, result);
+    }
+
+    [Fact]
+    public void GetSelectedLanguageCookieValueBackendStandard_ShouldReturnEmptyString_WhenCookieIsNull()
+    {
+        // Arrange
+        var httpContextMock = new Mock<HttpContext>();
+        var requestMock = new Mock<HttpRequest>();
+        var cookiesMock = new Mock<IRequestCookieCollection>();
+
+        cookiesMock.Setup(c => c["selectedLanguage"]).Returns((string)null);
+        requestMock.Setup(r => r.Cookies).Returns(cookiesMock.Object);
+        httpContextMock.Setup(h => h.Request).Returns(requestMock.Object);
+
+        // Act
+        var result = LanguageHelper.GetSelectedLanguageCookieValueBackendStandard(httpContextMock.Object);
+
+        // Assert
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Theory]
+    [InlineData("UL=1044", "nb")]
+    [InlineData("UL=2068", "nn")]
+    [InlineData("UL=1033", "en")]
+    [InlineData("no_nb", "nb")]
+    [InlineData("no_nn", "nn")]
+    [InlineData("en", "en")]
+    public void GetBackendStandardLanguage_ShouldReturnExpectedValue(string cookieValue, string expectedValue)
+    {
+        // Act
+        var result = LanguageHelper.GetBackendStandardLanguage(cookieValue);
+
+        // Assert
+        Assert.Equal(expectedValue, result);
+    }
+
+    [Theory]
+    [InlineData("UL=1044", "no_nb")]
+    [InlineData("UL=2068", "no_nn")]
+    [InlineData("UL=1033", "en")]
+    [InlineData("nb", "no_nb")]
+    [InlineData("nn", "no_nn")]
+    [InlineData("en", "en")]
+    public void GetFrontendStandardLanguage_ShouldReturnExpectedValue(string cookieValue, string expectedValue)
+    {
+        // Act
+        var result = LanguageHelper.GetFrontendStandardLanguage(cookieValue);
+
+        // Assert
+        Assert.Equal(expectedValue, result);
+    }
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Helpers/LangugageHelperTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Helpers/LangugageHelperTest.cs
@@ -6,6 +6,26 @@ using Moq;
 [Collection("LanguageHelper Tests")]
 public class LanguageHelperTests
 {
+
+    [Fact]
+    public void GetAltinnPersistenceCookieValueFrontendStandard_ShouldReturnEmptyString_WhenCookieIsNull()
+    {
+        // Arrange
+        var httpContextMock = new Mock<HttpContext>();
+        var requestMock = new Mock<HttpRequest>();
+        var cookiesMock = new Mock<IRequestCookieCollection>();
+
+        cookiesMock.Setup(c => c["altinnPersistentContext"]).Returns((string)null);
+        requestMock.Setup(r => r.Cookies).Returns(cookiesMock.Object);
+        httpContextMock.Setup(h => h.Request).Returns(requestMock.Object);
+
+        // Act
+        var result = LanguageHelper.GetAltinnPersistenceCookieValueFrontendStandard(httpContextMock.Object);
+
+        // Assert
+        Assert.Equal(string.Empty, result);
+    }
+
     [Theory]
     [InlineData("UL=1044", "no_nb")]
     [InlineData("UL=2068", "no_nn")]
@@ -28,20 +48,21 @@ public class LanguageHelperTests
         Assert.Equal(expectedValue, result);
     }
 
+
     [Fact]
-    public void GetAltinnPersistenceCookieValueFrontendStandard_ShouldReturnEmptyString_WhenCookieIsNull()
+    public void GetSelectedLanguageCookieValueBackendStandard_ShouldReturnEmptyString_WhenCookieIsNull()
     {
         // Arrange
         var httpContextMock = new Mock<HttpContext>();
         var requestMock = new Mock<HttpRequest>();
         var cookiesMock = new Mock<IRequestCookieCollection>();
 
-        cookiesMock.Setup(c => c["altinnPersistentContext"]).Returns((string)null);
+        cookiesMock.Setup(c => c["selectedLanguage"]).Returns((string)null);
         requestMock.Setup(r => r.Cookies).Returns(cookiesMock.Object);
         httpContextMock.Setup(h => h.Request).Returns(requestMock.Object);
 
         // Act
-        var result = LanguageHelper.GetAltinnPersistenceCookieValueFrontendStandard(httpContextMock.Object);
+        var result = LanguageHelper.GetSelectedLanguageCookieValueBackendStandard(httpContextMock.Object);
 
         // Assert
         Assert.Equal(string.Empty, result);
@@ -67,26 +88,6 @@ public class LanguageHelperTests
 
         // Assert
         Assert.Equal(expectedValue, result);
-    }
-
-
-    [Fact]
-    public void GetSelectedLanguageCookieValueBackendStandard_ShouldReturnEmptyString_WhenCookieIsNull()
-    {
-        // Arrange
-        var httpContextMock = new Mock<HttpContext>();
-        var requestMock = new Mock<HttpRequest>();
-        var cookiesMock = new Mock<IRequestCookieCollection>();
-
-        cookiesMock.Setup(c => c["selectedLanguage"]).Returns((string)null);
-        requestMock.Setup(r => r.Cookies).Returns(cookiesMock.Object);
-        httpContextMock.Setup(h => h.Request).Returns(requestMock.Object);
-
-        // Act
-        var result = LanguageHelper.GetSelectedLanguageCookieValueBackendStandard(httpContextMock.Object);
-
-        // Assert
-        Assert.Equal(string.Empty, result);
     }
 
     [Theory]

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Helpers/LangugageHelperTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Helpers/LangugageHelperTest.cs
@@ -6,13 +6,13 @@ using Moq;
 [Collection("LanguageHelper Tests")]
 public class LanguageHelperTests
 {
-    [Fact]
-    public void GetAltinnPersistenceCookieValueFrontendStandard_ShouldReturnExpectedValue()
+    [Theory]
+    [InlineData("UL=1044", "no_nb")]
+    [InlineData("UL=2068", "no_nn")]
+    [InlineData("UL=1033", "en")]
+    public void GetAltinnPersistenceCookieValueFrontendStandard_ShouldReturnExpectedValue(string cookieValue, string expectedValue)
     {
         // Arrange
-        var cookieValue = "UL=2068";
-        var expectedValue = "no_nn";
-
         var httpContextMock = new Mock<HttpContext>();
         var requestMock = new Mock<HttpRequest>();
         var cookiesMock = new Mock<IRequestCookieCollection>();
@@ -70,7 +70,7 @@ public class LanguageHelperTests
     }
 
 
-
+    [Fact]
     public void GetSelectedLanguageCookieValueBackendStandard_ShouldReturnEmptyString_WhenCookieIsNull()
     {
         // Arrange

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Helpers/LangugageHelperTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Helpers/LangugageHelperTest.cs
@@ -47,13 +47,13 @@ public class LanguageHelperTests
         Assert.Equal(string.Empty, result);
     }
 
-     [Fact]
-    public void GetSelectedLanguageCookieValueBackendStandard_ShouldReturnExpectedValue()
+    [Theory]
+    [InlineData("UL=1044", "nb")]
+    [InlineData("UL=2068", "nn")]
+    [InlineData("UL=1033", "en")]
+    public void GetSelectedLanguageCookieValueBackendStandard_ShouldReturnExpectedValue(string cookieValue, string expectedValue)
     {
         // Arrange
-        var cookieValue = "UL=2068";
-        var expectedValue = "nn"; // Replace with the expected value from GetBackendStandardLanguage
-
         var httpContextMock = new Mock<HttpContext>();
         var requestMock = new Mock<HttpRequest>();
         var cookiesMock = new Mock<IRequestCookieCollection>();
@@ -69,7 +69,8 @@ public class LanguageHelperTests
         Assert.Equal(expectedValue, result);
     }
 
-    [Fact]
+
+
     public void GetSelectedLanguageCookieValueBackendStandard_ShouldReturnEmptyString_WhenCookieIsNull()
     {
         // Arrange

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Helpers/LangugageHelperTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Helpers/LangugageHelperTest.cs
@@ -2,123 +2,125 @@ using Altinn.AccessManagement.UI.Core.Helpers;
 using Microsoft.AspNetCore.Http;
 using Moq;
 
-
-[Collection("LanguageHelper Tests")]
-public class LanguageHelperTests
+namespace Altinn.AccessManagement.UI.Tests.Helpers
 {
-
-    [Fact]
-    public void GetAltinnPersistenceCookieValueFrontendStandard_ShouldReturnEmptyString_WhenCookieIsNull()
+    [Collection("LanguageHelper Tests")]
+    public class LanguageHelperTests
     {
-        // Arrange
-        var httpContextMock = new Mock<HttpContext>();
-        var requestMock = new Mock<HttpRequest>();
-        var cookiesMock = new Mock<IRequestCookieCollection>();
 
-        cookiesMock.Setup(c => c["altinnPersistentContext"]).Returns((string)null);
-        requestMock.Setup(r => r.Cookies).Returns(cookiesMock.Object);
-        httpContextMock.Setup(h => h.Request).Returns(requestMock.Object);
+        [Fact]
+        public void GetAltinnPersistenceCookieValueFrontendStandard_ShouldReturnEmptyString_WhenCookieIsNull()
+        {
+            // Arrange
+            var httpContextMock = new Mock<HttpContext>();
+            var requestMock = new Mock<HttpRequest>();
+            var cookiesMock = new Mock<IRequestCookieCollection>();
 
-        // Act
-        var result = LanguageHelper.GetAltinnPersistenceCookieValueFrontendStandard(httpContextMock.Object);
+            cookiesMock.Setup(c => c["altinnPersistentContext"]).Returns((string)null);
+            requestMock.Setup(r => r.Cookies).Returns(cookiesMock.Object);
+            httpContextMock.Setup(h => h.Request).Returns(requestMock.Object);
 
-        // Assert
-        Assert.Equal(string.Empty, result);
-    }
+            // Act
+            var result = LanguageHelper.GetAltinnPersistenceCookieValueFrontendStandard(httpContextMock.Object);
 
-    [Theory]
-    [InlineData("UL=1044", "no_nb")]
-    [InlineData("UL=2068", "no_nn")]
-    [InlineData("UL=1033", "en")]
-    public void GetAltinnPersistenceCookieValueFrontendStandard_ShouldReturnExpectedValue(string cookieValue, string expectedValue)
-    {
-        // Arrange
-        var httpContextMock = new Mock<HttpContext>();
-        var requestMock = new Mock<HttpRequest>();
-        var cookiesMock = new Mock<IRequestCookieCollection>();
+            // Assert
+            Assert.Equal(string.Empty, result);
+        }
 
-        cookiesMock.Setup(c => c["altinnPersistentContext"]).Returns(cookieValue);
-        requestMock.Setup(r => r.Cookies).Returns(cookiesMock.Object);
-        httpContextMock.Setup(h => h.Request).Returns(requestMock.Object);
+        [Theory]
+        [InlineData("UL=1044", "no_nb")]
+        [InlineData("UL=2068", "no_nn")]
+        [InlineData("UL=1033", "en")]
+        public void GetAltinnPersistenceCookieValueFrontendStandard_ShouldReturnExpectedValue(string cookieValue, string expectedValue)
+        {
+            // Arrange
+            var httpContextMock = new Mock<HttpContext>();
+            var requestMock = new Mock<HttpRequest>();
+            var cookiesMock = new Mock<IRequestCookieCollection>();
 
-        // Act
-        var result = LanguageHelper.GetAltinnPersistenceCookieValueFrontendStandard(httpContextMock.Object);
+            cookiesMock.Setup(c => c["altinnPersistentContext"]).Returns(cookieValue);
+            requestMock.Setup(r => r.Cookies).Returns(cookiesMock.Object);
+            httpContextMock.Setup(h => h.Request).Returns(requestMock.Object);
 
-        // Assert
-        Assert.Equal(expectedValue, result);
-    }
+            // Act
+            var result = LanguageHelper.GetAltinnPersistenceCookieValueFrontendStandard(httpContextMock.Object);
+
+            // Assert
+            Assert.Equal(expectedValue, result);
+        }
 
 
-    [Fact]
-    public void GetSelectedLanguageCookieValueBackendStandard_ShouldReturnEmptyString_WhenCookieIsNull()
-    {
-        // Arrange
-        var httpContextMock = new Mock<HttpContext>();
-        var requestMock = new Mock<HttpRequest>();
-        var cookiesMock = new Mock<IRequestCookieCollection>();
+        [Fact]
+        public void GetSelectedLanguageCookieValueBackendStandard_ShouldReturnEmptyString_WhenCookieIsNull()
+        {
+            // Arrange
+            var httpContextMock = new Mock<HttpContext>();
+            var requestMock = new Mock<HttpRequest>();
+            var cookiesMock = new Mock<IRequestCookieCollection>();
 
-        cookiesMock.Setup(c => c["selectedLanguage"]).Returns((string)null);
-        requestMock.Setup(r => r.Cookies).Returns(cookiesMock.Object);
-        httpContextMock.Setup(h => h.Request).Returns(requestMock.Object);
+            cookiesMock.Setup(c => c["selectedLanguage"]).Returns((string)null);
+            requestMock.Setup(r => r.Cookies).Returns(cookiesMock.Object);
+            httpContextMock.Setup(h => h.Request).Returns(requestMock.Object);
 
-        // Act
-        var result = LanguageHelper.GetSelectedLanguageCookieValueBackendStandard(httpContextMock.Object);
+            // Act
+            var result = LanguageHelper.GetSelectedLanguageCookieValueBackendStandard(httpContextMock.Object);
 
-        // Assert
-        Assert.Equal(string.Empty, result);
-    }
+            // Assert
+            Assert.Equal(string.Empty, result);
+        }
 
-    [Theory]
-    [InlineData("UL=1044", "nb")]
-    [InlineData("UL=2068", "nn")]
-    [InlineData("UL=1033", "en")]
-    public void GetSelectedLanguageCookieValueBackendStandard_ShouldReturnExpectedValue(string cookieValue, string expectedValue)
-    {
-        // Arrange
-        var httpContextMock = new Mock<HttpContext>();
-        var requestMock = new Mock<HttpRequest>();
-        var cookiesMock = new Mock<IRequestCookieCollection>();
+        [Theory]
+        [InlineData("UL=1044", "nb")]
+        [InlineData("UL=2068", "nn")]
+        [InlineData("UL=1033", "en")]
+        public void GetSelectedLanguageCookieValueBackendStandard_ShouldReturnExpectedValue(string cookieValue, string expectedValue)
+        {
+            // Arrange
+            var httpContextMock = new Mock<HttpContext>();
+            var requestMock = new Mock<HttpRequest>();
+            var cookiesMock = new Mock<IRequestCookieCollection>();
 
-        cookiesMock.Setup(c => c["selectedLanguage"]).Returns(cookieValue);
-        requestMock.Setup(r => r.Cookies).Returns(cookiesMock.Object);
-        httpContextMock.Setup(h => h.Request).Returns(requestMock.Object);
+            cookiesMock.Setup(c => c["selectedLanguage"]).Returns(cookieValue);
+            requestMock.Setup(r => r.Cookies).Returns(cookiesMock.Object);
+            httpContextMock.Setup(h => h.Request).Returns(requestMock.Object);
 
-        // Act
-        var result = LanguageHelper.GetSelectedLanguageCookieValueBackendStandard(httpContextMock.Object);
+            // Act
+            var result = LanguageHelper.GetSelectedLanguageCookieValueBackendStandard(httpContextMock.Object);
 
-        // Assert
-        Assert.Equal(expectedValue, result);
-    }
+            // Assert
+            Assert.Equal(expectedValue, result);
+        }
 
-    [Theory]
-    [InlineData("UL=1044", "nb")]
-    [InlineData("UL=2068", "nn")]
-    [InlineData("UL=1033", "en")]
-    [InlineData("no_nb", "nb")]
-    [InlineData("no_nn", "nn")]
-    [InlineData("en", "en")]
-    public void GetBackendStandardLanguage_ShouldReturnExpectedValue(string cookieValue, string expectedValue)
-    {
-        // Act
-        var result = LanguageHelper.GetBackendStandardLanguage(cookieValue);
+        [Theory]
+        [InlineData("UL=1044", "nb")]
+        [InlineData("UL=2068", "nn")]
+        [InlineData("UL=1033", "en")]
+        [InlineData("no_nb", "nb")]
+        [InlineData("no_nn", "nn")]
+        [InlineData("en", "en")]
+        public void GetBackendStandardLanguage_ShouldReturnExpectedValue(string cookieValue, string expectedValue)
+        {
+            // Act
+            var result = LanguageHelper.GetBackendStandardLanguage(cookieValue);
 
-        // Assert
-        Assert.Equal(expectedValue, result);
-    }
+            // Assert
+            Assert.Equal(expectedValue, result);
+        }
 
-    [Theory]
-    [InlineData("UL=1044", "no_nb")]
-    [InlineData("UL=2068", "no_nn")]
-    [InlineData("UL=1033", "en")]
-    [InlineData("nb", "no_nb")]
-    [InlineData("nn", "no_nn")]
-    [InlineData("en", "en")]
-    public void GetFrontendStandardLanguage_ShouldReturnExpectedValue(string cookieValue, string expectedValue)
-    {
-        // Act
-        var result = LanguageHelper.GetFrontendStandardLanguage(cookieValue);
+        [Theory]
+        [InlineData("UL=1044", "no_nb")]
+        [InlineData("UL=2068", "no_nn")]
+        [InlineData("UL=1033", "en")]
+        [InlineData("nb", "no_nb")]
+        [InlineData("nn", "no_nn")]
+        [InlineData("en", "en")]
+        public void GetFrontendStandardLanguage_ShouldReturnExpectedValue(string cookieValue, string expectedValue)
+        {
+            // Act
+            var result = LanguageHelper.GetFrontendStandardLanguage(cookieValue);
 
-        // Assert
-        Assert.Equal(expectedValue, result);
+            // Assert
+            Assert.Equal(expectedValue, result);
+        }
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/APIDelegationController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/APIDelegationController.cs
@@ -67,7 +67,7 @@ namespace Altinn.AccessManagement.UI.Controllers
         {
             try
             {
-                var languageCode = ProfileHelper.GetSelectedLanguageCookieValueBackendStandard(_httpContextAccessor.HttpContext);
+                var languageCode = LanguageHelper.GetSelectedLanguageCookieValueBackendStandard(_httpContextAccessor.HttpContext);
 
                 return await _apiDelegationService.GetReceivedMaskinportenSchemaDelegations(party, languageCode);
             }
@@ -90,7 +90,7 @@ namespace Altinn.AccessManagement.UI.Controllers
         {
             try
             {
-                var languageCode = ProfileHelper.GetSelectedLanguageCookieValueBackendStandard(_httpContextAccessor.HttpContext);
+                var languageCode = LanguageHelper.GetSelectedLanguageCookieValueBackendStandard(_httpContextAccessor.HttpContext);
                 return await _apiDelegationService.GetOfferedMaskinportenSchemaDelegations(party, languageCode);
             }
             catch (Exception ex)

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/APIDelegationController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/APIDelegationController.cs
@@ -29,7 +29,7 @@ namespace Altinn.AccessManagement.UI.Controllers
         private readonly IResourceService _resourceService;
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly ILogger<APIDelegationController> _logger;
-        private readonly IUserService _profileService;
+        private readonly IUserService _userService;
         private readonly JsonSerializerOptions _serializerOptions = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
 
         /// <summary>
@@ -38,19 +38,19 @@ namespace Altinn.AccessManagement.UI.Controllers
         /// <param name="logger">the handler for logger service</param>
         /// <param name="apiDelegationService">The service implementation for handling maskinporten schema delegations</param>
         /// <param name="resourceService">The resource administration point</param>
-        /// <param name="profileService">The service implementation for user profile operations</param>
+        /// <param name="userService">The service implementation for user profile operations</param>
         /// <param name="httpContextAccessor">Accessor for httpcontext</param>
         public APIDelegationController(
             ILogger<APIDelegationController> logger,
             IAPIDelegationService apiDelegationService,
             IResourceService resourceService,
-            IUserService profileService,
+            IUserService userService,
             IHttpContextAccessor httpContextAccessor)
         {
             _logger = logger;
             _apiDelegationService = apiDelegationService;
             _resourceService = resourceService;
-            _profileService = profileService;
+            _userService = userService;
             _serializerOptions.Converters.Add(new JsonStringEnumConverter());
             _httpContextAccessor = httpContextAccessor;
         }
@@ -67,9 +67,8 @@ namespace Altinn.AccessManagement.UI.Controllers
         {
             try
             {
-                int userId = AuthenticationHelper.GetUserId(_httpContextAccessor.HttpContext);
-                UserProfile userProfile = await _profileService.GetUserProfile(userId);
-                string languageCode = ProfileHelper.GetLanguageCodeForUserAltinnStandard(userProfile, HttpContext);
+                var languageCode = await ProfileHelper.GetLanguageCode(_httpContextAccessor, _userService);
+
                 return await _apiDelegationService.GetReceivedMaskinportenSchemaDelegations(party, languageCode);
             }
             catch (Exception ex)
@@ -91,9 +90,7 @@ namespace Altinn.AccessManagement.UI.Controllers
         {
             try
             {
-                int userId = AuthenticationHelper.GetUserId(_httpContextAccessor.HttpContext);
-                UserProfile userProfile = await _profileService.GetUserProfile(userId);
-                string languageCode = ProfileHelper.GetLanguageCodeForUserAltinnStandard(userProfile, HttpContext);
+                var languageCode = await ProfileHelper.GetLanguageCode(_httpContextAccessor, _userService);
                 return await _apiDelegationService.GetOfferedMaskinportenSchemaDelegations(party, languageCode);
             }
             catch (Exception ex)

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/APIDelegationController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/APIDelegationController.cs
@@ -67,7 +67,7 @@ namespace Altinn.AccessManagement.UI.Controllers
         {
             try
             {
-                var languageCode = await ProfileHelper.GetLanguageCode(_httpContextAccessor, _userService);
+                var languageCode = ProfileHelper.GetSelectedLanguageCookieValueBackendStandard(_httpContextAccessor.HttpContext);
 
                 return await _apiDelegationService.GetReceivedMaskinportenSchemaDelegations(party, languageCode);
             }
@@ -90,7 +90,7 @@ namespace Altinn.AccessManagement.UI.Controllers
         {
             try
             {
-                var languageCode = await ProfileHelper.GetLanguageCode(_httpContextAccessor, _userService);
+                var languageCode = ProfileHelper.GetSelectedLanguageCookieValueBackendStandard(_httpContextAccessor.HttpContext);
                 return await _apiDelegationService.GetOfferedMaskinportenSchemaDelegations(party, languageCode);
             }
             catch (Exception ex)

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/APIDelegationController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/APIDelegationController.cs
@@ -1,17 +1,12 @@
-﻿using System.ComponentModel.DataAnnotations;
-using System.Net;
+﻿using System.Net;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Altinn.AccessManagement.UI.Core.Enums;
 using Altinn.AccessManagement.UI.Core.Helpers;
 using Altinn.AccessManagement.UI.Core.Models;
 using Altinn.AccessManagement.UI.Core.Models.Delegation.Frontend;
-using Altinn.AccessManagement.UI.Core.Models.ResourceRegistry.Frontend;
 using Altinn.AccessManagement.UI.Core.Models.SingleRight;
-using Altinn.AccessManagement.UI.Core.Services;
 using Altinn.AccessManagement.UI.Core.Services.Interfaces;
 using Altinn.AccessManagement.UI.Filters;
-using Altinn.Platform.Profile.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -26,10 +21,9 @@ namespace Altinn.AccessManagement.UI.Controllers
     public class APIDelegationController : ControllerBase
     {
         private readonly IAPIDelegationService _apiDelegationService;
-        private readonly IResourceService _resourceService;
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly ILogger<APIDelegationController> _logger;
-        private readonly IUserService _userService;
+  
         private readonly JsonSerializerOptions _serializerOptions = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
 
         /// <summary>
@@ -37,20 +31,14 @@ namespace Altinn.AccessManagement.UI.Controllers
         /// </summary>
         /// <param name="logger">the handler for logger service</param>
         /// <param name="apiDelegationService">The service implementation for handling maskinporten schema delegations</param>
-        /// <param name="resourceService">The resource administration point</param>
-        /// <param name="userService">The service implementation for user profile operations</param>
         /// <param name="httpContextAccessor">Accessor for httpcontext</param>
         public APIDelegationController(
             ILogger<APIDelegationController> logger,
             IAPIDelegationService apiDelegationService,
-            IResourceService resourceService,
-            IUserService userService,
             IHttpContextAccessor httpContextAccessor)
         {
             _logger = logger;
             _apiDelegationService = apiDelegationService;
-            _resourceService = resourceService;
-            _userService = userService;
             _serializerOptions.Converters.Add(new JsonStringEnumConverter());
             _httpContextAccessor = httpContextAccessor;
         }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/HomeController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/HomeController.cs
@@ -93,10 +93,18 @@ namespace Altinn.AccessManagement.UI.Controllers
         {
             int userId = AuthenticationHelper.GetUserId(_httpContextAccessor.HttpContext);
             UserProfile user = await _profileService.GetUserProfile(userId);
-            AntiforgeryTokenSet tokens = _antiforgery.GetAndStoreTokens(HttpContext);
-            string languageCode = ProfileHelper.GetStandardLanguageCodeIsoStandard(user, HttpContext);
 
-            HttpContext.Response.Cookies.Append("i18next", languageCode, new CookieOptions
+            string languageCode = null;
+            if (user != null)
+            {
+                languageCode = ProfileHelper.GetFrontendStandardLanguage(user.ProfileSettingPreference?.Language);
+            }
+            else
+            {
+                ProfileHelper.GetAltinnPersistenceCookieValueFrontendStandard(_httpContextAccessor.HttpContext);
+            }
+
+            HttpContext.Response.Cookies.Append("selectedLanguage", languageCode ?? "no_nb", new CookieOptions
             {
                 // Make this cookie readable by Javascript.
                 HttpOnly = false,

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/HomeController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/HomeController.cs
@@ -24,7 +24,7 @@ namespace Altinn.AccessManagement.UI.Controllers
         private readonly GeneralSettings _generalSettings;
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly PlatformSettings _platformSettings;
-        private readonly IUserService _profileService;
+        private readonly IUserService _userService;
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="HomeController" /> class.
@@ -33,7 +33,7 @@ namespace Altinn.AccessManagement.UI.Controllers
         /// <param name="antiforgery">the anti forgery service</param>
         /// <param name="platformSettings">settings related to the platform</param>
         /// <param name="env">the current environment</param>
-        /// <param name="profileService">service implementation for user profile</param>
+        /// <param name="userService">service implementation for user profile</param>
         /// <param name="httpContextAccessor">http context</param>
         /// <param name="generalSettings">general settings</param>
         public HomeController(
@@ -41,14 +41,14 @@ namespace Altinn.AccessManagement.UI.Controllers
             IAntiforgery antiforgery,
             IOptions<PlatformSettings> platformSettings,
             IWebHostEnvironment env,
-            IUserService profileService,
+            IUserService userService,
             IHttpContextAccessor httpContextAccessor,
             IOptions<GeneralSettings> generalSettings)
         {
             _antiforgery = antiforgery;
             _platformSettings = platformSettings.Value;
             _env = env;
-            _profileService = profileService;
+            _userService = userService;
             _httpContextAccessor = httpContextAccessor;
             _generalSettings = generalSettings.Value;
         }
@@ -98,7 +98,7 @@ namespace Altinn.AccessManagement.UI.Controllers
             if (string.IsNullOrEmpty(languageCode))
             {
                 int userId = AuthenticationHelper.GetUserId(_httpContextAccessor.HttpContext);
-                UserProfile user = await _profileService.GetUserProfile(userId);
+                UserProfile user = await _userService.GetUserProfile(userId);
                 languageCode = LanguageHelper.GetFrontendStandardLanguage(user.ProfileSettingPreference?.Language);
             }
 

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/HomeController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/HomeController.cs
@@ -92,14 +92,14 @@ namespace Altinn.AccessManagement.UI.Controllers
         private async Task SetLanguageCookie()
         {
             // Get the language code from the Altinn persistence cookie
-            string languageCode = ProfileHelper.GetAltinnPersistenceCookieValueFrontendStandard(_httpContextAccessor.HttpContext);
+            string languageCode = LanguageHelper.GetAltinnPersistenceCookieValueFrontendStandard(_httpContextAccessor.HttpContext);
             
             // If the language code is not found in the Altinn persistence cookie, get the language code from user profile.
             if (string.IsNullOrEmpty(languageCode))
             {
                 int userId = AuthenticationHelper.GetUserId(_httpContextAccessor.HttpContext);
                 UserProfile user = await _profileService.GetUserProfile(userId);
-                languageCode = ProfileHelper.GetFrontendStandardLanguage(user.ProfileSettingPreference?.Language);
+                languageCode = LanguageHelper.GetFrontendStandardLanguage(user.ProfileSettingPreference?.Language);
             }
 
             HttpContext.Response.Cookies.Append("selectedLanguage", languageCode ?? "no_nb", new CookieOptions

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/HomeController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/HomeController.cs
@@ -91,17 +91,15 @@ namespace Altinn.AccessManagement.UI.Controllers
 
         private async Task SetLanguageCookie()
         {
-            int userId = AuthenticationHelper.GetUserId(_httpContextAccessor.HttpContext);
-            UserProfile user = await _profileService.GetUserProfile(userId);
-
-            string languageCode = null;
-            if (user != null)
+            // Get the language code from the Altinn persistence cookie
+            string languageCode = ProfileHelper.GetAltinnPersistenceCookieValueFrontendStandard(_httpContextAccessor.HttpContext);
+            
+            // If the language code is not found in the Altinn persistence cookie, get the language code from user profile.
+            if (string.IsNullOrEmpty(languageCode))
             {
+                int userId = AuthenticationHelper.GetUserId(_httpContextAccessor.HttpContext);
+                UserProfile user = await _profileService.GetUserProfile(userId);
                 languageCode = ProfileHelper.GetFrontendStandardLanguage(user.ProfileSettingPreference?.Language);
-            }
-            else
-            {
-                ProfileHelper.GetAltinnPersistenceCookieValueFrontendStandard(_httpContextAccessor.HttpContext);
             }
 
             HttpContext.Response.Cookies.Append("selectedLanguage", languageCode ?? "no_nb", new CookieOptions

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/ResourceController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/ResourceController.cs
@@ -43,6 +43,7 @@ namespace Altinn.AccessManagement.UI.Controllers
             _httpContextAccessor = httpContextAccessor;
         }
 
+
         /// <summary>
         ///     Gets list of resource owners that has the resourceTypesProvided by <param name="relevantResourceTypes"></param>
         /// </summary>
@@ -52,9 +53,8 @@ namespace Altinn.AccessManagement.UI.Controllers
         [Route("resourceowners")]
         public async Task<ActionResult<List<ResourceOwnerFE>>> GetResourceOwners([FromQuery] List<ResourceType> relevantResourceTypes)
         {
-            int userId = AuthenticationHelper.GetUserId(_httpContextAccessor.HttpContext);
-            UserProfile userProfile = await _userService.GetUserProfile(userId);
-            string languageCode = ProfileHelper.GetLanguageCodeForUserAltinnStandard(userProfile, HttpContext);
+
+            var languageCode = await ProfileHelper.GetLanguageCode(_httpContextAccessor, _userService);
 
             if (relevantResourceTypes?.Count > 0)
             {
@@ -75,9 +75,7 @@ namespace Altinn.AccessManagement.UI.Controllers
         [Route("search")]
         public async Task<ActionResult<PaginatedList<ServiceResourceFE>>> PaginatedSearch([FromQuery] PaginatedSearchParams parameters)
         {
-            int userId = AuthenticationHelper.GetUserId(_httpContextAccessor.HttpContext);
-            UserProfile userProfile = await _userService.GetUserProfile(userId);
-            string languageCode = ProfileHelper.GetLanguageCodeForUserAltinnStandard(userProfile, HttpContext);
+            var languageCode = await ProfileHelper.GetLanguageCode(_httpContextAccessor, _userService);
 
             try
             {
@@ -94,7 +92,7 @@ namespace Altinn.AccessManagement.UI.Controllers
                 return new ObjectResult(ProblemDetailsFactory.CreateProblemDetails(HttpContext, (int?)ex.StatusCode, "Unexpected HttpStatus response", detail: responseContent));
             }
         }
-        
+
         /// <summary>
         ///     Searches through all delegable maskinportenschema services and returns matches based on the provided search string and filters
         /// </summary>
@@ -104,9 +102,7 @@ namespace Altinn.AccessManagement.UI.Controllers
         [Route("maskinportenapi/search")]
         public async Task<ActionResult<List<ServiceResourceFE>>> MaskinportenSearch([FromQuery] ApiSearchParams parameters)
         {
-            int userId = AuthenticationHelper.GetUserId(_httpContextAccessor.HttpContext);
-            UserProfile userProfile = await _userService.GetUserProfile(userId);
-            string languageCode = ProfileHelper.GetLanguageCodeForUserAltinnStandard(userProfile, HttpContext);
+            var languageCode = await ProfileHelper.GetLanguageCode(_httpContextAccessor, _userService);
 
             try
             {

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/ResourceController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/ResourceController.cs
@@ -53,7 +53,7 @@ namespace Altinn.AccessManagement.UI.Controllers
         [Route("resourceowners")]
         public async Task<ActionResult<List<ResourceOwnerFE>>> GetResourceOwners([FromQuery] List<ResourceType> relevantResourceTypes)
         {
-            var languageCode = ProfileHelper.GetSelectedLanguageCookieValueBackendStandard(_httpContextAccessor.HttpContext);
+            var languageCode = LanguageHelper.GetSelectedLanguageCookieValueBackendStandard(_httpContextAccessor.HttpContext);
             if (relevantResourceTypes?.Count > 0)
             {
                 return await _resourceService.GetResourceOwners(relevantResourceTypes, languageCode);
@@ -73,7 +73,7 @@ namespace Altinn.AccessManagement.UI.Controllers
         [Route("search")]
         public async Task<ActionResult<PaginatedList<ServiceResourceFE>>> PaginatedSearch([FromQuery] PaginatedSearchParams parameters)
         {
-            var languageCode = ProfileHelper.GetSelectedLanguageCookieValueBackendStandard(_httpContextAccessor.HttpContext);
+            var languageCode = LanguageHelper.GetSelectedLanguageCookieValueBackendStandard(_httpContextAccessor.HttpContext);
             try
             {
                 return await _resourceService.GetPaginatedSearchResults(languageCode, parameters.ROFilters, parameters.SearchString, parameters.Page, parameters.ResultsPerPage);
@@ -99,7 +99,7 @@ namespace Altinn.AccessManagement.UI.Controllers
         [Route("maskinportenapi/search")]
         public async Task<ActionResult<List<ServiceResourceFE>>> MaskinportenSearch([FromQuery] ApiSearchParams parameters)
         {
-            var languageCode = ProfileHelper.GetSelectedLanguageCookieValueBackendStandard(_httpContextAccessor.HttpContext);
+            var languageCode = LanguageHelper.GetSelectedLanguageCookieValueBackendStandard(_httpContextAccessor.HttpContext);
             try
             {
                 return await _resourceService.MaskinportenschemaSearch(languageCode, parameters.ROFilters, parameters.SearchString);

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/ResourceController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/ResourceController.cs
@@ -5,7 +5,6 @@ using Altinn.AccessManagement.UI.Core.Models.ResourceRegistry;
 using Altinn.AccessManagement.UI.Core.Models.ResourceRegistry.Frontend;
 using Altinn.AccessManagement.UI.Core.Services.Interfaces;
 using Altinn.AccessManagement.UI.Filters;
-using Altinn.Platform.Profile.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -20,29 +19,20 @@ namespace Altinn.AccessManagement.UI.Controllers
     public class ResourceController : ControllerBase
     {
         private readonly IHttpContextAccessor _httpContextAccessor;
-        private readonly ILogger _logger;
-        private readonly IUserService _userService;
         private readonly IResourceService _resourceService;
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="ResourceController" /> class.
         /// </summary>
-        /// <param name="logger">the logger.</param>
         /// <param name="resourceService">The resource administration point</param>
-        /// <param name="userService">handler for profile service</param>
         /// <param name="httpContextAccessor">handler for httpcontext</param>
         public ResourceController(
-            ILogger<ResourceController> logger,
             IResourceService resourceService,
-            IUserService userService,
             IHttpContextAccessor httpContextAccessor)
         {
-            _logger = logger;
             _resourceService = resourceService;
-            _userService = userService;
             _httpContextAccessor = httpContextAccessor;
         }
-
 
         /// <summary>
         ///     Gets list of resource owners that has the resourceTypesProvided by <param name="relevantResourceTypes"></param>

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/ResourceController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/ResourceController.cs
@@ -53,9 +53,7 @@ namespace Altinn.AccessManagement.UI.Controllers
         [Route("resourceowners")]
         public async Task<ActionResult<List<ResourceOwnerFE>>> GetResourceOwners([FromQuery] List<ResourceType> relevantResourceTypes)
         {
-
-            var languageCode = await ProfileHelper.GetLanguageCode(_httpContextAccessor, _userService);
-
+            var languageCode = ProfileHelper.GetSelectedLanguageCookieValueBackendStandard(_httpContextAccessor.HttpContext);
             if (relevantResourceTypes?.Count > 0)
             {
                 return await _resourceService.GetResourceOwners(relevantResourceTypes, languageCode);
@@ -75,8 +73,7 @@ namespace Altinn.AccessManagement.UI.Controllers
         [Route("search")]
         public async Task<ActionResult<PaginatedList<ServiceResourceFE>>> PaginatedSearch([FromQuery] PaginatedSearchParams parameters)
         {
-            var languageCode = await ProfileHelper.GetLanguageCode(_httpContextAccessor, _userService);
-
+            var languageCode = ProfileHelper.GetSelectedLanguageCookieValueBackendStandard(_httpContextAccessor.HttpContext);
             try
             {
                 return await _resourceService.GetPaginatedSearchResults(languageCode, parameters.ROFilters, parameters.SearchString, parameters.Page, parameters.ResultsPerPage);
@@ -102,8 +99,7 @@ namespace Altinn.AccessManagement.UI.Controllers
         [Route("maskinportenapi/search")]
         public async Task<ActionResult<List<ServiceResourceFE>>> MaskinportenSearch([FromQuery] ApiSearchParams parameters)
         {
-            var languageCode = await ProfileHelper.GetLanguageCode(_httpContextAccessor, _userService);
-
+            var languageCode = ProfileHelper.GetSelectedLanguageCookieValueBackendStandard(_httpContextAccessor.HttpContext);
             try
             {
                 return await _resourceService.MaskinportenschemaSearch(languageCode, parameters.ROFilters, parameters.SearchString);

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.json
@@ -16,7 +16,6 @@
   "GeneralSettings": {
     "FrontendBaseUrl": "http://localhost:5101",
     "Hostname": "localhost",
-    "LanguageCookie": "i18next",
     "UseMockData": false
   },
   "KeyVaultSettings": {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -33,6 +33,7 @@ const queryClientDevDefaults = {
 use(LanguageDetector)
   .use(initReactI18next)
   .init({
+    detection: { lookupCookie: 'selectedLanguage' },
     resources: {
       no_nb: { translation: no_nb },
       no_nn: { translation: no_nn },


### PR DESCRIPTION
Get the user's selected language from the cookie instead of the user profile.

Description
- Rename "ProfileHelper" to "LanguageHelper."
- Stop getting the language from the user profile if not necessary.
- Continue getting the language from "altinnPersistentContext" in HomeController, and from the Profile if it doesn't exist; otherwise, use the cookie from the frontend.
- Rename the "i18next" cookie to "selectedLanguage" and use this in the frontend for loading the language.
- Simplify the mapping of languages between standards.

## Related Issue(s)
- #994 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
