### PR TITLE
Made TT02 and PROD env names uppercase in deploy workflow

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -19,7 +19,7 @@ jobs:
     uses: './.github/workflows/template-deploy-container.yml'
     secrets: inherit
     with:
-      environment: tt02
+      environment: TT02
       tag: ${{ github.ref_name }}
 
   playwright-release-to-tt02:
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         environment: [TT02]
-        project: [ e2e-tests ]
+        project: [e2e-tests]
     with:
       environment: ${{ matrix.environment }}
       project: ${{ matrix.project }}
@@ -41,5 +41,5 @@ jobs:
     uses: './.github/workflows/template-deploy-container.yml'
     secrets: inherit
     with:
-      environment: prod
+      environment: PROD
       tag: ${{ github.ref_name }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In an attempt at fixing an error with azure login in the deploy pipeline workflow, the env names for tt02 and prod has been made uppercase. The names of the AT-environments are already uppercase and deployment to these environments seem to be working.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
