### PR TITLE
Chore/general/fix eslint import rule

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -27,7 +27,7 @@ module.exports = {
     
   ],
   overrides: [],
-  plugins: ['react' , 'cypress'],
+  plugins: ['react' , 'cypress', 'import'],
   rules: {
     'react/react-in-jsx-scope': 'off',
     'react/jsx-no-bind': 'off',

--- a/src/features/amUI/common/FakePageWrapper/FakePageWrapper.tsx
+++ b/src/features/amUI/common/FakePageWrapper/FakePageWrapper.tsx
@@ -6,7 +6,9 @@ import {
   PersonGroupIcon,
   RobotSmileIcon,
 } from '@navikt/aksel-icons';
+
 import AltinnTextLogo from '@/assets/AltinnTextLogo.svg?react';
+
 import classes from './FakePageWrapper.module.css';
 
 interface FakePageWrapperProps {

--- a/src/features/amUI/common/PageContainer/PageContainer.tsx
+++ b/src/features/amUI/common/PageContainer/PageContainer.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
-import classes from './PageContainer.module.css';
 import { Button } from '@digdir/designsystemet-react';
 import { ArrowLeftIcon } from '@navikt/aksel-icons';
-import { getButtonIconSize } from '@/resources/utils/iconUtils';
 import { useTranslation } from 'react-i18next';
+
+import { getButtonIconSize } from '@/resources/utils/iconUtils';
+
+import classes from './PageContainer.module.css';
 
 interface PageContainerProps {
   children: React.ReactNode;

--- a/src/features/amUI/userRightsPage/UserRightsPage.tsx
+++ b/src/features/amUI/userRightsPage/UserRightsPage.tsx
@@ -1,18 +1,19 @@
 import * as React from 'react';
-import { useDocumentTitle } from '@/resources/hooks/useDocumentTitle';
 import { useTranslation } from 'react-i18next';
-
 import { Heading } from '@digdir/designsystemet-react';
-
-import { FakePageWrapper } from '../common/FakePageWrapper';
 import { useNavigate, useParams } from 'react-router-dom';
+
+import { useDocumentTitle } from '@/resources/hooks/useDocumentTitle';
 import { UserIcon } from '@/components/UserIcon/UserIcon';
-import classes from './UserRightsPage.module.css';
-import { PageContainer } from '../common/PageContainer/PageContainer';
 import { PageWrapper } from '@/components';
 import { useGetPartyByUUIDQuery } from '@/rtk/features/lookup/lookupApi';
 import { useGetReporteeQuery } from '@/rtk/features/userInfo/userInfoApi';
 import { amUIPath } from '@/routes/paths';
+
+import { PageContainer } from '../common/PageContainer/PageContainer';
+import { FakePageWrapper } from '../common/FakePageWrapper';
+
+import classes from './UserRightsPage.module.css';
 
 export const UserRightsPage = () => {
   const { t } = useTranslation();

--- a/src/features/apiDelegation/components/OverviewPageContent/OverviewPageContent.tsx
+++ b/src/features/apiDelegation/components/OverviewPageContent/OverviewPageContent.tsx
@@ -23,12 +23,12 @@ import { ApiDelegationPath } from '@/routes/paths';
 import { ErrorPanel } from '@/components';
 import { resetChosenApis } from '@/rtk/features/apiDelegation/delegableApi/delegableApiSlice';
 import { getButtonIconSize } from '@/resources/utils';
+import { StatusMessageForScreenReader } from '@/components/StatusMessageForScreenReader/StatusMessageForScreenReader';
 
 import { LayoutState } from '../LayoutState';
 
 import { OrgDelegationActionBar } from './OrgDelegationActionBar';
 import classes from './OverviewPageContent.module.css';
-import { StatusMessageForScreenReader } from '@/components/StatusMessageForScreenReader/StatusMessageForScreenReader';
 
 export interface OverviewPageContentInterface {
   layout: LayoutState;


### PR DESCRIPTION
Fix eslint import-order-rule 

## Description
Import order rules now working when formating document and no longer showing "rule not found error"

## Related Issue(s)
- n/a

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
