### PR TITLE
Chore/add nginx setup to readme

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,4 @@
 {
-  // Use IntelliSense to learn about possible attributes.
-  // Hover to view descriptions of existing attributes.
-  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
   "configurations": [
     {
@@ -12,24 +9,11 @@
       "webRoot": "${workspaceFolder}"
     },
     {
-      "name": ".NET Core Attach",
-      "type": "coreclr",
-      "request": "attach",
-      "processId": "${command:pickProcess}",
-      "justMyCode": true
-    },
-    {
-      "name": ".NET Core Launch",
-      "type": "coreclr",
+      "name": "C#: Altinn.AccessManagement.UI [LocalDev_5000] asd",
+      "type": "dotnet",
       "request": "launch",
-      "preLaunchTask": "build",
-      "program": "${workspaceFolder}/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/bin/Debug/net8.0/Altinn.AccessManagement.UI.dll",
-      "env": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "console": "internalConsole",
-      "internalConsoleOptions": "openOnSessionStart",
-      "args": ["--launch-profile", "LocalDev_5000"]
+      "projectPath": "${workspaceFolder}/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.csproj",
+      "launchConfigurationId": "TargetFramework=;LocalDev_5000"
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,6 +10,26 @@
       "name": "Launch Chrome against localhost",
       "url": "http://localhost:8080",
       "webRoot": "${workspaceFolder}"
+    },
+    {
+      "name": ".NET Core Attach",
+      "type": "coreclr",
+      "request": "attach",
+      "processId": "${command:pickProcess}",
+      "justMyCode": true
+    },
+    {
+      "name": ".NET Core Launch",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "${workspaceFolder}/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/bin/Debug/net8.0/Altinn.AccessManagement.UI.dll",
+      "env": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "console": "internalConsole",
+      "internalConsoleOptions": "openOnSessionStart",
+      "args": ["--launch-profile", "LocalDev_5000"]
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
       "webRoot": "${workspaceFolder}"
     },
     {
-      "name": "C#: Altinn.AccessManagement.UI [LocalDev_5000] asd",
+      "name": "C#: Altinn.AccessManagement.UI [LocalDev_5000]",
       "type": "dotnet",
       "request": "launch",
       "projectPath": "${workspaceFolder}/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.csproj",

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ OBS: These settings use https which requires a certificate to be uploaded or gen
 
 Now that the BFF is running, you can move on to the react app.
 
-#### Troubleshooting: "Unhandled exception. System.IO.IOException: Failed to bind to address https://localhost:443"
+#### Troubleshooting
 
-If you encounter the error "Unhandled exception. System.IO.IOException: Failed to bind to address https://localhost:443", it usually means the application doesn't have the necessary permissions to use that port. This is because port 443 is a privileged port, typically requiring root access. However, running your entire application with elevated privileges (e.g., using sudo) is not recommended due to security risks. Instead, you can use a reverse proxy like nginx to handle port 443 and forward requests to your application running on a non-privileged port. This allows you to avoid running your app as root while still serving it on the standard HTTPS port.
+If you encounter the error **"Unhandled exception. System.IO.IOException: Failed to bind to address https://localhost:443"**, it usually means the application doesn't have the necessary permissions to use that port. This is because port 443 is a privileged port, typically requiring root access. However, running your entire application with elevated privileges (e.g., using sudo) is not recommended due to security risks. Instead, you can use a reverse proxy like nginx to handle port 443 and forward requests to your application running on a non-privileged port. This allows you to avoid running your app as root while still serving it on the standard HTTPS port.
 
 1. Install nginx:
 
@@ -112,15 +112,15 @@ Go back to the main nginx directory:
 
 ```Bash
 cd /opt/homebrew/etc/nginx/
-````
+```
 
-4. Create an ssl directory:
+Create an ssl directory:
 
 ```Bash
 mkdir ssl
 ```
 
-5. Generate a self-signed certificate:
+Generate a self-signed certificate:
 
 ```Bash
 cd ssl
@@ -128,13 +128,15 @@ openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout localhost.key -out l
 ```
 (You'll be prompted to enter information for the certificate. This information is not critical for local development, so feel free to fill in any values.)
 
-6. Start nginx:
+4. Start nginx:
+
+Try running your app again. It should now work correctly on port 443, with nginx handling SSL encryption and forwarding requests to your application.
 
 ```Bash
 sudo nginx
 ```
 
-Try running your app again. It should now work correctly on port 443, with nginx handling SSL encryption and forwarding requests to your application.
+
 
 ### Step 3: Run the React application
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,78 @@ OBS: These settings use https which requires a certificate to be uploaded or gen
 
 Now that the BFF is running, you can move on to the react app.
 
+#### Troubleshooting: "Unhandled exception. System.IO.IOException: Failed to bind to address https://localhost:443"
+
+If you encounter the error "Unhandled exception. System.IO.IOException: Failed to bind to address https://localhost:443", it usually means the application doesn't have the necessary permissions to use that port. This is because port 443 is a privileged port, typically requiring root access. However, running your entire application with elevated privileges (e.g., using sudo) is not recommended due to security risks. Instead, you can use a reverse proxy like nginx to handle port 443 and forward requests to your application running on a non-privileged port. This allows you to avoid running your app as root while still serving it on the standard HTTPS port.
+
+1. Install nginx:
+
+```Bash
+brew install nginx
+```
+
+2. Configure nginx:
+
+Navigate to the nginx servers directory:
+
+```Bash
+cd /opt/homebrew/etc/nginx/servers
+```
+
+Create a new configuration file (e.g., am_ui.conf) and add the following content:
+
+```Nginx
+server {
+    listen 443 ssl;
+    server_name localhost;
+
+    ssl_certificate ssl/localhost.crt;
+    ssl_certificate_key ssl/localhost.key;
+
+    location / {
+        proxy_pass https://localhost:5000;  
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection keep-alive;
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+
+3. Create an SSL certificate:
+
+Go back to the main nginx directory:
+
+```Bash
+cd /opt/homebrew/etc/nginx/
+````
+
+4. Create an ssl directory:
+
+```Bash
+mkdir ssl
+```
+
+5. Generate a self-signed certificate:
+
+```Bash
+cd ssl
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout localhost.key -out localhost.crt
+```
+(You'll be prompted to enter information for the certificate. This information is not critical for local development, so feel free to fill in any values.)
+
+6. Start nginx:
+
+```Bash
+sudo nginx
+```
+
+Try running your app again. It should now work correctly on port 443, with nginx handling SSL encryption and forwarding requests to your application.
+
 ### Step 3: Run the React application
 
 Pull the newest version of this repo and navigate to its root
@@ -234,3 +306,5 @@ This project uses [MSW (Mock Service Worker)](https://mswjs.io/) to mock API req
 ### Documentation: 
 *  For more information on writing stories, see the [Storybook Docs](https://storybook.js.org/docs/react/get-started/introduction).
 *  To learn about using MSW with Storybook, check out the [MSW documentation](https://mswjs.io/docs/getting-started/integrate/storybook).
+
+

--- a/README.md
+++ b/README.md
@@ -130,11 +130,13 @@ openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout localhost.key -out l
 
 4. Start nginx:
 
-Try running your app again. It should now work correctly on port 443, with nginx handling SSL encryption and forwarding requests to your application.
-
+Start nginx
 ```Bash
 sudo nginx
 ```
+
+Try running your app again. It should now work correctly on port 443, with nginx handling SSL encryption and forwarding requests to your application.
+
 
 
 

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Properties/launchSettings.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Properties/launchSettings.json
@@ -1,5 +1,16 @@
 {
   "profiles": {
+    "LocalDev_5000": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "dotnetRunMessages": true,
+      "applicationUrl": "https://localhost:5000",
+      "useSSL": true
+    },
     "LocalDev": {
       "commandName": "Project",
       "launchBrowser": true,


### PR DESCRIPTION
Add instructions for running BFF locally on macOS

## Description
Currently, running the BFF locally on macOS requires root privileges. This can be inconvenient and pose security concerns as well as making it difficult to use a debugger.
This PR adds instructions to the README on how to run the BFF locally on a macOS machine without needing root access by setting up nginx as a reverse proxy.
I'm curious to see if others can get this working too.

## Related Issue(s)
- #na

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
