### PR TITLE
Refactor: replace react-router-dom package with react-router

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -14,7 +14,7 @@ import no_nn from '../src/localizations/no_nn.json';
 import en from '../src/localizations/en.json';
 import { Suspense, useEffect } from 'react';
 import React from 'react';
-import { Router } from 'react-router-dom';
+import { Router } from 'react-router';
 
 import { worker } from '../.mock/browser';
 worker.start();

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "react-dom": "^18.3.1",
     "react-i18next": "^15.0.0",
     "react-redux": "^9.0.0",
-    "react-router-dom": "^7.0.0"
+    "react-router": "^7.2.0"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.10.1",

--- a/src/components/CollectionBar/CollectionBar.tsx
+++ b/src/components/CollectionBar/CollectionBar.tsx
@@ -7,7 +7,7 @@ import {
 } from '@navikt/aksel-icons';
 import { Button, Paragraph } from '@digdir/designsystemet-react';
 import cn from 'classnames';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { ActionBar, type ActionBarProps } from '../ActionBar';
 

--- a/src/components/RestartPrompter/RestartPrompter.tsx
+++ b/src/components/RestartPrompter/RestartPrompter.tsx
@@ -2,7 +2,7 @@ import type { AlertProps } from '@digdir/designsystemet-react';
 import { Alert, Button, Heading, Paragraph } from '@digdir/designsystemet-react';
 import * as React from 'react';
 import cn from 'classnames';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useTranslation } from 'react-i18next';
 
 import classes from './RestartPrompter.module.css';

--- a/src/features/amUI/common/PageLayoutWrapper/PageLayoutWrapper.tsx
+++ b/src/features/amUI/common/PageLayoutWrapper/PageLayoutWrapper.tsx
@@ -1,6 +1,6 @@
 import { Layout, RootProvider } from '@altinn/altinn-components';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { HandshakeIcon, PersonGroupIcon, InboxIcon, TenancyIcon } from '@navikt/aksel-icons';
 
 import { useGetReporteeQuery } from '@/rtk/features/userInfoApi';

--- a/src/features/amUI/common/UserList/UserListItem.tsx
+++ b/src/features/amUI/common/UserList/UserListItem.tsx
@@ -2,7 +2,7 @@ import type { ListItemProps } from '@altinn/altinn-components';
 import { ListItem } from '@altinn/altinn-components';
 import { useEffect, useState } from 'react';
 import cn from 'classnames';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useTranslation } from 'react-i18next';
 
 import classes from './UserList.module.css';

--- a/src/features/amUI/reporteeRightsPage/ReporteeRightsPage.tsx
+++ b/src/features/amUI/reporteeRightsPage/ReporteeRightsPage.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import { PageContainer } from '../common/PageContainer/PageContainer';
 import { PageLayoutWrapper } from '../common/PageLayoutWrapper';

--- a/src/features/amUI/systemUser/CreateSystemUserPage/RightsIncluded.tsx
+++ b/src/features/amUI/systemUser/CreateSystemUserPage/RightsIncluded.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Alert, Button, Spinner } from '@digdir/designsystemet-react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router';
 
 import {
   useCreateSystemUserMutation,

--- a/src/features/amUI/systemUser/CreateSystemUserPage/SelectRegisteredSystem.tsx
+++ b/src/features/amUI/systemUser/CreateSystemUserPage/SelectRegisteredSystem.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Alert, Button, Combobox, Heading, Paragraph } from '@digdir/designsystemet-react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router';
 
 import { useGetRegisteredSystemsQuery } from '@/rtk/features/systemUserApi';
 import { SystemUserPath } from '@/routes/paths';

--- a/src/features/amUI/systemUser/SystemUserChangeRequestPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserChangeRequestPage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation, Trans } from 'react-i18next';
-import { useSearchParams, useNavigate } from 'react-router-dom';
+import { useSearchParams, useNavigate } from 'react-router';
 import { Alert, Spinner, Button, Heading, Paragraph } from '@digdir/designsystemet-react';
 
 import {

--- a/src/features/amUI/systemUser/SystemUserDetailPage/SystemUserDetailsPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserDetailPage/SystemUserDetailsPage.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Button, Alert, Spinner, Paragraph, Popover } from '@digdir/designsystemet-react';
 import { TrashIcon } from '@navikt/aksel-icons';
 import { useTranslation } from 'react-i18next';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import { useDeleteSystemuserMutation, useGetSystemUserQuery } from '@/rtk/features/systemUserApi';
 import { getCookie } from '@/resources/Cookie/CookieMethods';

--- a/src/features/amUI/systemUser/SystemUserRequestPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserRequestPage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation, Trans } from 'react-i18next';
-import { useSearchParams, useNavigate } from 'react-router-dom';
+import { useSearchParams, useNavigate } from 'react-router';
 import { Alert, Spinner, Button, Heading, Paragraph } from '@digdir/designsystemet-react';
 
 import {

--- a/src/features/amUI/systemUser/SystemUsersOverviewPage/SystemUserOverviewPage.tsx
+++ b/src/features/amUI/systemUser/SystemUsersOverviewPage/SystemUserOverviewPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate, Link, useLocation } from 'react-router-dom';
+import { useNavigate, Link, useLocation } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { Alert, Button, Heading, Paragraph, Spinner, Tabs } from '@digdir/designsystemet-react';
 import { PlusIcon, TenancyIcon } from '@navikt/aksel-icons';

--- a/src/features/amUI/userRightsPage/AccessPackageSection/AccessPackageSection.tsx
+++ b/src/features/amUI/userRightsPage/AccessPackageSection/AccessPackageSection.tsx
@@ -1,7 +1,7 @@
 import { Heading } from '@digdir/designsystemet-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { useGetPartyByUUIDQuery } from '@/rtk/features/lookupApi';
 

--- a/src/features/amUI/userRightsPage/DelegationModal/SingleRights/ResourceInfo.tsx
+++ b/src/features/amUI/userRightsPage/DelegationModal/SingleRights/ResourceInfo.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Alert, Button, Chip, Heading, Paragraph } from '@digdir/designsystemet-react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { Avatar, Badge } from '@altinn/altinn-components';
 
 import type {

--- a/src/features/amUI/userRightsPage/DelegationModal/SingleRights/ResourceSearch.tsx
+++ b/src/features/amUI/userRightsPage/DelegationModal/SingleRights/ResourceSearch.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Alert, Chip, Heading, Paragraph, Search, Spinner } from '@digdir/designsystemet-react';
 import { Trans, useTranslation } from 'react-i18next';
 import { FilterIcon } from '@navikt/aksel-icons';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { ResourceListItem } from '@altinn/altinn-components';
 
 import type { ServiceResource } from '@/rtk/features/singleRights/singleRightsApi';

--- a/src/features/amUI/userRightsPage/RoleSection/RoleSection.tsx
+++ b/src/features/amUI/userRightsPage/RoleSection/RoleSection.tsx
@@ -1,4 +1,4 @@
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { Paragraph, Heading } from '@digdir/designsystemet-react';
 import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/features/amUI/userRightsPage/SingleRightsSection/SingleRightsSection.tsx
+++ b/src/features/amUI/userRightsPage/SingleRightsSection/SingleRightsSection.tsx
@@ -1,7 +1,7 @@
 import { Heading } from '@digdir/designsystemet-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { useGetSingleRightsForRightholderQuery } from '@/rtk/features/singleRights/singleRightsApi';
 import { getCookie } from '@/resources/Cookie/CookieMethods';

--- a/src/features/amUI/userRightsPage/UserRightsPage.tsx
+++ b/src/features/amUI/userRightsPage/UserRightsPage.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Spinner } from '@digdir/designsystemet-react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import { useDocumentTitle } from '@/resources/hooks/useDocumentTitle';
 import { PageWrapper } from '@/components';

--- a/src/features/amUI/users/UsersList.tsx
+++ b/src/features/amUI/users/UsersList.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 import { Heading, Search } from '@digdir/designsystemet-react';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 import type { User } from '@/rtk/features/userInfoApi';
 import { useGetRightHoldersQuery, useGetUserInfoQuery } from '@/rtk/features/userInfoApi';

--- a/src/features/apiDelegation/components/OverviewPageContent/OverviewPageContent.tsx
+++ b/src/features/apiDelegation/components/OverviewPageContent/OverviewPageContent.tsx
@@ -1,7 +1,7 @@
 import { Alert, Button, Heading, Paragraph, Spinner } from '@digdir/designsystemet-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router';
 import * as React from 'react';
 import { PlusIcon, PencilIcon, XMarkOctagonIcon } from '@navikt/aksel-icons';
 import { useDispatch } from 'react-redux';

--- a/src/features/apiDelegation/offered/ChooseApiPage/ChooseApiPage.tsx
+++ b/src/features/apiDelegation/offered/ChooseApiPage/ChooseApiPage.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FilterIcon } from '@navikt/aksel-icons';
 import * as React from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router';
 
 import { Page, PageHeader, PageContent, PageContainer } from '@/components';
 import { useAppDispatch, useAppSelector } from '@/rtk/app/hooks';

--- a/src/features/apiDelegation/offered/ChooseOrgPage/ChooseOrgPage.tsx
+++ b/src/features/apiDelegation/offered/ChooseOrgPage/ChooseOrgPage.tsx
@@ -2,7 +2,7 @@ import { Button, Spinner, Search, Heading } from '@digdir/designsystemet-react';
 import { useTranslation } from 'react-i18next';
 import * as React from 'react';
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import cn from 'classnames';
 
 import { Page, PageHeader, PageContent, PageContainer, RestartPrompter } from '@/components';

--- a/src/features/apiDelegation/offered/ConfirmationPage/ConfirmationPage.tsx
+++ b/src/features/apiDelegation/offered/ConfirmationPage/ConfirmationPage.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import * as React from 'react';
 import { Alert, Button, Heading, Paragraph, Spinner } from '@digdir/designsystemet-react';

--- a/src/features/singleRight/delegate/ChooseRightsPage/ChooseRightsPage.tsx
+++ b/src/features/singleRight/delegate/ChooseRightsPage/ChooseRightsPage.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { PersonIcon } from '@navikt/aksel-icons';
 import { Button, Paragraph, Popover } from '@digdir/designsystemet-react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router';
 import { useEffect, useState } from 'react';
 
 import {

--- a/src/features/singleRight/delegate/ChooseServicePage/ChooseServicePage.tsx
+++ b/src/features/singleRight/delegate/ChooseServicePage/ChooseServicePage.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { PersonIcon } from '@navikt/aksel-icons';
 import { useTranslation } from 'react-i18next';
 import { Paragraph } from '@digdir/designsystemet-react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router';
 import { useLayoutEffect } from 'react';
 
 import { Page, PageHeader, PageContent, PageContainer } from '@/components';

--- a/src/features/singleRight/delegate/ReceiptPage/ReceiptPage.tsx
+++ b/src/features/singleRight/delegate/ReceiptPage/ReceiptPage.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@digdir/designsystemet-react';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router';
 import { PersonIcon } from '@navikt/aksel-icons';
 import { useEffect } from 'react';
 

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -8,15 +8,11 @@ import '@altinn/altinn-components/dist/global.css';
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { Provider } from 'react-redux';
-import { RouterProvider } from 'react-router-dom';
+import { RouterProvider } from 'react-router';
 import { initReactI18next } from 'react-i18next';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { use } from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
-
-import { ReloadAlert } from '@/components/ReloadAlert/ReloadAlert';
-import { RefreshToken } from '@/resources/Token/RefreshToken';
-import { Router } from '@/routes/Router/Router';
 
 import { getConfig } from '../config';
 
@@ -24,6 +20,10 @@ import no_nb from './localizations/no_nb.json';
 import no_nn from './localizations/no_nn.json';
 import en from './localizations/en.json';
 import store from './rtk/app/store';
+
+import { Router } from '@/routes/Router/Router';
+import { RefreshToken } from '@/resources/Token/RefreshToken';
+import { ReloadAlert } from '@/components/ReloadAlert/ReloadAlert';
 
 /**
  * Special behaviour for react-query in dev environment

--- a/src/routes/Router/Router.tsx
+++ b/src/routes/Router/Router.tsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter, createRoutesFromElements, Route } from 'react-router-dom';
+import { createBrowserRouter, createRoutesFromElements, Route } from 'react-router';
 import * as React from 'react';
 
 import { ChooseApiPage } from '@/features/apiDelegation/offered/ChooseApiPage';

--- a/src/sites/ErrorPage/ErrorPage.tsx
+++ b/src/sites/ErrorPage/ErrorPage.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useTranslation } from 'react-i18next';
-import { useRouteError } from 'react-router-dom';
+import { useRouteError } from 'react-router';
 import * as React from 'react';
 import { Paragraph } from '@digdir/designsystemet-react';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3281,7 +3281,7 @@ __metadata:
     react-dom: "npm:^18.3.1"
     react-i18next: "npm:^15.0.0"
     react-redux: "npm:^9.0.0"
-    react-router-dom: "npm:^7.0.0"
+    react-router: "npm:^7.2.0"
     redux-logger: "npm:^3.0.6"
     storybook: "npm:8.5.6"
     typescript: "npm:5.7.3"
@@ -9453,21 +9453,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router-dom@npm:^7.0.0":
-  version: 7.1.5
-  resolution: "react-router-dom@npm:7.1.5"
-  dependencies:
-    react-router: "npm:7.1.5"
-  peerDependencies:
-    react: ">=18"
-    react-dom: ">=18"
-  checksum: 10/caf34daec7ef6fdd4043dd56295fe6d5de4a2bfbbd650897b8cde23571a51f73f2b0ef2681a55f46ef524dc7e360b1f6c55d5b5bb1875196b48917042b52d82d
-  languageName: node
-  linkType: hard
-
-"react-router@npm:7.1.5":
-  version: 7.1.5
-  resolution: "react-router@npm:7.1.5"
+"react-router@npm:^7.2.0":
+  version: 7.2.0
+  resolution: "react-router@npm:7.2.0"
   dependencies:
     "@types/cookie": "npm:^0.6.0"
     cookie: "npm:^1.0.1"
@@ -9479,7 +9467,7 @@ __metadata:
   peerDependenciesMeta:
     react-dom:
       optional: true
-  checksum: 10/3802ff0e0419aa53c1824b1ad2ebac6facb918306c67ff64ed86b5cbc49197c15f077b84e425f57beb24dd01cd5818a100da5269b8e160deee62b06fda008b56
+  checksum: 10/2b8d51bf0787d088c1b12857a686719fa922256a8ac84045e64c98b86c5ff81a4b76d49a25e6fb9bc9f582fb0d92233207917573358a26dd40ad4e91b01bfb66
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description
The package `react-router-dom` has been renamed to `react-router` (see https://reactrouter.com/upgrading/v6#upgrade-to-v7). Replace `react-router-dom` with `react-router`

## Related Issue(s)
- this PR

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
