### PR TITLE
Remove systemuser overrides for old version of designsystemet

### DIFF
--- a/src/features/amUI/systemUser/components/RightsList/RightsList.tsx
+++ b/src/features/amUI/systemUser/components/RightsList/RightsList.tsx
@@ -26,18 +26,15 @@ export const RightsList = ({ resources, accessPackages }: RightsListProps): Reac
     React.useState<SystemUserAccessPackage | null>(null);
 
   const onSelectResource = (resource: ServiceResource): void => {
-    setSelectedAccessPackage(null);
     setSelectedResource(resource);
     modalRef.current?.showModal();
   };
 
   const onSelectAccessPackage = (accessPackage: SystemUserAccessPackage): void => {
-    setSelectedResource(null);
     setSelectedAccessPackage(accessPackage);
     modalRef.current?.showModal();
   };
 
-  // Note! This function is not called on click outside modal. It is fixed in newer versions of designsystemet
   const closeModal = (): void => {
     setSelectedResource(null);
     setSelectedAccessPackage(null);
@@ -115,7 +112,6 @@ export const RightsList = ({ resources, accessPackages }: RightsListProps): Reac
             data-size='sm'
             className={classes.backButton}
             onClick={() => setSelectedResource(null)}
-            icon
           >
             <ArrowLeftIcon fontSize={getButtonIconSize(true)} />
             {t('common.back')}

--- a/src/resources/css/systemuser.css
+++ b/src/resources/css/systemuser.css
@@ -1,29 +1,3 @@
-/* TODO: copied values from designsystemet. Can be removed when we upgrade designsystemet to version > 0.45 */
-:root {
-  --ds-size-base: 18;
-  --ds-size-step: 4;
-  --ds-size-0: round(down, calc(var(--ds-size-step) / var(--ds-size-base) * 1em * 0), 0.0625rem);
-  --ds-size-1: round(down, calc(var(--ds-size-step) / var(--ds-size-base) * 1em * 1), 0.0625rem);
-  --ds-size-2: round(down, calc(var(--ds-size-step) / var(--ds-size-base) * 1em * 2), 0.0625rem);
-  --ds-size-3: round(down, calc(var(--ds-size-step) / var(--ds-size-base) * 1em * 3), 0.0625rem);
-  --ds-size-4: round(down, calc(var(--ds-size-step) / var(--ds-size-base) * 1em * 4), 0.0625rem);
-  --ds-size-5: round(down, calc(var(--ds-size-step) / var(--ds-size-base) * 1em * 5), 0.0625rem);
-  --ds-size-6: round(down, calc(var(--ds-size-step) / var(--ds-size-base) * 1em * 6), 0.0625rem);
-  --ds-size-7: round(down, calc(var(--ds-size-step) / var(--ds-size-base) * 1em * 7), 0.0625rem);
-  --ds-size-8: round(down, calc(var(--ds-size-step) / var(--ds-size-base) * 1em * 8), 0.0625rem);
-  --ds-size-9: round(down, calc(var(--ds-size-step) / var(--ds-size-base) * 1em * 9), 0.0625rem);
-  --ds-size-10: round(down, calc(var(--ds-size-step) / var(--ds-size-base) * 1em * 10), 0.0625rem);
-  --ds-size-11: round(down, calc(var(--ds-size-step) / var(--ds-size-base) * 1em * 11), 0.0625rem);
-  --ds-size-12: round(down, calc(var(--ds-size-step) / var(--ds-size-base) * 1em * 12), 0.0625rem);
-  --ds-size-13: round(down, calc(var(--ds-size-step) / var(--ds-size-base) * 1em * 13), 0.0625rem);
-  --ds-size-14: round(down, calc(var(--ds-size-step) / var(--ds-size-base) * 1em * 14), 0.0625rem);
-  --ds-size-15: round(down, calc(var(--ds-size-step) / var(--ds-size-base) * 1em * 15), 0.0625rem);
-  --ds-size-18: round(down, calc(var(--ds-size-step) / var(--ds-size-base) * 1em * 18), 0.0625rem);
-  --ds-size-22: round(down, calc(var(--ds-size-step) / var(--ds-size-base) * 1em * 22), 0.0625rem);
-  --ds-size-26: round(down, calc(var(--ds-size-step) / var(--ds-size-base) * 1em * 26), 0.0625rem);
-  --ds-size-30: round(down, calc(var(--ds-size-step) / var(--ds-size-base) * 1em * 30), 0.0625rem);
-}
-
 @media (min-width: 1024px) {
   .systemuser_combobox_workaround aside {
     display: flex !important;


### PR DESCRIPTION
## Description
- Remove css overrides (these are now included in designsystemet)
- Remove icon prop on button
- Remove state reset, since dialog onClose will now run when dialog is closed both by clicking X and click outside

## Related Issue(s)
- this PR

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
