### PR TITLE
Fix formatting on dete resource snackbar

### DIFF
--- a/src/features/amUI/userRightsPage/SingleRightsSection/DeleteResourceButton.tsx
+++ b/src/features/amUI/userRightsPage/SingleRightsSection/DeleteResourceButton.tsx
@@ -28,12 +28,12 @@ export const DeleteResourceButton = ({
 
   const snackbar = (isSuccessful: boolean) => {
     const snackbarData = {
-      message: t(
-        isSuccessful
-          ? 'single_rights.delete_singleRight_success_message'
-          : 'single_rights.delete_singleRight_error_message',
-        { servicename: resource.title },
-      ),
+      message:
+        t(
+          isSuccessful
+            ? 'single_rights.delete_singleRight_success_message'
+            : 'single_rights.delete_singleRight_error_message',
+        ) + resource.title,
       variant: SnackbarMessageVariant.Default,
       duration: isSuccessful ? SnackbarDuration.normal : SnackbarDuration.infinite,
     };

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -219,8 +219,8 @@
     "popular_services": "Popular services",
     "give_new_single_right": "Give power of attorney to new service",
     "current_services_title": "Power of attorney to {{count}} services",
-    "delete_singleRight_success_message": "Access to service: {{servicename}} was successfully deleted",
-    "delete_singleRight_error_message": "Failed to delete access to service: {{servicename}}"
+    "delete_singleRight_success_message": "Deleted access to ",
+    "delete_singleRight_error_message": "Failed to delete access to "
   },
   "access_packages": {
     "current_access_packages_title": "Power of attorney to {{count}} access package(s)",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -220,8 +220,8 @@
     "popular_services": "Populære tjenester:",
     "give_new_single_right": "Gi fullmakt til ny tjeneste",
     "current_services_title": "Fullmakt til {{count}} tjenester",
-    "delete_singleRight_success_message": "Tilgang til tjenesten: {{servicename}} er slettet",
-    "delete_singleRight_error_message": "Kunne ikke slette tilgang til tjenesten {{servicename}}"
+    "delete_singleRight_success_message": "Slettet tilgang til ",
+    "delete_singleRight_error_message": "Kunne ikke slette tilgang til "
   },
   "access_packages": {
     "current_access_packages_title": "Fullmakt til {{count}} tilgangspakke(r)",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -217,8 +217,8 @@
     "popular_services": "Populære tenester:",
     "give_new_single_right": "Gi fullmakt til ny teneste",
     "current_services_title": "Fullmakt til {{count}} tenester",
-    "delete_singleRight_success_message": "Tilgang til tjenesten: {{servicename}} er slettet",
-    "delete_singleRight_error_message": "Kunne ikkje slette tilgang til tenesta {{servicename}}"
+    "delete_singleRight_success_message": "Slettet tilgang til ",
+    "delete_singleRight_error_message": "Kunne ikke slette tilgang til "
   },
   "access_packages": {
     "current_access_packages_title": "Fullmakt til {{count}} tilgangspakke(r)",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
![image](https://github.com/user-attachments/assets/79a166ba-9cd9-4824-9cf0-1f6311764750)

## Description
<!--- Describe your changes in detail -->
Formatting is no longer an issue when the resource name is not printed through i18next.
In the long run we should reevaluate whether or not to even use snackbars for feedback in the case of deletion. At least when the operation fails we should probably open the infomodal instead to display a more detailed description of why the operation failed

## Related Issue(s)
- https://github.com/Altinn/altinn-access-management-frontend/issues/1191

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
