### PR TITLE
Hide single rights feature behind feature toggle

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,7 +1,9 @@
 <script>
     console.log("Script is running");
     window.featureFlags = {
-        displayPopularSingleRightsServices: false
+        displayPopularSingleRightsServices: false,
+        displayResourceDelegation: false,
+        displayConfettiPackage: false,
     }
     document.cookie = "AltinnPartyId=51329012";
 </script>

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Configuration/FeatureFlags.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Configuration/FeatureFlags.cs
@@ -14,6 +14,11 @@ namespace Altinn.AccessManagement.UI.Core.Configuration
         /// <summary>
         /// Whether or not to display features related to the confetti package launch in the UI
         /// </summary>
-        public bool ConfettiPackage { get; set; }
+        public bool DisplayConfettiPackage { get; set; }
+
+        /// <summary>
+        /// Whether or not to only display the service/resource delegation feature in the UI
+        /// </summary>
+        public bool DisplayResourceDelegation { get; set; }
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.AT22.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.AT22.json
@@ -27,6 +27,7 @@
     "SecretUri": "https://altinn-at22-am-kv.vault.azure.net/"
   },
   "FeatureFlags": {
-    "ConfettiPackage": true
+    "DisplayConfettiPackage": true,
+    "DisplayResourceDelegation": false
   }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.Development.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.Development.json
@@ -28,6 +28,7 @@
   },
   "FeatureFlags": {
     "DisplayPopularSingleRightsServices": false,
-    "ConfettiPackage": true
+    "DisplayConfettiPackage": true,
+    "DisplayResourceDelegation": true
   }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.json
@@ -41,6 +41,7 @@
   },
   "FeatureFlags": {
     "DisplayPopularSingleRightsServices": false,
-    "ConfettiPackage": false
+    "DisplayConfettiPackage": false,
+    "DisplayResourceDelegation": false
   }
 }

--- a/src/features/amUI/common/PageLayoutWrapper/SidebarItems.tsx
+++ b/src/features/amUI/common/PageLayoutWrapper/SidebarItems.tsx
@@ -13,7 +13,7 @@ import { amUIPath, SystemUserPath } from '@/routes/paths';
  *                            and optionally a confetti package if the feature flag is enabled.
  */
 export const SidebarItems = () => {
-  const displayConfettiPackage = window.featureFlags?.confettiPackage;
+  const displayConfettiPackage = window.featureFlags?.displayConfettiPackage;
 
   const heading: MenuItemProps = {
     groupId: 1,

--- a/src/features/amUI/common/RightsTabs/RightsTabs.tsx
+++ b/src/features/amUI/common/RightsTabs/RightsTabs.tsx
@@ -4,11 +4,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 interface RightsTabsProps {
-  tabBadge?: {
-    accessPackages: number;
-    services: number;
-    roles: number;
-  };
+  tabBadge?: { accessPackages: number; services: number; roles: number };
   packagesPanel: ReactNode;
   singleRightsPanel: ReactNode;
   roleAssignmentsPanel: ReactNode;
@@ -22,6 +18,8 @@ export const RightsTabs = ({
 }: RightsTabsProps) => {
   const { t } = useTranslation();
   const [chosenTab, setChosenTab] = useState('packages');
+
+  const displaySingleRights = window.featureFlags?.displayResourceDelegation === true;
   return (
     <Tabs
       defaultValue='packages'
@@ -39,15 +37,17 @@ export const RightsTabs = ({
           />
           {t('user_rights_page.access_packages_title')}
         </Tabs.Tab>
-        <Tabs.Tab value='singleRights'>
-          <Badge
-            size='sm'
-            color={chosenTab === 'singleRights' ? 'accent' : 'neutral'}
-            count={tabBadge?.services ?? 0}
-            maxCount={99}
-          />
-          {t('user_rights_page.single_rights_title')}
-        </Tabs.Tab>
+        {displaySingleRights && (
+          <Tabs.Tab value='singleRights'>
+            <Badge
+              size='sm'
+              color={chosenTab === 'singleRights' ? 'accent' : 'neutral'}
+              count={tabBadge?.services ?? 0}
+              maxCount={99}
+            />
+            {t('user_rights_page.single_rights_title')}
+          </Tabs.Tab>
+        )}
         <Tabs.Tab value='roleAssignments'>
           <Badge
             size='sm'
@@ -59,7 +59,7 @@ export const RightsTabs = ({
         </Tabs.Tab>
       </Tabs.List>
       <Tabs.Panel value='packages'>{packagesPanel}</Tabs.Panel>
-      <Tabs.Panel value='singleRights'>{singleRightsPanel}</Tabs.Panel>
+      {displaySingleRights && <Tabs.Panel value='singleRights'>{singleRightsPanel}</Tabs.Panel>}
       <Tabs.Panel value='roleAssignments'>{roleAssignmentsPanel}</Tabs.Panel>
     </Tabs>
   );

--- a/src/features/amUI/reporteeRightsPage/ReporteeAccessPackageSection.tsx
+++ b/src/features/amUI/reporteeRightsPage/ReporteeAccessPackageSection.tsx
@@ -9,6 +9,7 @@ import { useActionError } from '@/resources/hooks/useActionError';
 
 import { AccessPackageList } from '../common/AccessPackageList/AccessPackageList';
 import { DelegationAction, EditModal } from '../common/DelegationModal/EditModal';
+import { AccessPackageInfoModal } from '../userRightsPage/AccessPackageSection/AccessPackageInfoModal';
 
 interface ReporteeAccessPackageSectionProps {
   reporteeUuid?: string;
@@ -62,12 +63,12 @@ export const ReporteeAccessPackageSection = ({
         }}
       />
       {party && (
-        <EditModal
-          ref={modalRef}
+        <AccessPackageInfoModal
+          modalRef={modalRef}
           toPartyUuid={getCookie('AltinnPartyUuid')}
-          fromPartyUuid={party.partyUuid}
-          accessPackage={modalItem}
-          availableActions={[DelegationAction.REVOKE, DelegationAction.REQUEST]}
+          fromPartyUuid={reporteeUuid ?? ''}
+          modalItem={modalItem}
+          modalActions={[DelegationAction.REVOKE, DelegationAction.REQUEST]}
           onClose={() => {
             setModalItem(undefined);
             setError(null);

--- a/src/features/amUI/userRightsPage/AccessPackageSection/AccessPackageInfoModal.tsx
+++ b/src/features/amUI/userRightsPage/AccessPackageSection/AccessPackageInfoModal.tsx
@@ -1,9 +1,7 @@
 import { useEffect } from 'react';
-import { useParams } from 'react-router';
 
 import type { AccessPackage } from '@/rtk/features/accessPackageApi';
-import type { Party } from '@/rtk/features/lookupApi';
-import { useGetReporteeQuery, useGetUserInfoQuery } from '@/rtk/features/userInfoApi';
+import { useGetUserInfoQuery } from '@/rtk/features/userInfoApi';
 import type { ActionError } from '@/resources/hooks/useActionError';
 
 import { DelegationAction, EditModal } from '../../common/DelegationModal/EditModal';
@@ -11,43 +9,45 @@ import { DelegationModalProvider } from '../../common/DelegationModal/Delegation
 
 interface AccessPackageInfoModalProps {
   modalRef: React.RefObject<HTMLDialogElement>;
-  toParty: Party;
+  toPartyUuid: string;
+  fromPartyUuid: string;
   modalItem: AccessPackage | undefined;
   onClose?: () => void;
   openWithError?: ActionError | null;
+  modalActions?: DelegationAction | DelegationAction[];
 }
 
 export const AccessPackageInfoModal = ({
   modalRef,
-  toParty,
+  toPartyUuid,
+  fromPartyUuid,
   modalItem,
   onClose,
   openWithError,
+  modalActions,
 }: AccessPackageInfoModalProps) => {
-  useEffect(() => {
-    const handleClose = () => onClose?.();
-    modalRef.current?.addEventListener('close', handleClose);
-    return () => modalRef.current?.removeEventListener('close', handleClose);
-  }, [onClose, modalRef]);
-
-  const { data: reportee } = useGetReporteeQuery();
-  const { id: rightHolderUuid } = useParams();
-
   const { data: currentUser } = useGetUserInfoQuery();
-  const isCurrentUser = currentUser?.uuid === toParty.partyUuid;
+  const isCurrentUser = currentUser?.uuid === toPartyUuid;
 
   return (
     <DelegationModalProvider>
       <EditModal
         ref={modalRef}
-        toPartyUuid={rightHolderUuid ?? ''}
-        fromPartyUuid={reportee?.partyUuid ?? ''}
+        toPartyUuid={toPartyUuid}
+        fromPartyUuid={fromPartyUuid}
         accessPackage={modalItem}
         openWithError={openWithError}
-        availableActions={[
-          !isCurrentUser ? DelegationAction.DELEGATE : DelegationAction.REQUEST,
-          DelegationAction.REVOKE,
-        ]}
+        onClose={onClose}
+        availableActions={
+          Array.isArray(modalActions)
+            ? modalActions
+            : modalActions !== undefined
+              ? [modalActions]
+              : [
+                  !isCurrentUser ? DelegationAction.DELEGATE : DelegationAction.REQUEST,
+                  DelegationAction.REVOKE,
+                ]
+        }
       />
     </DelegationModalProvider>
   );

--- a/src/features/amUI/userRightsPage/AccessPackageSection/ActiveDelegations.tsx
+++ b/src/features/amUI/userRightsPage/AccessPackageSection/ActiveDelegations.tsx
@@ -48,7 +48,8 @@ export const ActiveDelegations = ({ toParty }: { toParty: Party }) => {
       />
       <AccessPackageInfoModal
         modalRef={modalRef}
-        toParty={toParty}
+        toPartyUuid={toParty.partyUuid}
+        fromPartyUuid={getCookie('AltinnPartyUuid')}
         modalItem={modalItem}
         onClose={() => {
           setModalItem(undefined);

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -4,7 +4,8 @@ declare global {
   interface Window {
     featureFlags: {
       displayPopularSingleRightsServices: boolean;
-      confettiPackage: boolean;
+      displayResourceDelegation: boolean;
+      displayConfettiPackage: boolean;
     };
   }
 }

--- a/src/resources/utils/featureFlagUtils.tsx
+++ b/src/resources/utils/featureFlagUtils.tsx
@@ -2,7 +2,7 @@ import { useNavigate } from 'react-router';
 
 export const rerouteIfNotConfetti = () => {
   const navigate = useNavigate();
-  if (window.featureFlags.confettiPackage === false) {
+  if (window.featureFlags.displayConfettiPackage === false) {
     navigate('/not-found');
   }
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When the feature flag is disabled, the service delegation tab is not visible.

This PR also fixes a couple of bugs:
- Rights at a chosen other party: Page crashes
- Error on action is not removed on closing the access package modal

## Related Issue(s)
- https://github.com/Altinn/altinn-access-management-frontend/issues/1300

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
