### PR TITLE
Display error message on failed Access List delegation check

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/SingleRight/DelegationAccessCheckResponse/appid-510.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/SingleRight/DelegationAccessCheckResponse/appid-510.json
@@ -11,7 +11,7 @@
     "status": "NotDelegable",
     "details": [
       {
-        "code": "MissingSrrRightAccess",
+        "code": "AccessListValidationFail",
         "description": "The user have access through delegation(s) of the right to the recipient(s)",
         "parameters": {
           "roleRequirementsMatches": [
@@ -36,7 +36,7 @@
     "status": "NotDelegable",
     "details": [
       {
-        "code": "MissingSrrRightAccess",
+        "code": "AccessListValidationFail",
         "description": "The user have access through delegation(s) of the right to the recipient(s)",
         "parameters": {
           "roleRequirementsMatches": [
@@ -61,7 +61,7 @@
     "status": "NotDelegable",
     "details": [
       {
-        "code": "MissingSrrRightAccess",
+        "code": "AccessListValidationFail",
         "description": "The user have access through delegation(s) of the right to the recipient(s)",
         "parameters": {
           "roleRequirementsMatches": [

--- a/src/features/amUI/userRightsPage/DelegationModal/SingleRights/ResourceAlert.tsx
+++ b/src/features/amUI/userRightsPage/DelegationModal/SingleRights/ResourceAlert.tsx
@@ -52,7 +52,13 @@ export const ResourceAlert = ({ resource, error, rightReasons }: ResourceAlertPr
       </>
     );
   } else if (rightReasons) {
-    if (rightReasons.every((reason) => reason === ErrorCode.MissingSrrRightAccess)) {
+    if (
+      rightReasons.every(
+        (reason) =>
+          reason === ErrorCode.MissingSrrRightAccess ||
+          reason === ErrorCode.AccessListValidationFail,
+      )
+    ) {
       headingText = t('delegation_modal.service_error.general_heading');
       content = (
         <Paragraph>

--- a/src/features/amUI/userRightsPage/DelegationModal/SingleRights/ResourceInfo.tsx
+++ b/src/features/amUI/userRightsPage/DelegationModal/SingleRights/ResourceInfo.tsx
@@ -123,7 +123,11 @@ export const ResourceInfo = ({ resource, toParty, onDelegate }: ResourceInfoProp
     const hasMissingSrrRightAccess = response.some(
       (result) =>
         !hasMissingRoleAccess &&
-        result.details?.some((detail) => detail.code === ErrorCode.MissingSrrRightAccess),
+        result.details?.some(
+          (detail) =>
+            detail.code === ErrorCode.MissingSrrRightAccess ||
+            detail.code === ErrorCode.AccessListValidationFail,
+        ),
     );
 
     if (hasMissingRoleAccess) {

--- a/src/resources/utils/errorCodeUtils.ts
+++ b/src/resources/utils/errorCodeUtils.ts
@@ -6,6 +6,7 @@ export enum ErrorCode {
   HTTPError = 'HTTPError',
   Unauthorized = 'Unauthorized',
   InsufficientAuthenticationLevel = 'InsufficientAuthenticationLevel',
+  AccessListValidationFail = 'AccessListValidationFail',
   Unknown = 'Unknown',
 }
 
@@ -16,6 +17,7 @@ export const getErrorCodeTextKey = (errorCode: string | undefined): string | und
     case ErrorCode.MissingDelegationAccess:
       return 'single_rights.missing_delegation_access';
     case ErrorCode.MissingSrrRightAccess:
+    case ErrorCode.AccessListValidationFail:
       return 'single_rights.missing_srr_right_access';
     case ErrorCode.Unknown:
       return 'single_rights.unknown';
@@ -39,6 +41,7 @@ export const prioritizeErrors = (errors: string[]): string[] => {
     ErrorCode.MissingRoleAccess,
     ErrorCode.MissingDelegationAccess,
     ErrorCode.MissingSrrRightAccess,
+    ErrorCode.AccessListValidationFail,
     ErrorCode.Unknown,
   ];
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
![image](https://github.com/user-attachments/assets/c321f5fd-3399-4d5f-8d3d-938b9d21fb65)


## Description
<!--- Describe your changes in detail -->
Added support for displaying error message when delegation check fails due to resources using access lists. The displayed message is the same as for srr-errors for A2-services

## Related Issue(s)
- #1123

![image](https://github.com/user-attachments/assets/fb0338fd-021c-47ee-b2de-3e6a7471584d)