### PR TITLE
Fix so that overview refetches after new delegations

### DIFF
--- a/src/features/apiDelegation/offered/ConfirmationPage/ConfirmationPage.tsx
+++ b/src/features/apiDelegation/offered/ConfirmationPage/ConfirmationPage.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import * as React from 'react';
 import { Alert, Button, Heading, Paragraph, Spinner } from '@digdir/designsystemet-react';
+import { useDispatch } from 'react-redux';
 
 import { useAppSelector } from '@/rtk/app/hooks';
 import { ApiDelegationPath } from '@/routes/paths';
@@ -26,6 +27,7 @@ import classes from './ConfirmationPage.module.css';
 import { DelegableApiList, DelegableOrgList, DelegationReceiptList } from './DelegationLists';
 
 export const ConfirmationPage = () => {
+  const dispatch = useDispatch();
   const chosenApis = useAppSelector((state) => state.delegableApi.chosenApis);
   const chosenOrgs = useAppSelector((state) => state.apiDelegation.chosenOrgs);
 
@@ -47,7 +49,7 @@ export const ConfirmationPage = () => {
 
   React.useEffect(() => {
     if (successfulApiDelegations && successfulApiDelegations.length > 0) {
-      overviewOrgApi.util.invalidateTags(['overviewOrg']);
+      dispatch(overviewOrgApi.util.invalidateTags(['overviewOrg']));
     }
   }, [successfulApiDelegations]);
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix so that overview refetches after new delegations.
For the cache invalidation to occur, it has to be manually dispatched

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
