### PR TITLE
Linking in header and footer

### DIFF
--- a/src/features/amUI/common/PageLayoutWrapper/PageLayoutWrapper.tsx
+++ b/src/features/amUI/common/PageLayoutWrapper/PageLayoutWrapper.tsx
@@ -5,6 +5,7 @@ import { HandshakeIcon, PersonGroupIcon, InboxIcon, TenancyIcon } from '@navikt/
 
 import { useGetReporteeQuery } from '@/rtk/features/userInfoApi';
 import { amUIPath, SystemUserPath } from '@/routes/paths';
+import { getAltinnStartPageUrl } from '@/resources/utils/pathUtils';
 
 interface PageLayoutWrapperProps {
   children?: React.ReactNode;
@@ -19,6 +20,7 @@ export const PageLayoutWrapper = ({ children }: PageLayoutWrapperProps): React.R
         color={'neutral'}
         theme='subtle'
         header={{
+          logo: { href: getAltinnStartPageUrl(), title: 'Altinn' },
           currentAccount: {
             name: reportee?.name || '',
             type: reportee?.type === 'Organization' ? 'company' : 'person',
@@ -99,24 +101,11 @@ export const PageLayoutWrapper = ({ children }: PageLayoutWrapperProps): React.R
           address: 'Postboks 1382 Vika, 0114 Oslo.',
           address2: 'Org.nr. 991 825 827',
           menu: {
-            items: [
-              {
-                id: '1',
-                title: 'Om Altinn',
-              },
-              {
-                id: '2',
-                title: 'Driftsmeldinger',
-              },
-              {
-                id: '3',
-                title: 'Personvern',
-              },
-              {
-                id: '4',
-                title: 'Tilgjengelighet',
-              },
-            ],
+            items: footerLinks.map((link) => ({
+              href: link.href,
+              id: link.resourceId,
+              title: t(link.resourceId),
+            })),
           },
         }}
       >
@@ -125,3 +114,22 @@ export const PageLayoutWrapper = ({ children }: PageLayoutWrapperProps): React.R
     </RootProvider>
   );
 };
+
+const footerLinks = [
+  {
+    href: 'https://info.altinn.no/om-altinn/',
+    resourceId: 'footer.about_altinn',
+  },
+  {
+    href: 'https://info.altinn.no/om-altinn/driftsmeldinger/',
+    resourceId: 'footer.service_messages',
+  },
+  {
+    href: 'https://info.altinn.no/om-altinn/personvern/',
+    resourceId: 'footer.privacy_policy',
+  },
+  {
+    href: 'https://info.altinn.no/om-altinn/tilgjengelighet/',
+    resourceId: 'footer.accessibility',
+  },
+];

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -81,6 +81,12 @@
     "change-label": "Change",
     "back-label": "Back"
   },
+  "footer": {
+    "about_altinn": "About Altinn",
+    "service_messages": "Service messages",
+    "privacy_policy": "Privacy policy",
+    "accessibility": "Accessibility"
+  },
   "sidebar": {
     "users": "Users",
     "reportees": "Our access to other companies",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -93,6 +93,12 @@
     "change-label": "Bytt",
     "back-label": "Tilbake"
   },
+  "footer": {
+    "about_altinn": "Om Altinn",
+    "service_messages": "Driftsmeldinger",
+    "privacy_policy": "Personvern",
+    "accessibility": "Tilgjengelighet"
+  },
   "sidebar": {
     "users": "Brukere",
     "reportees": "Våre tilganger hos andre",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -78,6 +78,12 @@
     "change-label": "Bytt",
     "back-label": "Tilbake"
   },
+  "footer": {
+    "about_altinn": "Om Altinn",
+    "service_messages": "Driftsmeldingar",
+    "privacy_policy": "Personvern",
+    "accessibility": "Tilgjengeligheit"
+  },
   "sidebar": {
     "users": "Brukere",
     "reportees": "Våre tilganger hos andre",

--- a/src/resources/utils/pathUtils.tsx
+++ b/src/resources/utils/pathUtils.tsx
@@ -1,0 +1,49 @@
+enum Environment {
+  TT02 = 'tt02',
+  PROD = 'prod',
+  AT21 = 'at21',
+  AT22 = 'at22',
+  AT23 = 'at23',
+  AT24 = 'at24',
+}
+
+export const getEnv = () => {
+  const host = window.location.host;
+  if (host.includes('tt02')) {
+    return Environment.TT02;
+  }
+  if (host.includes('at21')) {
+    return Environment.AT21;
+  }
+  if (host.includes('at22')) {
+    return Environment.AT22;
+  }
+  if (host.includes('at23')) {
+    return Environment.AT23;
+  }
+  if (host.includes('at24')) {
+    return Environment.AT24;
+  }
+  return Environment.PROD;
+};
+
+export const getAltinnStartPageUrl = () => {
+  const env = getEnv();
+
+  switch (env) {
+    case Environment.TT02:
+      return 'https://info.tt02.altinn.no/';
+    case Environment.AT21:
+      return 'https://info.at21.altinn.cloud/';
+    case Environment.AT22:
+      return 'https://info.at22.altinn.cloud/';
+    case Environment.AT23:
+      return 'https://info.at23.altinn.cloud/';
+    case Environment.AT24:
+      return 'https://info.at24.altinn.cloud/';
+    case Environment.PROD:
+      return 'https://info.altinn.no/';
+    default:
+      return 'https://info.altinn.no/';
+  }
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Altinn logo now links to starting page in A2
  - Added utils function for getting the env-specific start page url, though I am not sure how to or if it is worth writing tests for this with how env specific it is.
- Links in footer link to various info pages - the same as in Arbeidsflate

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/375
- https://github.com/Altinn/altinn-authorization-tmp/issues/378

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
