### PR TITLE
Removed temporary PartyUuid cookie fix

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/HomeControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/HomeControllerTest.cs
@@ -48,11 +48,10 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.Equal(4, cookieHeaders.Count());
+            Assert.Equal(3, cookieHeaders.Count());
             Assert.StartsWith("AS-", cookieHeaders.ElementAt(0));
             Assert.StartsWith("XSR", cookieHeaders.ElementAt(1));
-            Assert.StartsWith("AltinnPartyUuid", cookieHeaders.ElementAt(2));
-            Assert.StartsWith("selectedLanguage", cookieHeaders.ElementAt(3));
+            Assert.StartsWith("selectedLanguage", cookieHeaders.ElementAt(2));
             Assert.StartsWith("deny", xframeHeaders.ElementAt(0));
             Assert.StartsWith("nosniff", contentTypeHeaders.ElementAt(0));
             Assert.StartsWith("0", xxsProtectionHeaders.ElementAt(0));
@@ -101,11 +100,10 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         
             // Verify that 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.Equal(4, cookieHeaders.Count());
+            Assert.Equal(3, cookieHeaders.Count());
             Assert.StartsWith("AS-", cookieHeaders.ElementAt(0));
             Assert.StartsWith("XSR", cookieHeaders.ElementAt(1));
-            Assert.StartsWith("AltinnPartyUuid", cookieHeaders.ElementAt(2));
-            Assert.StartsWith("selectedLanguage", cookieHeaders.ElementAt(3));
+            Assert.StartsWith("selectedLanguage", cookieHeaders.ElementAt(2));
         }
 
 

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/HomeController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/HomeController.cs
@@ -85,13 +85,6 @@ namespace Altinn.AccessManagement.UI.Controllers
                 });
             }
 
-            HttpContext.Response.Cookies.Append("AltinnPartyUuid", "cd35779b-b174-4ecc-bbef-ece13611be7f", new CookieOptions
-            {
-                Secure = true,
-                HttpOnly = false, // Make this cookie readable by Javascript.
-                SameSite = SameSiteMode.Strict
-            });
-
             if (await ShouldShowAppView())
             {
                 ViewBag.featureFlags = _featureFlags;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Removed temporary fix where HomeController generated hardcoded PartyUuid cookie value. This cookie is now instead generated by A2 on login

## Related Issue(s)
- https://github.com/Altinn/altinn-access-management-frontend/issues/1126

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
