### PR TITLE
Remove deploy to AT21

### DIFF
--- a/.github/workflows/deploy-at.yml
+++ b/.github/workflows/deploy-at.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        environment: [AT21, AT22, AT23, AT24]
+        environment: [AT22, AT23, AT24]
     uses: './.github/workflows/template-deploy-container.yml'
     secrets: inherit
     with:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
AT21 is no longer used for Altinn 2 - it is mainly a testing environment for other things than the altinn portal.
To minimize noise in the deploy pipeline, (and since our solution likely wouldn't work there anyway), deploy to AT21 is removed. Focus will only be on AT22, 23 and 24 going forward.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
