### PR TITLE
Fix mapping of systemuser error messages

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Constants/Problem.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Constants/Problem.cs
@@ -16,5 +16,77 @@ namespace Altinn.AccessManagement.UI.Core.Constants
         /// </summary>
         public static ProblemDescriptor Reportee_Orgno_NotFound { get; }
             = _factory.Create(0, HttpStatusCode.BadRequest, "Can't resolve the Organisation Number from the logged in Reportee PartyId.");
+
+        /// <summary>
+        /// Gets a <see cref="ProblemDescriptor"/>.
+        /// </summary>
+        public static ProblemDescriptor Rights_NotFound_Or_NotDelegable { get; }
+            = _factory.Create(1, HttpStatusCode.BadRequest, "One or more Right not found or not delegable.");
+
+        /// <summary>
+        /// Gets a <see cref="ProblemDescriptor"/>.
+        /// </summary>
+        public static ProblemDescriptor Rights_FailedToDelegate { get; }
+            = _factory.Create(2, HttpStatusCode.BadRequest, "The Delegation failed.");
+
+        /// <summary>
+        /// Gets a <see cref="ProblemDescriptor"/>.
+        /// </summary>
+        public static ProblemDescriptor SystemUser_FailedToCreate { get; }
+            = _factory.Create(3, HttpStatusCode.BadRequest, "Failed to create the SystemUser.");
+
+        /// <summary>
+        /// Gets a <see cref="ProblemDescriptor"/>.
+        /// </summary>
+        public static ProblemDescriptor SystemUser_AlreadyExists { get; }
+            = _factory.Create(4, HttpStatusCode.BadRequest, "Failed to create new SystemUser, existing SystemUser tied to the given System-Id.");
+
+        /// <summary>
+        /// Gets a <see cref="ProblemDescriptor"/>.
+        /// </summary>
+        public static ProblemDescriptor Generic_EndOfMethod { get; }
+            = _factory.Create(5, HttpStatusCode.BadRequest, "Default error at the end of logic chain. Not supposed to appear.");
+
+        /// <summary>
+        /// Gets a <see cref="ProblemDescriptor"/>.
+        /// </summary>
+        public static ProblemDescriptor RequestNotFound { get; }
+            = _factory.Create(10, HttpStatusCode.NotFound, "The request was not found for given party.");
+
+        /// <summary>
+        /// Gets a <see cref="ProblemDescriptor"/>.
+        /// </summary>
+        public static ProblemDescriptor SystemIdNotFound { get; }
+            = _factory.Create(11, HttpStatusCode.NotFound, "The Id does not refer to a Registered System.");
+            
+        /// <summary>
+        /// Gets a <see cref="ProblemDescriptor"/>.
+        /// </summary>
+        public static ProblemDescriptor UnableToDoDelegationCheck { get; }
+            = _factory.Create(14, HttpStatusCode.InternalServerError, "DelegationCheck failed with unknown error.");
+
+        /// <summary>
+        /// Gets a <see cref="ProblemDescriptor"/>.
+        /// </summary>
+        public static ProblemDescriptor DelegationRightMissingRoleAccess { get; }
+            = _factory.Create(16, HttpStatusCode.Forbidden, "DelegationCheck failed with error: Has not access by a delegation of role in ER or Altinn.");
+
+        /// <summary>
+        /// Gets a <see cref="ProblemDescriptor"/>.
+        /// </summary>
+        public static ProblemDescriptor DelegationRightMissingDelegationAccess { get; }
+            = _factory.Create(18, HttpStatusCode.Forbidden, "DelegationCheck failed with error: Has not access by direct delegation.");
+
+        /// <summary>
+        /// Gets a <see cref="ProblemDescriptor"/>.
+        /// </summary>
+        public static ProblemDescriptor DelegationRightMissingSrrRightAccess { get; }
+            = _factory.Create(19, HttpStatusCode.Forbidden, "DelegationCheck failed with error: The service requires explicit access in SRR and the reportee is missing this.");
+
+        /// <summary>
+        /// Gets a <see cref="ProblemDescriptor"/>.
+        /// </summary>
+        public static ProblemDescriptor DelegationRightInsufficientAuthenticationLevel { get; }
+            = _factory.Create(20, HttpStatusCode.Forbidden, "DelegationCheck failed with error: The service requires explicit authentication level and the reportee is missing this.");
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Helpers/ProblemMapper.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Helpers/ProblemMapper.cs
@@ -1,0 +1,32 @@
+using Altinn.AccessManagement.UI.Core.Constants;
+using Altinn.Authorization.ProblemDetails;
+
+namespace Altinn.AccessManagement.UI.Core.Helpers
+{
+    /// <summary>
+    /// Problem descriptors for the Systemuser BFF.
+    /// </summary>
+    public static class ProblemMapper
+    {
+        /// <summary>
+        /// Map error codes from AUTH to AMUI error codes
+        /// </summary>
+        public static ProblemDescriptor MapToAuthUiError(string authErrorCode)
+        {
+            return authErrorCode switch
+            {
+                "AUTH-00001" => Problem.Rights_NotFound_Or_NotDelegable,
+                "AUTH-00002" => Problem.Rights_FailedToDelegate,
+                "AUTH-00003" => Problem.SystemUser_FailedToCreate,
+                "AUTH-00004" => Problem.SystemUser_AlreadyExists,
+                "AUTH-00011" => Problem.SystemIdNotFound,
+                "AUTH-00014" => Problem.UnableToDoDelegationCheck,
+                "AUTH-00016" => Problem.DelegationRightMissingRoleAccess,
+                "AUTH-00018" => Problem.DelegationRightMissingDelegationAccess,
+                "AUTH-00019" => Problem.DelegationRightMissingSrrRightAccess,
+                "AUTH-00020" => Problem.DelegationRightInsufficientAuthenticationLevel,
+                _ => Problem.Generic_EndOfMethod,
+            };
+        }
+    }
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/SystemUser/Frontend/SystemUserCreateResponseFE.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/SystemUser/Frontend/SystemUserCreateResponseFE.cs
@@ -1,0 +1,16 @@
+using System.Text.Json.Serialization;
+
+namespace Altinn.AccessManagement.UI.Core.Models.SystemUser.Frontend
+{
+    /// <summary>
+    /// The model of the System User response given in the CRUD API in SystemUserController
+    /// </summary>
+    public class SystemUserCreateResponseFE
+    {
+        /// <summary>
+        /// GUID created by the "real" Authentication Component
+        /// </summary>
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = string.Empty;
+    }
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/SystemUserChangeRequestClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/SystemUserChangeRequestClient.cs
@@ -63,7 +63,8 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
 
                 _logger.LogError("AccessManagement.UI // SystemUserChangeRequestClient // GetSystemUserChangeRequest // Unexpected HttpStatusCode: {StatusCode}\n {responseBody}", response.StatusCode, responseContent);
                 
-                return await response.Content.ReadFromJsonAsync<ProblemInstance>(cancellationToken);
+                AltinnProblemDetails problemDetails = await response.Content.ReadFromJsonAsync<AltinnProblemDetails>(cancellationToken);
+                return ProblemMapper.MapToAuthUiError(problemDetails?.ErrorCode.ToString());
             }
             catch (Exception ex)
             {
@@ -89,7 +90,8 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
 
                 _logger.LogError("AccessManagement.UI // SystemUserChangeRequestClient // ApproveSystemUserChangeRequest // Unexpected HttpStatusCode: {StatusCode}\n {responseBody}", response.StatusCode, responseContent);
                 
-                return await response.Content.ReadFromJsonAsync<ProblemInstance>(cancellationToken);
+                AltinnProblemDetails problemDetails = await response.Content.ReadFromJsonAsync<AltinnProblemDetails>(cancellationToken);
+                return ProblemMapper.MapToAuthUiError(problemDetails?.ErrorCode.ToString());
             }
             catch (Exception ex)
             {
@@ -115,7 +117,8 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
 
                 _logger.LogError("AccessManagement.UI // SystemUserChangeRequestClient // RejectSystemUserChangeRequest // Unexpected HttpStatusCode: {StatusCode}\n {responseBody}", response.StatusCode, responseContent);
                 
-                return await response.Content.ReadFromJsonAsync<ProblemInstance>(cancellationToken);
+                AltinnProblemDetails problemDetails = await response.Content.ReadFromJsonAsync<AltinnProblemDetails>(cancellationToken);
+                return ProblemMapper.MapToAuthUiError(problemDetails?.ErrorCode.ToString());
             }
             catch (Exception ex)
             {

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/SystemUserClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/SystemUserClient.cs
@@ -91,7 +91,8 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
 
                 _logger.LogError("AccessManagement.UI // SystemUserClient // CreateNewSystemUser // Unexpected HttpStatusCode: {StatusCode}\n {responseBody}", response.StatusCode, responseContent);
                 
-                return await response.Content.ReadFromJsonAsync<ProblemInstance>(cancellationToken);
+                AltinnProblemDetails problemDetails = await response.Content.ReadFromJsonAsync<AltinnProblemDetails>(cancellationToken);
+                return ProblemMapper.MapToAuthUiError(problemDetails?.ErrorCode.ToString());
             }
             catch (Exception ex)
             {

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/SystemUserRequestClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/SystemUserRequestClient.cs
@@ -63,7 +63,8 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
 
                 _logger.LogError("AccessManagement.UI // SystemUserRequestClient // GetSystemUserRequest // Unexpected HttpStatusCode: {StatusCode}\n {responseBody}", response.StatusCode, responseContent);
                 
-                return await response.Content.ReadFromJsonAsync<ProblemInstance>(cancellationToken);
+                AltinnProblemDetails problemDetails = await response.Content.ReadFromJsonAsync<AltinnProblemDetails>(cancellationToken);
+                return ProblemMapper.MapToAuthUiError(problemDetails?.ErrorCode.ToString());
             }
             catch (Exception ex)
             {
@@ -89,7 +90,8 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
 
                 _logger.LogError("AccessManagement.UI // SystemUserRequestClient // ApproveSystemUserRequest // Unexpected HttpStatusCode: {StatusCode}\n {responseBody}", response.StatusCode, responseContent);
                 
-                return await response.Content.ReadFromJsonAsync<ProblemInstance>(cancellationToken);
+                AltinnProblemDetails problemDetails = await response.Content.ReadFromJsonAsync<AltinnProblemDetails>(cancellationToken);
+                return ProblemMapper.MapToAuthUiError(problemDetails?.ErrorCode.ToString());
             }
             catch (Exception ex)
             {
@@ -115,7 +117,8 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
 
                 _logger.LogError("AccessManagement.UI // SystemUserRequestClient // RejectSystemUserRequest // Unexpected HttpStatusCode: {StatusCode}\n {responseBody}", response.StatusCode, responseContent);
                 
-                return await response.Content.ReadFromJsonAsync<ProblemInstance>(cancellationToken);
+                AltinnProblemDetails problemDetails = await response.Content.ReadFromJsonAsync<AltinnProblemDetails>(cancellationToken);
+                return ProblemMapper.MapToAuthUiError(problemDetails?.ErrorCode.ToString());
             }
             catch (Exception ex)
             {

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/SystemUserClientMock.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/SystemUserClientMock.cs
@@ -71,7 +71,7 @@ namespace Altinn.AccessManagement.UI.Mocks.Mocks
         internal static class TestErrors
         {
             private static readonly ProblemDescriptorFactory _factory
-                = ProblemDescriptorFactory.New("AUTH");
+                = ProblemDescriptorFactory.New("AMUI");
 
             public static ProblemDescriptor SystemNotFound { get; }
                 = _factory.Create(11, HttpStatusCode.NotFound, "System not found");

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/SystemUserControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/SystemUserControllerTest.cs
@@ -1,7 +1,6 @@
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
-using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
 using Altinn.AccessManagement.UI.Controllers;
@@ -155,11 +154,11 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
 
             // Act
             HttpResponseMessage httpResponse = await _client.PostAsync($"accessmanagement/api/v1/systemuser/{partyId}", content);
-            string actualResponse = await httpResponse.Content.ReadFromJsonAsync<string>();
+            SystemUserCreateResponseFE actualResponse = await httpResponse.Content.ReadFromJsonAsync<SystemUserCreateResponseFE>();
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, httpResponse.StatusCode);
-            Assert.Equal(expectedResponse, actualResponse);
+            Assert.Equal(expectedResponse, actualResponse.Id);
         }
 
         /// <summary>
@@ -171,7 +170,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         {
             // Arrange
             int partyId = 51329012;
-            string expectedResponse = "AUTH-00011";
+            string expectedResponse = "AMUI-00011";
             NewSystemUserRequest dto = new NewSystemUserRequest
             {
                 IntegrationTitle = "NotFound",

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Helpers/ProblemMapperTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Helpers/ProblemMapperTest.cs
@@ -66,8 +66,8 @@ namespace Altinn.AccessManagement.UI.Tests.Helpers
         public void MapToAuthUiError_ShouldReturnError11()
         {
             // Arrange
-            string errorCode = "AUTH-000011";
-            string expectedErrorCode = "AMUI-000011";
+            string errorCode = "AUTH-00011";
+            string expectedErrorCode = "AMUI-00011";
 
             // Act
             ProblemDescriptor actualError = ProblemMapper.MapToAuthUiError(errorCode);
@@ -80,8 +80,8 @@ namespace Altinn.AccessManagement.UI.Tests.Helpers
         public void MapToAuthUiError_ShouldReturnError14()
         {
             // Arrange
-            string errorCode = "AUTH-000014";
-            string expectedErrorCode = "AMUI-000014";
+            string errorCode = "AUTH-00014";
+            string expectedErrorCode = "AMUI-00014";
 
             // Act
             ProblemDescriptor actualError = ProblemMapper.MapToAuthUiError(errorCode);
@@ -94,8 +94,8 @@ namespace Altinn.AccessManagement.UI.Tests.Helpers
         public void MapToAuthUiError_ShouldReturnError16()
         {
             // Arrange
-            string errorCode = "AUTH-000016";
-            string expectedErrorCode = "AMUI-000016";
+            string errorCode = "AUTH-00016";
+            string expectedErrorCode = "AMUI-00016";
 
             // Act
             ProblemDescriptor actualError = ProblemMapper.MapToAuthUiError(errorCode);
@@ -108,8 +108,8 @@ namespace Altinn.AccessManagement.UI.Tests.Helpers
         public void MapToAuthUiError_ShouldReturnError18()
         {
             // Arrange
-            string errorCode = "AUTH-000018";
-            string expectedErrorCode = "AMUI-000018";
+            string errorCode = "AUTH-00018";
+            string expectedErrorCode = "AMUI-00018";
 
             // Act
             ProblemDescriptor actualError = ProblemMapper.MapToAuthUiError(errorCode);
@@ -122,8 +122,8 @@ namespace Altinn.AccessManagement.UI.Tests.Helpers
         public void MapToAuthUiError_ShouldReturnError19()
         {
             // Arrange
-            string errorCode = "AUTH-000019";
-            string expectedErrorCode = "AMUI-000019";
+            string errorCode = "AUTH-00019";
+            string expectedErrorCode = "AMUI-00019";
 
             // Act
             ProblemDescriptor actualError = ProblemMapper.MapToAuthUiError(errorCode);
@@ -136,8 +136,8 @@ namespace Altinn.AccessManagement.UI.Tests.Helpers
         public void MapToAuthUiError_ShouldReturnError20()
         {
             // Arrange
-            string errorCode = "AUTH-000020";
-            string expectedErrorCode = "AMUI-000020";
+            string errorCode = "AUTH-00020";
+            string expectedErrorCode = "AMUI-00020";
 
             // Act
             ProblemDescriptor actualError = ProblemMapper.MapToAuthUiError(errorCode);

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Helpers/ProblemMapperTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Helpers/ProblemMapperTest.cs
@@ -1,0 +1,163 @@
+using Altinn.AccessManagement.UI.Core.Helpers;
+using Altinn.Authorization.ProblemDetails;
+
+namespace Altinn.AccessManagement.UI.Tests.Helpers
+{
+    [Collection("ProblemMapperTests")]
+    public class ProblemMapperTests
+    {
+        [Fact]
+        public void MapToAuthUiError_ShouldReturnError1()
+        {
+            // Arrange
+            string errorCode = "AUTH-00001";
+            string expectedErrorCode = "AMUI-00001";
+
+            // Act
+            ProblemDescriptor actualError = ProblemMapper.MapToAuthUiError(errorCode);
+
+            // Assert
+            Assert.Equal(expectedErrorCode, actualError.ErrorCode.ToString());
+        }
+
+        [Fact]
+        public void MapToAuthUiError_ShouldReturnError2()
+        {
+            // Arrange
+            string errorCode = "AUTH-00002";
+            string expectedErrorCode = "AMUI-00002";
+
+            // Act
+            ProblemDescriptor actualError = ProblemMapper.MapToAuthUiError(errorCode);
+
+            // Assert
+            Assert.Equal(expectedErrorCode, actualError.ErrorCode.ToString());
+        }
+        
+        [Fact]
+        public void MapToAuthUiError_ShouldReturnError3()
+        {
+            // Arrange
+            string errorCode = "AUTH-00003";
+            string expectedErrorCode = "AMUI-00003";
+
+            // Act
+            ProblemDescriptor actualError = ProblemMapper.MapToAuthUiError(errorCode);
+
+            // Assert
+            Assert.Equal(expectedErrorCode, actualError.ErrorCode.ToString());
+        }
+
+        [Fact]
+        public void MapToAuthUiError_ShouldReturnError4()
+        {
+            // Arrange
+            string errorCode = "AUTH-00004";
+            string expectedErrorCode = "AMUI-00004";
+
+            // Act
+            ProblemDescriptor actualError = ProblemMapper.MapToAuthUiError(errorCode);
+
+            // Assert
+            Assert.Equal(expectedErrorCode, actualError.ErrorCode.ToString());
+        }
+
+        [Fact]
+        public void MapToAuthUiError_ShouldReturnError11()
+        {
+            // Arrange
+            string errorCode = "AUTH-000011";
+            string expectedErrorCode = "AMUI-000011";
+
+            // Act
+            ProblemDescriptor actualError = ProblemMapper.MapToAuthUiError(errorCode);
+
+            // Assert
+            Assert.Equal(expectedErrorCode, actualError.ErrorCode.ToString());
+        }
+
+        [Fact]
+        public void MapToAuthUiError_ShouldReturnError14()
+        {
+            // Arrange
+            string errorCode = "AUTH-000014";
+            string expectedErrorCode = "AMUI-000014";
+
+            // Act
+            ProblemDescriptor actualError = ProblemMapper.MapToAuthUiError(errorCode);
+
+            // Assert
+            Assert.Equal(expectedErrorCode, actualError.ErrorCode.ToString());
+        }
+
+        [Fact]
+        public void MapToAuthUiError_ShouldReturnError16()
+        {
+            // Arrange
+            string errorCode = "AUTH-000016";
+            string expectedErrorCode = "AMUI-000016";
+
+            // Act
+            ProblemDescriptor actualError = ProblemMapper.MapToAuthUiError(errorCode);
+
+            // Assert
+            Assert.Equal(expectedErrorCode, actualError.ErrorCode.ToString());
+        }
+
+        [Fact]
+        public void MapToAuthUiError_ShouldReturnError18()
+        {
+            // Arrange
+            string errorCode = "AUTH-000018";
+            string expectedErrorCode = "AMUI-000018";
+
+            // Act
+            ProblemDescriptor actualError = ProblemMapper.MapToAuthUiError(errorCode);
+
+            // Assert
+            Assert.Equal(expectedErrorCode, actualError.ErrorCode.ToString());
+        }
+
+        [Fact]
+        public void MapToAuthUiError_ShouldReturnError19()
+        {
+            // Arrange
+            string errorCode = "AUTH-000019";
+            string expectedErrorCode = "AMUI-000019";
+
+            // Act
+            ProblemDescriptor actualError = ProblemMapper.MapToAuthUiError(errorCode);
+
+            // Assert
+            Assert.Equal(expectedErrorCode, actualError.ErrorCode.ToString());
+        }
+
+        [Fact]
+        public void MapToAuthUiError_ShouldReturnError20()
+        {
+            // Arrange
+            string errorCode = "AUTH-000020";
+            string expectedErrorCode = "AMUI-000020";
+
+            // Act
+            ProblemDescriptor actualError = ProblemMapper.MapToAuthUiError(errorCode);
+
+            // Assert
+            Assert.Equal(expectedErrorCode, actualError.ErrorCode.ToString());
+        }
+
+        [Fact]
+        public void MapToAuthUiError_ShouldGenericError()
+        {
+            // Arrange
+            string errorCode = "AUTH-HEHE?";
+            string expectedErrorCode = "AMUI-00005";
+
+            // Act
+            ProblemDescriptor actualError = ProblemMapper.MapToAuthUiError(errorCode);
+
+            // Assert
+            Assert.Equal(expectedErrorCode, actualError.ErrorCode.ToString());
+        }
+    }
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/SystemUserController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/SystemUserController.cs
@@ -103,7 +103,11 @@ namespace Altinn.AccessManagement.UI.Controllers
                 return systemUserResult.Problem.ToActionResult(); 
             }
 
-            return Ok(systemUserResult.Value.Id);
+            SystemUserCreateResponseFE createResponse = new SystemUserCreateResponseFE()
+            {
+                Id = systemUserResult.Value.Id,
+            };
+            return Ok(createResponse);
         }
 
         /// <summary>

--- a/src/features/amUI/systemUser/CreateSystemUserPage/RightsIncluded.tsx
+++ b/src/features/amUI/systemUser/CreateSystemUserPage/RightsIncluded.tsx
@@ -48,9 +48,9 @@ export const RightsIncluded = ({ selectedSystem, onNavigateBack }: RightsInclude
 
       postNewSystemUser(postObjekt)
         .unwrap()
-        .then((newSystemUserId: string) => {
+        .then((newSystemUser: { id: string }) => {
           navigate(`/${SystemUserPath.SystemUser}/${SystemUserPath.Overview}`, {
-            state: { createdId: newSystemUserId },
+            state: { createdId: newSystemUser.id },
           });
         });
     }

--- a/src/features/amUI/systemUser/components/DelegationCheckError/DelegationCheckError.tsx
+++ b/src/features/amUI/systemUser/components/DelegationCheckError/DelegationCheckError.tsx
@@ -21,26 +21,28 @@ export const DelegationCheckError = ({
 
   const getErrorMessage = (): string => {
     switch (error?.data?.code) {
-      case 'AUTH-00001':
-        return t('delegation_errors.01_rights_not_found_or_not_delegable');
-      case 'AUTH-00002':
-        return t('delegation_errors.02_rights_failed_to_delegate');
-      case 'AUTH-00003':
-        return t('delegation_errors.03_systemuser_failed_to_create');
-      case 'AUTH-00004':
-        return t('delegation_errors.04_system_user_already_exists');
-      case 'AUTH-00011':
-        return t('delegation_errors.11_system_not_found');
-      case 'AUTH-00014':
-        return t('delegation_errors.14_unable_to_do_delegation_check');
-      case 'AUTH-00016':
-        return t('delegation_errors.16_delegation_right_missing_role_access');
-      case 'AUTH-00018':
-        return t('delegation_errors.18_delegation_right_missing_delegation_access');
-      case 'AUTH-00019':
-        return t('delegation_errors.19_delegation_right_missing_srr_right_access');
-      case 'AUTH-00020':
-        return t('delegation_errors.20_delegation_right_insufficient_systemuserication_level');
+      case 'AMUI-00001':
+        return t('systemuser_delegation_errors.01_rights_not_found_or_not_delegable');
+      case 'AMUI-00002':
+        return t('systemuser_delegation_errors.02_rights_failed_to_delegate');
+      case 'AMUI-00003':
+        return t('systemuser_delegation_errors.03_systemuser_failed_to_create');
+      case 'AMUI-00004':
+        return t('systemuser_delegation_errors.04_system_user_already_exists');
+      case 'AMUI-00011':
+        return t('systemuser_delegation_errors.11_system_not_found');
+      case 'AMUI-00014':
+        return t('systemuser_delegation_errors.14_unable_to_do_delegation_check');
+      case 'AMUI-00016':
+        return t('systemuser_delegation_errors.16_delegation_right_missing_role_access');
+      case 'AMUI-00018':
+        return t('systemuser_delegation_errors.18_delegation_right_missing_delegation_access');
+      case 'AMUI-00019':
+        return t('systemuser_delegation_errors.19_delegation_right_missing_srr_right_access');
+      case 'AMUI-00020':
+        return t(
+          'systemuser_delegation_errors.20_delegation_right_insufficient_systemuserication_level',
+        );
       default:
         return t(defaultError);
     }

--- a/src/rtk/features/systemUserApi.ts
+++ b/src/rtk/features/systemUserApi.ts
@@ -47,12 +47,11 @@ export const systemUserApi = createApi({
     getSystemUser: builder.query<SystemUser, { partyId: string; systemUserId: string }>({
       query: ({ partyId, systemUserId }) => `systemuser/${partyId}/${systemUserId}`,
     }),
-    createSystemUser: builder.mutation<string, NewSystemUserRequest>({
+    createSystemUser: builder.mutation<{ id: string }, NewSystemUserRequest>({
       query: ({ partyId, ...systemUser }) => ({
         url: `systemuser/${partyId}`,
         method: 'POST',
         body: systemUser,
-        responseHandler: 'text',
       }),
       invalidatesTags: [Tags.SystemUsers],
     }),
@@ -112,6 +111,10 @@ export const systemUserApi = createApi({
   }),
 });
 
+const apiWithTag = systemUserApi.enhanceEndpoints({
+  addTagTypes: [Tags.SystemUsers],
+});
+
 export const {
   useCreateSystemUserMutation,
   useDeleteSystemuserMutation,
@@ -126,6 +129,6 @@ export const {
   useGetChangeRequestQuery,
   useApproveChangeRequestMutation,
   useRejectChangeRequestMutation,
-} = systemUserApi;
+} = apiWithTag;
 
-export const { endpoints, reducerPath, reducer, middleware } = systemUserApi;
+export const { endpoints, reducerPath, reducer, middleware } = apiWithTag;


### PR DESCRIPTION
## Description
- Add mapper utils function to map `AUTH` error messages for systemuser to `AMUI` error messages
- Fix missing tag in rtk API

## Related Issue(s)
- #1237

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
