### PR TITLE
Removed ssn from bff output

### DIFF
--- a/.mock/handlers/lookup.ts
+++ b/.mock/handlers/lookup.ts
@@ -13,7 +13,6 @@ export const lookupHandlers = (ACCESSMANAGEMENT_BASE_URL: string) => [
       partyUuid: 'cd35779b-b174-4ecc-bbef-ece13611be7f',
       partyTypeName: 2,
       orgNumber: '310202398',
-      ssn: '',
       unitType: 'AS',
       name: 'DISKRET NÆR TIGER AS',
       isDeleted: false,

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/AccessManagement/AuthorizedParty.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/AccessManagement/AuthorizedParty.cs
@@ -25,11 +25,6 @@ namespace Altinn.AccessManagement.UI.Core.Models.AccessManagement
         public string OrganizationNumber { get; set; }
 
         /// <summary>
-        /// Gets the national identity number if the party is a person
-        /// </summary>
-        public string PersonId { get; set; }
-
-        /// <summary>
         /// Gets or sets the party id
         /// </summary>
         public int PartyId { get; set; }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/Common/Frontend/PartyFE.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/Common/Frontend/PartyFE.cs
@@ -1,0 +1,105 @@
+﻿using Altinn.Platform.Register.Enums;
+using Altinn.Platform.Register.Models;
+using System.IO;
+
+namespace Altinn.AccessManagement.UI.Core.Models
+{
+    /// <summary>
+    /// Class representing a party for use in GUI (equal to the one from registry but without ssn)
+    /// </summary>
+    public class PartyFE
+    {
+        /// <summary>
+        /// Gets or sets the ID of the party
+        /// </summary>
+        public int PartyId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the UUID of the party
+        /// </summary>
+        public Guid? PartyUuid { get; set; }
+
+        /// <summary>
+        /// Gets or sets the type of party
+        /// </summary>
+        public PartyType PartyTypeName { get; set; }
+
+        /// <summary>
+        /// Gets the parties org number
+        /// </summary>
+        public string OrgNumber { get; set; }
+
+        /// <summary>
+        /// Gets or sets the UnitType
+        /// </summary>
+        public string UnitType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Name
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the IsDeleted
+        /// </summary>
+        public bool IsDeleted { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether if the reportee in the list is only there for showing the hierarchy (a parent unit with no access)
+        /// </summary>
+        public bool OnlyHierarchyElementWithNoAccess { get; set; }
+
+        /// <summary>
+        /// Gets or sets the person details for this party (will only be set if the party type is Person)
+        /// </summary>
+        public PersonFE Person { get; set; }
+
+        /// <summary>
+        /// Gets or sets the organization details for this party (will only be set if the party type is Organization)
+        /// </summary>
+        public Organization Organization { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value of ChildParties
+        /// </summary>
+        public List<PartyFE> ChildParties { get; set; }
+
+        /// <summary>
+        /// Creates a PartyFE object from a Party object
+        /// </summary>
+        /// <param name="party">A Party object</param>
+        public PartyFE(Party party)
+        {
+            PartyId = party.PartyId;
+            PartyUuid = party.PartyUuid;
+            PartyTypeName = party.PartyTypeName;
+            Name = party.Name;
+            IsDeleted = party.IsDeleted;
+            OrgNumber = party.OrgNumber;
+            UnitType = party.UnitType;
+            OnlyHierarchyElementWithNoAccess = party.OnlyHierarchyElementWithNoAccess;
+            Person = party.Person == null ? null : new PersonFE(party.Person);
+            Organization = party.Organization;
+            ChildParties = party.ChildParties == null ? null : MakeChildPartyFEList(party.ChildParties);
+        }
+
+        /// <summary>
+        /// Default contructor
+        /// </summary>
+        public PartyFE()
+        {
+        }
+
+        private List<PartyFE> MakeChildPartyFEList(List<Party> childParties)
+        {
+            List<PartyFE> childPartiesFE = new List<PartyFE>();
+
+            foreach (Party childParty in childParties)
+            {
+                childPartiesFE.Add(new PartyFE(childParty));
+            }
+
+            return childPartiesFE;
+        }
+    }
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/Common/Frontend/PersonFE.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/Common/Frontend/PersonFE.cs
@@ -1,0 +1,120 @@
+﻿using Altinn.Platform.Register.Models;
+
+namespace Altinn.AccessManagement.UI.Core.Models
+{
+    /// <summary>
+    /// Class representing a person for use in GUI (equal to the definition of regitry but without ssn)
+    /// </summary>
+    public class PersonFE
+    {
+        /// <summary>
+        /// Gets a persons name
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the first name
+        /// </summary>
+        public string FirstName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the middle name
+        /// </summary>
+        public string MiddleName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the last name
+        /// </summary>
+        public string LastName { get; set; }
+
+        /// <summary>
+        /// Gets a persons telephone number
+        /// </summary>
+        public string TelephoneNumber { get; set; }
+
+        /// <summary>
+        /// Gets a persons mobile number
+        /// </summary>
+        public string MobileNumber { get; set; }
+
+        /// <summary>
+        /// Gets a persons mailing address
+        /// </summary>
+        public string MailingAddress { get; set; }
+
+        /// <summary>
+        /// Gets a persons mailing postal code
+        /// </summary>
+        public string MailingPostalCode { get; set; }
+
+        /// <summary>
+        /// Gets a persons mailing postal city
+        /// </summary>
+        public string MailingPostalCity { get; set; }
+
+        /// <summary>
+        /// Gets a persons address municipal number
+        /// </summary>
+        public string AddressMunicipalNumber { get; set; }
+
+        /// <summary>
+        /// Gets a persons address municipal name
+        /// </summary>
+        public string AddressMunicipalName { get; set; }
+
+        /// <summary>
+        /// Gets a persons address street name
+        /// </summary>
+        public string AddressStreetName { get; set; }
+
+        /// <summary>
+        /// Gets a persons address house number
+        /// </summary>
+        public string AddressHouseNumber { get; set; }
+
+        /// <summary>
+        /// Gets a persons address house letter
+        /// </summary>
+        public string AddressHouseLetter { get; set; }
+
+        /// <summary>
+        /// Gets a persons address postal code
+        /// </summary>
+        public string AddressPostalCode { get; set; }
+
+        /// <summary>
+        /// Gets a persons address city
+        /// </summary>
+        public string AddressCity { get; set; }
+
+        /// <summary>
+        /// Gets a persons date of death. Null if not dead.
+        /// </summary>
+        public DateTime? DateOfDeath { get; set; }
+
+        /// <summary>
+        /// Creates a PersonFE object from a Person object
+        /// </summary>
+        /// <param name="person">A Person object</param>
+        public PersonFE(Person person)
+        {
+            Name = person.Name;
+            FirstName = person.FirstName;
+            MiddleName = person.MiddleName;
+            LastName = person.LastName;
+            TelephoneNumber = person.TelephoneNumber;
+            MobileNumber = person.MobileNumber;
+            MailingAddress = person.MailingAddress;
+            MailingPostalCode = person.MailingPostalCode;
+            MailingPostalCity = person.MailingPostalCity;
+            AddressCity = person.AddressCity;
+            AddressMunicipalName = person.AddressMunicipalName;
+            AddressMunicipalNumber = person.AddressMunicipalNumber;
+            AddressStreetName = person.AddressStreetName;
+            AddressHouseNumber = person.AddressHouseNumber;
+            AddressHouseLetter = person.AddressHouseLetter;
+            AddressPostalCode = person.AddressPostalCode;
+            DateOfDeath = person.DateOfDeath;
+        }
+    }
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/Common/Frontend/UserProfileFE.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/Common/Frontend/UserProfileFE.cs
@@ -1,0 +1,93 @@
+﻿using Altinn.Platform.Profile.Enums;
+using Altinn.Platform.Profile.Models;
+using Altinn.Platform.Register.Models;
+
+namespace Altinn.AccessManagement.UI.Core.Models
+{
+    /// <summary>
+    /// Class describing a user profile for use in the front end GUI. Notably, this model does not include the party's ssn
+    /// </summary>
+    public class UserProfileFE
+    {
+        /// <summary>
+        /// Gets or sets the ID of the user
+        /// </summary>
+        public int UserId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the UUID of the user
+        /// </summary>
+        public Guid? UserUuid { get; set; }
+
+        /// <summary>
+        /// Gets or sets the username
+        /// </summary>
+        public string UserName { get; set; }
+
+        /// <summary>
+        /// Gets or sets ExternalIdentity
+        /// </summary>
+        public string ExternalIdentity { get; set; }
+
+        /// <summary>
+        /// Gets or sets a boolean indicating whether the user has reserved themselves from electronic communication
+        /// </summary>
+        public bool IsReserved { get; set; }
+
+        /// <summary>
+        /// Gets or sets the phone number
+        /// </summary>
+        public string PhoneNumber { get; set; }
+
+        /// <summary>
+        /// Gets or sets the email address
+        /// </summary>
+        public string Email { get; set; }
+
+        /// <summary>
+        /// Gets or sets the party ID
+        /// </summary>
+        public int PartyId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="Party"/>
+        /// </summary>
+        public PartyFE Party { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="UserType"/>
+        /// </summary>
+        public UserType UserType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="ProfileSettingPreference"/>
+        /// </summary>
+        public ProfileSettingPreference ProfileSettingPreference { get; set; }
+
+        /// <summary>
+        /// Creates a UserProfileFE object from a UserProfile object
+        /// </summary>
+        /// <param name="userProfile">A UserProfile object</param>
+        public UserProfileFE(UserProfile userProfile)
+        {
+            UserId = userProfile.UserId;
+            UserUuid = userProfile.UserUuid;
+            UserName = userProfile.UserName;
+            ExternalIdentity = userProfile.ExternalIdentity;
+            IsReserved = userProfile.IsReserved;
+            PhoneNumber = userProfile.PhoneNumber;
+            Email = userProfile.Email;
+            PartyId = userProfile.PartyId;
+            UserType = userProfile.UserType;
+            ProfileSettingPreference = userProfile.ProfileSettingPreference;
+            Party = new PartyFE(userProfile.Party);
+        }
+
+        /// <summary>
+        /// Default constructor
+        /// </summary>
+        public UserProfileFE()
+        {
+        }
+    }
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/User/RightHolder.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/User/RightHolder.cs
@@ -29,11 +29,6 @@ namespace Altinn.AccessManagement.UI.Core.Models.User
         public List<RegistryRoleType> RegistryRoles { get; set; }
 
         /// <summary>
-        /// The national identity number if the party is a person
-        /// </summary>
-        public string PersonId { get; set; }
-
-        /// <summary>
         /// The organization number if the party is an organization
         /// </summary>
         public string OrganizationNumber { get; set; }
@@ -63,7 +58,6 @@ namespace Altinn.AccessManagement.UI.Core.Models.User
             PartyUuid = party.PartyUuid;
             PartyType = party.Type;
             Name = party.Name;
-            PersonId = party.PersonId;
             OrganizationNumber = party.OrganizationNumber;
             UnitType = party.UnitType;
             RegistryRoles = party.AuthorizedRoles.Where(role => Enum.IsDefined(typeof(RegistryRoleType), role.ToUpper()))

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/Interfaces/ILookupService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/Interfaces/ILookupService.cs
@@ -1,4 +1,5 @@
-﻿using Altinn.Platform.Profile.Models;
+﻿using Altinn.AccessManagement.UI.Core.Models;
+using Altinn.Platform.Profile.Models;
 using Altinn.Platform.Register.Models;
 
 namespace Altinn.AccessManagement.UI.Core.Services.Interfaces
@@ -15,20 +16,20 @@ namespace Altinn.AccessManagement.UI.Core.Services.Interfaces
         /// <returns>
         /// Party information
         /// </returns>
-        Task<Party> GetPartyForOrganization(string organizationNumber);
+        Task<PartyFE> GetPartyForOrganization(string organizationNumber);
 
         /// <summary>
         /// Gets a Party based on provided uuid
         /// </summary>
         /// <param name="uuid">The uuid of the party</param>
         /// <returns>Party that corresponds to uuid parameter</returns>
-        Task<Party> GetPartyByUUID(Guid uuid);
+        Task<PartyFE> GetPartyByUUID(Guid uuid);
 
         /// <summary>
         /// Gets a UserProfile based on provided uuid
         /// </summary>
         /// <param name="uuid">The uuid of the user</param>
         /// <returns>The user profile that corresponds to the uuid parameter</returns>
-        Task<UserProfile> GetUserByUUID(Guid uuid);
+        Task<UserProfileFE> GetUserByUUID(Guid uuid);
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/Interfaces/IUserService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/Interfaces/IUserService.cs
@@ -1,6 +1,6 @@
-﻿using Altinn.AccessManagement.UI.Core.Models.AccessManagement;
+﻿using Altinn.AccessManagement.UI.Core.Models;
+using Altinn.AccessManagement.UI.Core.Models.AccessManagement;
 using Altinn.AccessManagement.UI.Core.Models.User;
-using Altinn.Platform.Profile.Models;
 
 namespace Altinn.AccessManagement.UI.Core.Services.Interfaces
 {
@@ -14,7 +14,7 @@ namespace Altinn.AccessManagement.UI.Core.Services.Interfaces
         /// </summary>
         /// <param name="userId">Id of user</param>
         /// <returns>users preferred settings</returns>
-        Task<UserProfile> GetUserProfile(int userId);
+        Task<UserProfileFE> GetUserProfile(int userId);
 
         /// <summary>
         /// Gets a Party based on partyId if the party is in the users reporteelist

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/LookupService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/LookupService.cs
@@ -1,7 +1,9 @@
 ﻿using Altinn.AccessManagement.UI.Core.ClientInterfaces;
+using Altinn.AccessManagement.UI.Core.Models;
 using Altinn.AccessManagement.UI.Core.Services.Interfaces;
 using Altinn.Platform.Profile.Models;
 using Altinn.Platform.Register.Models;
+using System.IO;
 
 namespace Altinn.AccessManagement.UI.Core.Services
 {
@@ -25,25 +27,28 @@ namespace Altinn.AccessManagement.UI.Core.Services
         }
 
         /// <inheritdoc/>        
-        public async Task<Party> GetPartyForOrganization(string organizationNumber)
+        public async Task<PartyFE> GetPartyForOrganization(string organizationNumber)
         {
-            return await _registerClient.GetPartyForOrganization(organizationNumber);
+            Party party = await _registerClient.GetPartyForOrganization(organizationNumber);
+            return party == null ? null : new PartyFE(party);
         }
 
         /// <inheritdoc/>        
-        public async Task<Party> GetPartyByUUID(Guid uuid)
+        public async Task<PartyFE> GetPartyByUUID(Guid uuid)
         {
             // We fetch the party using the partyList endpoint because it has better performance than the one ment for singular party queries.
             // However, since we only ask for one uuid, we will still only get one party back.
             List<Party> partyList = await _registerClient.GetPartyList(new List<Guid>() { uuid });
-            return partyList?.FirstOrDefault();
+            Party party = partyList?.FirstOrDefault();
+
+            return party == null ? null : new PartyFE(party);
         }
 
         /// <inheritdoc/>        
-        public async Task<UserProfile> GetUserByUUID(Guid uuid)
+        public async Task<UserProfileFE> GetUserByUUID(Guid uuid)
         {
             UserProfile user = await _profileClient.GetUserProfile(uuid);
-            return user;
+            return user == null ? null : new UserProfileFE(user);
         }
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/UserService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/UserService.cs
@@ -1,5 +1,6 @@
 ﻿using Altinn.AccessManagement.UI.Core.ClientInterfaces;
 using Altinn.AccessManagement.UI.Core.Enums;
+using Altinn.AccessManagement.UI.Core.Models;
 using Altinn.AccessManagement.UI.Core.Models.AccessManagement;
 using Altinn.AccessManagement.UI.Core.Models.Delegation;
 using Altinn.AccessManagement.UI.Core.Models.Delegation.Frontend;
@@ -38,10 +39,10 @@ namespace Altinn.AccessManagement.UI.Core.Services
         }
 
         /// <inheritdoc/>
-        public async Task<UserProfile> GetUserProfile(int userId)
+        public async Task<UserProfileFE> GetUserProfile(int userId)
         {
             UserProfile userProfile = await _profileClient.GetUserProfile(userId);
-            return userProfile;           
+            return userProfile == null ? null : new UserProfileFE(userProfile);         
         }
 
         /// <inheritdoc/>        

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/AccessManagementClientMock.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/AccessManagementClientMock.cs
@@ -77,7 +77,6 @@ namespace Altinn.AccessManagement.UI.Mocks.Mocks
                     Name = "Livsglad Film",
                     Type = AuthorizedPartyType.Person,
                     PartyUuid = new Guid("eb0e874b-5f37-44cc-b648-f9a902a82c89"),
-                    PersonId = "21915399719",
                     AuthorizedRoles = []
                 };
                 reportees.Add(currentUser);
@@ -356,14 +355,12 @@ namespace Altinn.AccessManagement.UI.Mocks.Mocks
                 .RuleFor(s => s.Name, f => f.Person.FullName)
                 .RuleFor(s => s.PartyId, f => f.Random.Number(10000000, 99999999))
                 .RuleFor(s => s.PartyUuid, f => f.Random.Guid())
-                .RuleFor(s => s.PersonId, f => f.Person.Fodselsnummer())
                 .RuleFor(s => s.AuthorizedRoles, f => f.Make(f.Random.Number(0, 5), () => f.PickRandom<RegistryRoleType>().ToString()).Distinct().ToList());
 
             _faker = new Faker<AuthorizedParty>()
                 .RuleFor(p => p.PartyUuid, f => f.Random.Guid())
                 .RuleFor(p => p.Type, f => f.PickRandom(allowedPartyTypes))
                 .RuleFor(p => p.OrganizationNumber, (f, p) => p.Type == AuthorizedPartyType.Organization ? f.Random.Number(100000000, 999999999).ToString() : null)
-                .RuleFor(p => p.PersonId, (f, p) => p.Type != AuthorizedPartyType.Organization ? f.Person.Fodselsnummer() : null)
                 .RuleFor(p => p.PartyId, f => f.Random.Number(10000000, 99999999))
                 .RuleFor(p => p.Name, (f, p) => p.Type == AuthorizedPartyType.Organization ? f.Company.CompanyName() : f.Person.FullName)
                 .RuleFor(p => p.UnitType, (f, p) => p.Type == AuthorizedPartyType.Organization ? f.Company.CompanySuffix() : null)

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/RegisterClientMock.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/RegisterClientMock.cs
@@ -22,7 +22,7 @@ namespace Altinn.AccessManagement.UI.Mocks.Mocks
         public Task<Party> GetPartyForOrganization(string organizationNumber)
         {
             Party party = null;
-            string testDataPath = Path.Combine(Path.GetDirectoryName(new Uri(typeof(RegisterClientMock).Assembly.Location).LocalPath), "Data", "Register", "Parties", "parties.json"); ;
+            string testDataPath = Path.Combine(Path.GetDirectoryName(new Uri(typeof(RegisterClientMock).Assembly.Location).LocalPath), "Data", "Register", "Parties", "parties.json");
             if (File.Exists(testDataPath))
             {
                 string content = File.ReadAllText(testDataPath);

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/LookupControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/LookupControllerTest.cs
@@ -3,11 +3,10 @@ using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using Altinn.AccessManagement.UI.Controllers;
 using Altinn.AccessManagement.UI.Core.ClientInterfaces;
+using Altinn.AccessManagement.UI.Core.Models;
 using Altinn.AccessManagement.UI.Mocks.Mocks;
 using Altinn.AccessManagement.UI.Mocks.Utils;
-using Altinn.Platform.Profile.Models;
 using Altinn.Platform.Register.Enums;
-using Altinn.Platform.Register.Models;
 using AltinnCore.Authentication.JwtCookie;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -72,7 +71,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-            Party actualParty = await response.Content.ReadFromJsonAsync<Party>();
+            PartyFE actualParty = await response.Content.ReadFromJsonAsync<PartyFE>();
             Assert.Equal(lookupOrgNo, actualParty.OrgNumber);
             Assert.Equal(50004222, actualParty.PartyId);
             Assert.Equal(PartyType.Organisation, actualParty.PartyTypeName);
@@ -105,7 +104,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-            Party actualParty = await response.Content.ReadFromJsonAsync<Party>();
+            PartyFE actualParty = await response.Content.ReadFromJsonAsync<PartyFE>();
             Assert.Equal(lookupUUID, actualParty.PartyUuid);
             Assert.Equal(51317934, actualParty.PartyId);
             Assert.Equal(PartyType.Organisation, actualParty.PartyTypeName);
@@ -152,7 +151,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-            UserProfile actualUser = await response.Content.ReadFromJsonAsync<UserProfile>();
+            UserProfileFE actualUser = await response.Content.ReadFromJsonAsync<UserProfileFE>();
             Assert.Equal(lookupUUID, actualUser.UserUuid);
             Assert.Equal(20004938, actualUser.UserId);
             Assert.Equal(50019992, actualUser.PartyId);

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/UserControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/UserControllerTest.cs
@@ -3,21 +3,14 @@ using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using Altinn.AccessManagement.UI.Controllers;
 using Altinn.AccessManagement.UI.Core.ClientInterfaces;
+using Altinn.AccessManagement.UI.Core.Models;
 using Altinn.AccessManagement.UI.Core.Models.AccessManagement;
 using Altinn.AccessManagement.UI.Core.Models.User;
-using Altinn.AccessManagement.UI.Mocks.Mocks;
 using Altinn.AccessManagement.UI.Mocks.Utils;
 using Altinn.AccessManagement.UI.Tests.Utils;
-using Altinn.Common.PEP.Interfaces;
 using Altinn.Platform.Profile.Enums;
 using Altinn.Platform.Profile.Models;
-using Altinn.Platform.Register.Models;
-using AltinnCore.Authentication.JwtCookie;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.AspNetCore.TestHost;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using Moq;
 
 namespace Altinn.AccessManagement.UI.Tests.Controllers
@@ -46,9 +39,9 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
 
         }
 
-        private static UserProfile GetUserProfile(int id)
+        private static UserProfileFE GetUserProfile(int id)
         {
-            return new UserProfile
+            return new UserProfileFE
             {
                 UserId = id,
                 Email = "email@domain.com",
@@ -57,7 +50,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
                 PhoneNumber = "12345678",
                 UserName = "UserName",
                 UserType = UserType.None,
-                Party = new Party(),
+                Party = new PartyFE(),
                 ProfileSettingPreference = new ProfileSettingPreference
                 {
                     DoNotPromptForParty = false,
@@ -81,7 +74,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             var response = await _client.GetAsync("accessmanagement/api/v1/user/profile");
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            var userProfile = await response.Content.ReadFromJsonAsync<UserProfile>();
+            var userProfile = await response.Content.ReadFromJsonAsync<UserProfileFE>();
             Assert.Equal(userId, userProfile.UserId);
         }
 

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Utils/AssertionUtil.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Utils/AssertionUtil.cs
@@ -233,7 +233,7 @@ namespace Altinn.AccessManagement.UI.Tests.Utils
             }
         }
 
-        public static void AssertEqual(Party expected, Party actual)
+        public static void AssertEqual(PartyFE expected, PartyFE actual)
         {
             Assert.NotNull(actual);
             Assert.NotNull(expected);
@@ -246,7 +246,7 @@ namespace Altinn.AccessManagement.UI.Tests.Utils
             Assert.Equal(expected.PartyUuid, actual.PartyUuid);
             Assert.Equal(expected.PartyId, actual.PartyId);
             Assert.Equal(expected.OnlyHierarchyElementWithNoAccess, actual.OnlyHierarchyElementWithNoAccess);
-            AssertCollections<Party>(expected.ChildParties, actual.ChildParties, AssertEqual);
+            AssertCollections<PartyFE>(expected.ChildParties, actual.ChildParties, AssertEqual);
 
         }
 
@@ -275,7 +275,6 @@ namespace Altinn.AccessManagement.UI.Tests.Utils
             Assert.Equal(expected.OrganizationNumber, actual.OrganizationNumber);
             Assert.Equal(expected.PartyUuid, actual.PartyUuid);
             Assert.Equal(expected.PartyType, actual.PartyType);
-            Assert.Equal(expected.PersonId, actual.PersonId);
             AssertCollections(expected.RegistryRoles, actual.RegistryRoles, Assert.Equal);
 
         }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/HomeController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/HomeController.cs
@@ -2,6 +2,7 @@
 using Altinn.AccessManagement.Models;
 using Altinn.AccessManagement.UI.Core.Configuration;
 using Altinn.AccessManagement.UI.Core.Helpers;
+using Altinn.AccessManagement.UI.Core.Models;
 using Altinn.AccessManagement.UI.Core.Services.Interfaces;
 using Altinn.AccessManagement.UI.Integration.Configuration;
 using Altinn.Platform.Profile.Models;
@@ -109,7 +110,7 @@ namespace Altinn.AccessManagement.UI.Controllers
             if (string.IsNullOrEmpty(languageCode))
             {
                 int userId = AuthenticationHelper.GetUserId(_httpContextAccessor.HttpContext);
-                UserProfile user = await _userService.GetUserProfile(userId);
+                UserProfileFE user = await _userService.GetUserProfile(userId);
                 languageCode = LanguageHelper.GetFrontendStandardLanguage(user?.ProfileSettingPreference?.Language);
             }
 

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/LookupController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/LookupController.cs
@@ -1,7 +1,6 @@
-﻿using Altinn.AccessManagement.UI.Core.Services.Interfaces;
+﻿using Altinn.AccessManagement.UI.Core.Models;
+using Altinn.AccessManagement.UI.Core.Services.Interfaces;
 using Altinn.AccessManagement.UI.Filters;
-using Altinn.Platform.Profile.Models;
-using Altinn.Platform.Register.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -39,11 +38,11 @@ namespace Altinn.AccessManagement.UI.Controllers
         [HttpGet]
         [Authorize]
         [Route("org/{orgNummer}")]
-        public async Task<ActionResult<Party>> GetOrganisation(string orgNummer)
+        public async Task<ActionResult<PartyFE>> GetOrganisation(string orgNummer)
         {
             try
             {
-                Party party = await _lookupService.GetPartyForOrganization(orgNummer);
+                PartyFE party = await _lookupService.GetPartyForOrganization(orgNummer);
 
                 if (party == null)
                 {
@@ -65,15 +64,15 @@ namespace Altinn.AccessManagement.UI.Controllers
         /// Endpoint for retrieving a party by uuid
         /// </summary>
         /// <param name="uuid">The uuid for the party to look up</param>
-        /// <returns>Party information</returns>
+        /// <returns>Party information for the GUI</returns>
         [HttpGet]
         [Authorize]
         [Route("party/{uuid}")]
-        public async Task<ActionResult<Party>> GetPartyByUUID(Guid uuid)
+        public async Task<ActionResult<PartyFE>> GetPartyByUUID(Guid uuid)
         {
             try
             {
-                Party party = await _lookupService.GetPartyByUUID(uuid);
+                PartyFE party = await _lookupService.GetPartyByUUID(uuid);
 
                 if (party != null)
                 {
@@ -86,7 +85,7 @@ namespace Altinn.AccessManagement.UI.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "GetPartyByUUID failed to fetch reportee information");
+                _logger.LogError(ex, "GetPartyByUUID failed to fetch party information");
                 return StatusCode(500);
             }
         }
@@ -95,15 +94,15 @@ namespace Altinn.AccessManagement.UI.Controllers
         /// Endpoint for retrieving a user by uuid
         /// </summary>
         /// <param name="uuid">The uuid for the user to look up</param>
-        /// <returns>Party information</returns>
+        /// <returns>Party information for the GUI</returns>
         [HttpGet]
         [Authorize]
         [Route("user/{uuid}")]
-        public async Task<ActionResult<UserProfile>> GetUserByUUID(Guid uuid)
+        public async Task<ActionResult<UserProfileFE>> GetUserByUUID(Guid uuid)
         {
             try
             {
-                UserProfile user = await _lookupService.GetUserByUUID(uuid);
+                UserProfileFE user = await _lookupService.GetUserByUUID(uuid);
 
                 if (user != null)
                 {
@@ -116,7 +115,7 @@ namespace Altinn.AccessManagement.UI.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "GetUserByUUID failed to fetch reportee information");
+                _logger.LogError(ex, "GetUserByUUID failed to fetch party information");
                 return StatusCode(500);
             }
         }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/SingleRightController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/SingleRightController.cs
@@ -154,7 +154,7 @@ namespace Altinn.AccessManagement.UI.Controllers
         [HttpGet]
         [Authorize]
         [Route("{party}/rightholder/{userId}")]
-        public async Task<IActionResult> GetSingleRightsForRightholder([FromRoute] string party, [FromRoute] string userId)
+        public async Task<ActionResult<List<ResourceDelegation>>> GetSingleRightsForRightholder([FromRoute] string party, [FromRoute] string userId)
         {
             var languageCode = LanguageHelper.GetSelectedLanguageCookieValueBackendStandard(_httpContextAccessor.HttpContext);
             try

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/UserController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/UserController.cs
@@ -1,8 +1,10 @@
 ﻿using Altinn.AccessManagement.UI.Core.ClientInterfaces;
 using Altinn.AccessManagement.UI.Core.Helpers;
+using Altinn.AccessManagement.UI.Core.Models;
 using Altinn.AccessManagement.UI.Core.Models.AccessManagement;
 using Altinn.AccessManagement.UI.Core.Models.User;
 using Altinn.AccessManagement.UI.Core.Services.Interfaces;
+using Altinn.Platform.Profile.Models;
 using Altinn.Platform.Register.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -35,7 +37,7 @@ namespace Altinn.AccessManagement.UI.Controllers
         [Authorize]
         [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
         [HttpGet("profile")]
-        public async Task<ActionResult> GetUser()
+        public async Task<ActionResult<UserProfileFE>> GetUser()
         {
             int userId = AuthenticationHelper.GetUserId(_httpContextAccessor.HttpContext);
             if (userId == 0)
@@ -45,7 +47,7 @@ namespace Altinn.AccessManagement.UI.Controllers
 
             try
             {
-                var user = await _userService.GetUserProfile(userId);
+                UserProfileFE user = await _userService.GetUserProfile(userId);
 
                 if (user == null)
                 {

--- a/src/features/amUI/userRightsPage/DelegationModal/DelegationModal.stories.tsx
+++ b/src/features/amUI/userRightsPage/DelegationModal/DelegationModal.stories.tsx
@@ -35,7 +35,6 @@ export const Default: StoryObj<DelegationModalProps> = {
       partyId: 123,
       partyUuid: '123',
       orgNumber: '123123123',
-      ssn: '123123123',
       unitType: 'unitType',
       name: 'Ola Nordmann',
       partyTypeName: PartyType.Person,

--- a/src/features/amUI/users/useFilteredRightHolders.ts
+++ b/src/features/amUI/users/useFilteredRightHolders.ts
@@ -10,9 +10,8 @@ export interface FilteredRightHolder extends RightHolder {
 
 const isSearchMatch = (searchString: string, rightHolder: RightHolder): boolean => {
   const isNameMatch = rightHolder.name.toLowerCase().indexOf(searchString.toLowerCase()) > -1;
-  const isPersonIdMatch = rightHolder.personId === searchString;
   const isOrgNrMatch = rightHolder.organizationNumber === searchString;
-  return isNameMatch || isPersonIdMatch || isOrgNrMatch;
+  return isNameMatch || isOrgNrMatch;
 };
 
 const sortRightHolders = (rightHolders: RightHolder[]): RightHolder[] =>

--- a/src/rtk/features/lookupApi.ts
+++ b/src/rtk/features/lookupApi.ts
@@ -19,7 +19,6 @@ export type Party = {
   partyId: number;
   partyUuid: string;
   orgNumber?: string;
-  ssn?: string;
   unitType?: string;
   name: string;
   partyTypeName: PartyType;

--- a/src/rtk/features/userInfoApi.ts
+++ b/src/rtk/features/userInfoApi.ts
@@ -32,7 +32,6 @@ export interface RightHolder {
   partyType: PartyType;
   name: string;
   registryRoles: string[];
-  personId?: string;
   organizationNumber?: string;
   unitType?: string;
   inheritingRightHolders: RightHolder[];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removed personId/ssn from all returned models in the bff so that it is never exposed to the browser.
This is due to security and because we don't actually use it in the GUI

## Related Issue(s)
- #1150 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
