### PR TITLE
Make Confetti package features inaccessible outside of dev and AT22

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Configuration/FeatureFlags.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Configuration/FeatureFlags.cs
@@ -10,5 +10,10 @@ namespace Altinn.AccessManagement.UI.Core.Configuration
         /// Whether or not to only display popular SingleRights services
         /// </summary>
         public bool DisplayPopularSingleRightsServices { get; set; }
+
+        /// <summary>
+        /// Whether or not to display features related to the confetti package launch in the UI
+        /// </summary>
+        public bool ConfettiPackage { get; set; }
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.AT22.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.AT22.json
@@ -24,5 +24,8 @@
   },
   "KeyVaultSettings": {
     "SecretUri": "https://altinn-at22-am-kv.vault.azure.net/"
+  },
+  "FeatureFlags": {
+    "ConfettiPackage": true
   }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.Development.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.Development.json
@@ -27,6 +27,7 @@
     "SecretUri": "https://altinn-dev-amui-kv.vault.azure.net/"
   },
   "FeatureFlags": {
-    "DisplayPopularSingleRightsServices": false
+    "DisplayPopularSingleRightsServices": false,
+    "ConfettiPackage": true
   }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.json
@@ -39,6 +39,7 @@
     "CertificateName": "JWTCertificate"
   },
   "FeatureFlags": {
-    "DisplayPopularSingleRightsServices": false
+    "DisplayPopularSingleRightsServices": false,
+    "ConfettiPackage": false
   }
 }

--- a/src/features/amUI/common/PageLayoutWrapper/PageLayoutWrapper.tsx
+++ b/src/features/amUI/common/PageLayoutWrapper/PageLayoutWrapper.tsx
@@ -1,11 +1,9 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Layout, RootProvider } from '@altinn/altinn-components';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router';
-import { HandshakeIcon, PersonGroupIcon, InboxIcon, TenancyIcon } from '@navikt/aksel-icons';
+import { SidebarItems } from './SidebarItems';
 
 import { useGetReporteeQuery } from '@/rtk/features/userInfoApi';
-import { amUIPath, SystemUserPath } from '@/routes/paths';
 import { getAltinnStartPageUrl } from '@/resources/utils/pathUtils';
 
 interface PageLayoutWrapperProps {
@@ -15,6 +13,7 @@ interface PageLayoutWrapperProps {
 export const PageLayoutWrapper = ({ children }: PageLayoutWrapperProps): React.ReactNode => {
   const { t } = useTranslation();
   const { data: reportee } = useGetReporteeQuery();
+  const sidebarItems = useMemo(() => SidebarItems(), [window.featureFlags.confettiPackage]);
   return (
     <RootProvider>
       <Layout
@@ -38,65 +37,12 @@ export const PageLayoutWrapper = ({ children }: PageLayoutWrapperProps): React.R
                 type: reportee?.type === 'Organization' ? 'company' : 'person',
                 id: reportee?.name || '',
               },
-              {
-                name: 'Test',
-                type: 'person',
-                id: 'test',
-              },
+              { name: 'Test', type: 'person', id: 'test' },
             ],
             items: [],
           },
         }}
-        sidebar={{
-          menu: {
-            groups: {},
-            items: [
-              {
-                groupId: 1,
-                icon: HandshakeIcon,
-                id: '1',
-                size: 'lg',
-                title: 'Tilgangsstyring',
-              },
-              {
-                groupId: 2,
-                id: '2',
-                title: t('sidebar.users'),
-                icon: PersonGroupIcon,
-                as: (props) => (
-                  <Link
-                    to={`/${amUIPath.Users}`}
-                    {...props}
-                  />
-                ),
-              },
-              {
-                groupId: 3,
-                id: '3',
-                title: t('sidebar.reportees'),
-                icon: InboxIcon,
-                as: (props) => (
-                  <Link
-                    to={`/${amUIPath.Reportees}`}
-                    {...props}
-                  />
-                ),
-              },
-              {
-                groupId: 4,
-                id: '4',
-                title: t('sidebar.systemaccess'),
-                icon: TenancyIcon,
-                as: (props) => (
-                  <Link
-                    to={`/${SystemUserPath.SystemUser}/${SystemUserPath.Overview}`}
-                    {...props}
-                  />
-                ),
-              },
-            ],
-          },
-        }}
+        sidebar={{ menu: { groups: {}, items: sidebarItems } }}
         content={{ color: 'neutral' }}
         footer={{
           address: 'Postboks 1382 Vika, 0114 Oslo.',
@@ -117,20 +63,11 @@ export const PageLayoutWrapper = ({ children }: PageLayoutWrapperProps): React.R
 };
 
 const footerLinks = [
-  {
-    href: 'https://info.altinn.no/om-altinn/',
-    resourceId: 'footer.about_altinn',
-  },
+  { href: 'https://info.altinn.no/om-altinn/', resourceId: 'footer.about_altinn' },
   {
     href: 'https://info.altinn.no/om-altinn/driftsmeldinger/',
     resourceId: 'footer.service_messages',
   },
-  {
-    href: 'https://info.altinn.no/om-altinn/personvern/',
-    resourceId: 'footer.privacy_policy',
-  },
-  {
-    href: 'https://info.altinn.no/om-altinn/tilgjengelighet/',
-    resourceId: 'footer.accessibility',
-  },
+  { href: 'https://info.altinn.no/om-altinn/personvern/', resourceId: 'footer.privacy_policy' },
+  { href: 'https://info.altinn.no/om-altinn/tilgjengelighet/', resourceId: 'footer.accessibility' },
 ];

--- a/src/features/amUI/common/PageLayoutWrapper/SidebarItems.tsx
+++ b/src/features/amUI/common/PageLayoutWrapper/SidebarItems.tsx
@@ -1,0 +1,72 @@
+import { amUIPath, SystemUserPath } from '@/routes/paths';
+import { MenuItemProps } from '@altinn/altinn-components';
+import { HandshakeIcon, InboxIcon, PersonGroupIcon, TenancyIcon } from '@navikt/aksel-icons';
+import { t } from 'i18next';
+import { Link } from 'react-router';
+
+/**
+ * Generates a list of sidebar items for the page layout.
+ *
+ * @returns {MenuItemProps[]} A list of sidebar items, including a heading,
+ *                            and optionally a confetti package if the feature flag is enabled.
+ */
+export const SidebarItems = () => {
+  const displayConfettiPackage = window.featureFlags.confettiPackage;
+
+  const heading: MenuItemProps = {
+    groupId: 1,
+    icon: HandshakeIcon,
+    id: '1',
+    size: 'lg',
+    title: t('sidebar.access_management'),
+  };
+
+  const confettiPackage: MenuItemProps[] = [
+    {
+      groupId: 2,
+      id: '2',
+      size: 'md',
+      title: t('sidebar.users'),
+      icon: PersonGroupIcon,
+      as: (props: any) => (
+        <Link
+          to={`/${amUIPath.Users}`}
+          {...props}
+        />
+      ),
+    },
+    {
+      groupId: 3,
+      id: '3',
+      size: 'md',
+      title: t('sidebar.reportees'),
+      icon: InboxIcon,
+      as: (props: any) => (
+        <Link
+          to={`/${amUIPath.Reportees}`}
+          {...props}
+        />
+      ),
+    },
+  ];
+
+  const systemUser: MenuItemProps = {
+    groupId: 4,
+    id: '4',
+    size: 'md',
+    title: t('sidebar.systemaccess'),
+    icon: TenancyIcon,
+    as: (props: any) => (
+      <Link
+        to={`/${SystemUserPath.SystemUser}/${SystemUserPath.Overview}`}
+        {...props}
+      />
+    ),
+  };
+
+  if (displayConfettiPackage) {
+    return [heading, ...confettiPackage, systemUser];
+  }
+
+  return [heading, systemUser];
+};

--- a/src/features/amUI/reporteeRightsPage/ReporteeRightsPage.tsx
+++ b/src/features/amUI/reporteeRightsPage/ReporteeRightsPage.tsx
@@ -18,6 +18,7 @@ import { useGetReporteeQuery, useGetUserAccessesQuery } from '@/rtk/features/use
 import { amUIPath } from '@/routes/paths';
 import { getCookie } from '@/resources/Cookie/CookieMethods';
 import { filterDigdirRole } from '@/resources/utils/roleUtils';
+import { rerouteIfNotConfetti } from '@/resources/utils/featureFlagUtils';
 
 export const ReporteeRightsPage = () => {
   const { t } = useTranslation();
@@ -35,6 +36,8 @@ export const ReporteeRightsPage = () => {
     from: reporteeUuid ?? '',
     to: getCookie('AltinnPartyUuid'),
   });
+
+  rerouteIfNotConfetti();
 
   return (
     <SnackbarProvider>

--- a/src/features/amUI/reportees/ReporteesPage.tsx
+++ b/src/features/amUI/reportees/ReporteesPage.tsx
@@ -1,7 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { Heading, Search } from '@digdir/designsystemet-react';
 import { useState } from 'react';
-
 import { useDocumentTitle } from '@/resources/hooks/useDocumentTitle';
 import { PageWrapper } from '@/components';
 import { useGetReporteeListForPartyQuery } from '@/rtk/features/userInfoApi';
@@ -12,6 +11,7 @@ import { PageLayoutWrapper } from '../common/PageLayoutWrapper';
 import { UserList } from '../common/UserList/UserList';
 
 import classes from './ReporteePage.module.css';
+import { rerouteIfNotConfetti } from '@/resources/utils/featureFlagUtils';
 
 export const ReporteesPage = () => {
   const { t } = useTranslation();
@@ -24,6 +24,9 @@ export const ReporteesPage = () => {
   useDocumentTitle(t('reportees_page.page_title'));
   const { data: userList, isLoading } = useGetReporteeListForPartyQuery();
   const { data: party } = useGetReporteePartyQuery();
+
+  rerouteIfNotConfetti();
+
   return (
     <PageWrapper>
       <PageLayoutWrapper>

--- a/src/features/amUI/userRightsPage/UserRightsPage.tsx
+++ b/src/features/amUI/userRightsPage/UserRightsPage.tsx
@@ -21,6 +21,7 @@ import { RightsTabs } from '../common/RightsTabs/RightsTabs';
 import { AccessPackageSection } from './AccessPackageSection/AccessPackageSection';
 import { SingleRightsSection } from './SingleRightsSection/SingleRightsSection';
 import { RoleSection } from './RoleSection/RoleSection';
+import { rerouteIfNotConfetti } from '@/resources/utils/featureFlagUtils';
 
 export const UserRightsPage = () => {
   const { t } = useTranslation();
@@ -37,6 +38,8 @@ export const UserRightsPage = () => {
     from: getCookie('AltinnPartyUuid'),
     to: id ?? '',
   });
+
+  rerouteIfNotConfetti();
 
   return (
     <SnackbarProvider>

--- a/src/features/amUI/users/UsersPage.tsx
+++ b/src/features/amUI/users/UsersPage.tsx
@@ -10,11 +10,14 @@ import { PageLayoutWrapper } from '../common/PageLayoutWrapper';
 
 import { UsersList } from './UsersList';
 import classes from './UsersList.module.css';
+import { rerouteIfNotConfetti } from '@/resources/utils/featureFlagUtils';
 
 export const UsersPage = () => {
   const { t } = useTranslation();
   useDocumentTitle(t('users_page.page_title'));
   const { data: reportee } = useGetReporteeQuery();
+
+  rerouteIfNotConfetti();
 
   return (
     <PageWrapper>

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -4,6 +4,7 @@ declare global {
   interface Window {
     featureFlags: {
       displayPopularSingleRightsServices: boolean;
+      confettiPackage: boolean;
     };
   }
 }

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -88,6 +88,7 @@
     "accessibility": "Accessibility"
   },
   "sidebar": {
+    "access_management": "Access management",
     "users": "Users",
     "reportees": "Our access to other companies",
     "systemaccess": "API- and system access"

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -100,6 +100,7 @@
     "accessibility": "Tilgjengelighet"
   },
   "sidebar": {
+    "access_management": "Tilgangsstyring",
     "users": "Brukere",
     "reportees": "Våre tilganger hos andre",
     "systemaccess": "API- og systemtilganger"

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -85,6 +85,7 @@
     "accessibility": "Tilgjengeligheit"
   },
   "sidebar": {
+    "access_management": "Tilgangsstyring",
     "users": "Brukere",
     "reportees": "Våre tilganger hos andre",
     "systemaccess": "API- og systemtilganger"

--- a/src/resources/utils/featureFlagUtils.tsx
+++ b/src/resources/utils/featureFlagUtils.tsx
@@ -1,0 +1,8 @@
+import { useNavigate } from 'react-router';
+
+export const rerouteIfNotConfetti = () => {
+  const navigate = useNavigate();
+  if (window.featureFlags.confettiPackage === false) {
+    navigate('/not-found');
+  }
+};

--- a/src/sites/ErrorPage/ErrorPage.module.css
+++ b/src/sites/ErrorPage/ErrorPage.module.css
@@ -26,6 +26,14 @@
   padding-bottom: 40px;
 }
 
+.errorContent {
+  padding-top: 1rem;
+}
+
+.header {
+  padding-bottom: 0.5rem;
+}
+
 @media only screen and (max-width: 576px) {
   .rightContainer {
     display: none;

--- a/src/sites/ErrorPage/contents/PageNotFound.tsx
+++ b/src/sites/ErrorPage/contents/PageNotFound.tsx
@@ -10,9 +10,9 @@ export const PageNotFound = () => {
   const { t } = useTranslation();
 
   return (
-    <div>
+    <div className={classes.errorContent}>
       <Heading
-        size='xl'
+        size='lg'
         level={1}
         className={classes.header}
       >

--- a/src/sites/ErrorPage/contents/UnknownError.tsx
+++ b/src/sites/ErrorPage/contents/UnknownError.tsx
@@ -10,9 +10,9 @@ export const UnknownError = () => {
   const { t } = useTranslation();
 
   return (
-    <div>
+    <div className={classes.errorContent}>
       <Heading
-        size='xl'
+        size='lg'
         className={classes.header}
       >
         {t('error_page.unknown_error_header')}


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->
Added new feature flag for the confetti package. When this is false, the features related to this delivery will not be visible in the side menu and those who for some reason manage to access the urls to these pages will instead be redirected to a **Not found** page.

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/376

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
