### PR TITLE
Feat/amui/402 delegation check on access package

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/ClientInterfaces/IAccessPackageClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/ClientInterfaces/IAccessPackageClient.cs
@@ -53,5 +53,12 @@ namespace Altinn.AccessManagement.UI.Core.ClientInterfaces
         /// Check if a user has the right to delegate a role
         /// </summary>
         Task<DelegationCheckResponse> RoleDelegationCheck(Guid rightOwner, Guid roleId);
+
+        /// <summary>
+        ///   Checks if the user can delegate roles on behalf of the specified reportee
+        /// </summary>
+        /// <param name="delegationCheckRequest">The request containing the packages to check and the reportee to check on behalf of</param>
+        /// <returns>The response containing whether or not the user can delegate the roles</returns>
+        Task<List<AccessPackageDelegationCheckResponse>> AccessPackageDelegationCheck(DelegationCheckRequest delegationCheckRequest);
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/ClientInterfaces/IAccessPackageClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/ClientInterfaces/IAccessPackageClient.cs
@@ -55,10 +55,10 @@ namespace Altinn.AccessManagement.UI.Core.ClientInterfaces
         Task<DelegationCheckResponse> RoleDelegationCheck(Guid rightOwner, Guid roleId);
 
         /// <summary>
-        ///   Checks if the user can delegate roles on behalf of the specified reportee
+        ///   Checks if the user can delegate access packages on behalf of the specified reportee
         /// </summary>
         /// <param name="delegationCheckRequest">The request containing the packages to check and the reportee to check on behalf of</param>
-        /// <returns>The response containing whether or not the user can delegate the roles</returns>
+        /// <returns>The response containing whether or not the user can delegate the packages</returns>
         Task<List<AccessPackageDelegationCheckResponse>> AccessPackageDelegationCheck(DelegationCheckRequest delegationCheckRequest);
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/Common/Frontend/AccessPackageDelegationCheckResponse.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/Common/Frontend/AccessPackageDelegationCheckResponse.cs
@@ -1,0 +1,26 @@
+using Altinn.AccessManagement.UI.Core.Enums;
+using Microsoft.Identity.Client;
+
+namespace Altinn.AccessManagement.UI.Core.Models
+{
+    /// <summary>
+    /// The response of a delegation check
+    /// </summary>
+    public class AccessPackageDelegationCheckResponse
+    {
+        /// <summary> 
+        /// The package id that was checked
+        /// </summary>
+        public Guid PackageId { get; set; }
+
+        /// <summary>
+        /// True if the user can delegate the role
+        /// </summary>
+        public bool CanDelegate { get; set; }
+
+        /// <summary>
+        /// The error code if the user cannot delegate the role
+        /// </summary>
+        public DetailCode? DetailCode { get; set; } 
+    }
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/Common/Frontend/DelegationCheckRequest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/Common/Frontend/DelegationCheckRequest.cs
@@ -4,7 +4,7 @@ using Microsoft.Identity.Client;
 namespace Altinn.AccessManagement.UI.Core.Models
 {
     /// <summary>
-    /// The response of a delegation check
+    /// The input to a delegation check
     /// </summary>
     public class DelegationCheckRequest
     {

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/Common/Frontend/DelegationCheckRequest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/Common/Frontend/DelegationCheckRequest.cs
@@ -1,0 +1,21 @@
+using Altinn.AccessManagement.UI.Core.Enums;
+using Microsoft.Identity.Client;
+
+namespace Altinn.AccessManagement.UI.Core.Models
+{
+    /// <summary>
+    /// The response of a delegation check
+    /// </summary>
+    public class DelegationCheckRequest
+    {
+        /// <summary>
+        /// A list of packages to check if the user can delegate
+        /// </summary>
+        public Guid[] PackageIds { get; set; }
+
+        /// <summary>
+        /// The id of the reportee to check if the user can delegate on behalf of
+        /// </summary>
+        public Guid ReporteeUuid { get; set; } 
+    }
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/AccessPackageService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/AccessPackageService.cs
@@ -5,6 +5,7 @@ using Altinn.AccessManagement.UI.Core.Models;
 using Altinn.AccessManagement.UI.Core.Models.AccessPackage;
 using Altinn.AccessManagement.UI.Core.Models.AccessPackage.Frontend;
 using Altinn.AccessManagement.UI.Core.Services.Interfaces;
+using Microsoft.AspNetCore.Mvc;
 
 namespace Altinn.AccessManagement.UI.Core.Services
 {
@@ -96,6 +97,12 @@ namespace Altinn.AccessManagement.UI.Core.Services
         public async Task<HttpResponseMessage> CreateDelegation(string party, Guid to, string packageId, string languageCode)
         {
             return await _accessManagementClient.CreateAccessPackageDelegation(party, to, packageId, languageCode);
+        }
+
+        /// <inheritdoc/>
+        public async Task<ActionResult<List<AccessPackageDelegationCheckResponse>>> DelegationCheck(DelegationCheckRequest delegationCheckRequest)
+        {
+            return await _accessPackageClient.AccessPackageDelegationCheck(delegationCheckRequest);
         }
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/Interfaces/IAccessPackageService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/Interfaces/IAccessPackageService.cs
@@ -1,5 +1,7 @@
+using Altinn.AccessManagement.UI.Core.Models;
 using Altinn.AccessManagement.UI.Core.Models.AccessPackage;
 using Altinn.AccessManagement.UI.Core.Models.AccessPackage.Frontend;
+using Microsoft.AspNetCore.Mvc;
 
 namespace Altinn.AccessManagement.UI.Core.Services.Interfaces
 {
@@ -43,5 +45,12 @@ namespace Altinn.AccessManagement.UI.Core.Services.Interfaces
                 /// <param name="languageCode">The code of the language on which texts are to be returned</param>
                 /// <returns></returns> 
                 Task<HttpResponseMessage> CreateDelegation(string party, Guid to, string packageId, string languageCode);
-        }
+
+                /// <summary>
+                ///    Checks if the user can delegate roles on behalf of the specified reportee
+                /// </summary>
+                /// <param name="delegationCheckRequest">The request containing the packages to check and the reportee to check on behalf of</param>
+                /// <returns>The response containing whether or not the user can delegate the roles</returns>
+                Task<ActionResult<List<AccessPackageDelegationCheckResponse>>> DelegationCheck(DelegationCheckRequest delegationCheckRequest);
+    }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/Interfaces/IAccessPackageService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/Interfaces/IAccessPackageService.cs
@@ -47,10 +47,10 @@ namespace Altinn.AccessManagement.UI.Core.Services.Interfaces
                 Task<HttpResponseMessage> CreateDelegation(string party, Guid to, string packageId, string languageCode);
 
                 /// <summary>
-                ///    Checks if the user can delegate roles on behalf of the specified reportee
+                ///    Checks if the user can delegate access packages on behalf of the specified reportee
                 /// </summary>
                 /// <param name="delegationCheckRequest">The request containing the packages to check and the reportee to check on behalf of</param>
-                /// <returns>The response containing whether or not the user can delegate the roles</returns>
+                /// <returns>The response containing whether or not the user can delegate the packages</returns>
                 Task<ActionResult<List<AccessPackageDelegationCheckResponse>>> DelegationCheck(DelegationCheckRequest delegationCheckRequest);
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/AccessPackageClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/AccessPackageClient.cs
@@ -177,5 +177,11 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
             // TODO: Implement this method when the API is ready
             throw new NotImplementedException();
         }
+
+        /// <inheritdoc />
+        public Task<List<AccessPackageDelegationCheckResponse>> AccessPackageDelegationCheck(DelegationCheckRequest delegationCheckRequest)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/AccessPackage/DelegationCheck/04c5a001-5249-4765-ae8e-58617c404223.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/AccessPackage/DelegationCheck/04c5a001-5249-4765-ae8e-58617c404223.json
@@ -1,0 +1,5 @@
+{
+    "packageId": "04c5a001-5249-4765-ae8e-58617c404223",
+    "canDelegate": false,
+    "detailCode": "InsufficientAuthenticationLevel"
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/AccessPackage/DelegationCheck/0bb5963e-df17-4f35-b913-3ce10a34b866.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/AccessPackage/DelegationCheck/0bb5963e-df17-4f35-b913-3ce10a34b866.json
@@ -1,0 +1,5 @@
+{
+    "packageId": "0bb5963e-df17-4f35-b913-3ce10a34b866",
+    "canDelegate": true,
+    "detailCode": "DelegationAccess"
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/AccessPackage/DelegationCheck/0bb5963e-df17-4f35-b913-3ce10a34b866.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/AccessPackage/DelegationCheck/0bb5963e-df17-4f35-b913-3ce10a34b866.json
@@ -1,5 +1,5 @@
 {
     "packageId": "0bb5963e-df17-4f35-b913-3ce10a34b866",
-    "canDelegate": true,
-    "detailCode": "DelegationAccess"
+    "canDelegate": false,
+    "detailCode": "Unknown"
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/AccessPackage/DelegationCheck/452bd15d-2cd2-4279-9470-cd97ba8ef1c7.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/AccessPackage/DelegationCheck/452bd15d-2cd2-4279-9470-cd97ba8ef1c7.json
@@ -1,5 +1,5 @@
 {
-    "packageId": "fa84bffc-ac17-40cd-af9c-61c89f92e44c",
+    "packageId": "452bd15d-2cd2-4279-9470-cd97ba8ef1c7",
     "canDelegate": false,
     "detailCode": "AccessListValidationFail"
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/AccessPackage/DelegationCheck/5eb07bdc-5c3c-4c85-add3-5405b214b8a3.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/AccessPackage/DelegationCheck/5eb07bdc-5c3c-4c85-add3-5405b214b8a3.json
@@ -1,0 +1,5 @@
+{
+    "packageId": "5eb07bdc-5c3c-4c85-add3-5405b214b8a3",
+    "canDelegate": false,
+    "detailCode": "MissingSrrRightAccess"
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/AccessPackage/DelegationCheck/78c21107-7d2d-4e85-af82-47ea0e47ceca.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/AccessPackage/DelegationCheck/78c21107-7d2d-4e85-af82-47ea0e47ceca.json
@@ -1,0 +1,5 @@
+{
+    "packageId": "78c21107-7d2d-4e85-af82-47ea0e47ceca",
+    "canDelegate": true,
+    "detailCode": "SrrRightAccess"
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/AccessPackage/DelegationCheck/906aec0d-ad1f-496b-a0bb-40f81b3303cb.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/AccessPackage/DelegationCheck/906aec0d-ad1f-496b-a0bb-40f81b3303cb.json
@@ -1,0 +1,5 @@
+{
+    "packageId": "906aec0d-ad1f-496b-a0bb-40f81b3303cb",
+    "canDelegate": false,
+    "detailCode": "MissingRoleAccess"
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/AccessPackage/DelegationCheck/9d2ec6e9-5148-4f47-9ae4-4536f6c9c1cb.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/AccessPackage/DelegationCheck/9d2ec6e9-5148-4f47-9ae4-4536f6c9c1cb.json
@@ -1,0 +1,5 @@
+{
+    "packageId": "9d2ec6e9-5148-4f47-9ae4-4536f6c9c1cb",
+    "canDelegate": true,
+    "detailCode": "DelegationAccess"
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/AccessPackage/DelegationCheck/a03af7d5-74b9-4f18-aead-5d47edc36be5.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/AccessPackage/DelegationCheck/a03af7d5-74b9-4f18-aead-5d47edc36be5.json
@@ -1,0 +1,5 @@
+{
+    "packageId": "a03af7d5-74b9-4f18-aead-5d47edc36be5",
+    "canDelegate": true,
+    "detailCode": "AccessListValidationPass"
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/AccessPackage/DelegationCheck/ab656cf2-1e65-4b5a-a1e3-cd5bd4cb804c.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/AccessPackage/DelegationCheck/ab656cf2-1e65-4b5a-a1e3-cd5bd4cb804c.json
@@ -1,5 +1,5 @@
 {
-    "packageId": "f7e02568-90b6-477d-8abb-44984ddeb1f9",
+    "packageId": "ab656cf2-1e65-4b5a-a1e3-cd5bd4cb804c",
     "canDelegate": false,
     "detailCode": "MissingDelegationAccess"
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/AccessPackage/DelegationCheck/cfe074fa-0a66-4a4b-974a-5d1db8eb94e6.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/AccessPackage/DelegationCheck/cfe074fa-0a66-4a4b-974a-5d1db8eb94e6.json
@@ -1,5 +1,5 @@
 {
     "packageId": "cfe074fa-0a66-4a4b-974a-5d1db8eb94e6",
     "canDelegate": false,
-    "detailCode": "AlreadyDelegated"
+    "detailCode": "AccessListValidationFail"
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/AccessPackage/DelegationCheck/cfe074fa-0a66-4a4b-974a-5d1db8eb94e6.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/AccessPackage/DelegationCheck/cfe074fa-0a66-4a4b-974a-5d1db8eb94e6.json
@@ -1,0 +1,5 @@
+{
+    "packageId": "cfe074fa-0a66-4a4b-974a-5d1db8eb94e6",
+    "canDelegate": false,
+    "detailCode": "AlreadyDelegated"
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/AccessPackage/DelegationCheck/f7e02568-90b6-477d-8abb-44984ddeb1f9.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/AccessPackage/DelegationCheck/f7e02568-90b6-477d-8abb-44984ddeb1f9.json
@@ -1,0 +1,5 @@
+{
+    "packageId": "f7e02568-90b6-477d-8abb-44984ddeb1f9",
+    "canDelegate": false,
+    "detailCode": "MissingDelegationAccess"
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/AccessPackage/DelegationCheck/fa84bffc-ac17-40cd-af9c-61c89f92e44c.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/AccessPackage/DelegationCheck/fa84bffc-ac17-40cd-af9c-61c89f92e44c.json
@@ -1,0 +1,5 @@
+{
+    "packageId": "fa84bffc-ac17-40cd-af9c-61c89f92e44c",
+    "canDelegate": false,
+    "detailCode": "AccessListValidationFail"
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/AccessPackage/GetDelegations/cd35779b-b174-4ecc-bbef-ece13611be7f_5c0656db-cf51-43a4-bd64-6a91c8caacfb.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/AccessPackage/GetDelegations/cd35779b-b174-4ecc-bbef-ece13611be7f_5c0656db-cf51-43a4-bd64-6a91c8caacfb.json
@@ -69,5 +69,55 @@
       "DelegatedTo": "5c0656db-cf51-43a4-bd64-6a91c8caacfb",
       "LastChangedOn": "2024-11-22T14:57:39.2568955+01:00"
     }
+  },
+  {
+    "AccessPackage": {
+      "provider": {
+        "id": "73dfe32a-8f21-465c-9242-40d82e61f320",
+        "name": "Digdir",
+        "refId": null
+      },
+      "entityType": {
+        "id": "8c216e2f-afdd-4234-9ba2-691c727bb33d",
+        "providerId": "323f9ff9-11ad-4af3-8ccb-0db7bdb71d75",
+        "name": "Organisasjon"
+      },
+     "area": {
+        "id": "6e152c10-0f63-4060-9b14-66808e7ac320",
+        "name": "Energi, vann,avløp og avfall",
+        "description": "Dette fullmaktsområdet omfatter tilgangspakker knyttet til energi, vann,avløp og avfall.",
+        "iconUrl": "https://www.svgrepo.com/show/358402/water-glass.svg"
+      },
+      "id": "fef4aac0-d227-4ef6-834b-cc2eb4b942ed",
+      "providerId": "73dfe32a-8f21-465c-9242-40d82e61f320",
+      "entityTypeId": "8c216e2f-afdd-4234-9ba2-691c727bb33d",
+      "areaId": "a8834a7c-ed89-4c73-b5d5-19a2347f3b13",
+      "name": "Samle opp og behandle avløpsvann",
+      "description": "Denne tilgangspakken gir fullmakter til tjenester knyttet til samle opp og behandle avløpsvann. Ved regelverksendringer eller innføring av nye digitale tjenester kan det bli endringer i tilganger som fullmakten gir.  ",
+      "isDelegable": true,
+      "Resources": [
+        {
+          "Id": "appid-402",
+          "Name": "Det magiske klesskapet"
+        },
+        {
+          "Id": "appid-513",
+          "Name": "Kaffemaskinen i 5. etasje"
+        }
+      ]
+    },
+    "To": {
+      "Name": "Intelligent Albatross",
+      "Uuid": "5c0656db-cf51-43a4-bd64-6a91c8caacfb"
+    },
+    "From": {
+      "Name": "DISKRET NÆR TIGER AS",
+      "Uuid": "cd35779b-b174-4ecc-bbef-ece13611be7f"
+    },
+    "AccessDetails": {
+      "DelegatedFrom": "cd35779b-b174-4ecc-bbef-ece13611be7f",
+      "DelegatedTo": "5c0656db-cf51-43a4-bd64-6a91c8caacfb",
+      "LastChangedOn": "2024-11-22T14:57:39.2568955+01:00"
+    }
   }
 ]

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/RightHolders/UserAccesses/cd35779b-b174-4ecc-bbef-ece13611be7f_5c0656db-cf51-43a4-bd64-6a91c8caacfb.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/RightHolders/UserAccesses/cd35779b-b174-4ecc-bbef-ece13611be7f_5c0656db-cf51-43a4-bd64-6a91c8caacfb.json
@@ -1,5 +1,5 @@
 {
-  "accessPackages": [ "test_package" ],
+  "accessPackages": [ "test_package", "6e152c10-0f63-4060-9b14-66808e7ac320"],
   "services": [ "appid-502", "a3-app2" ],
   "roles": [ "digdir:role:ts" ]
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/AccessPackageClientMock.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/AccessPackageClientMock.cs
@@ -114,20 +114,27 @@ namespace Altinn.AccessManagement.UI.Mocks.Mocks
         /// <inheritdoc />
         public Task<List<AccessPackageDelegationCheckResponse>> AccessPackageDelegationCheck(DelegationCheckRequest delegationCheckRequest)
         {
-            try
+            if (delegationCheckRequest.ReporteeUuid.ToString() == "167536b5-f8ed-4c5a-8f48-0279507e53ae")
             {
-                var res = new List<AccessPackageDelegationCheckResponse>();
-                foreach (var packageId in delegationCheckRequest.PackageIds)
-                {
+                throw new Exception("Reportee uuid is not valid");
+            }
+
+            var res = new List<AccessPackageDelegationCheckResponse>();
+            foreach (var packageId in delegationCheckRequest.PackageIds)
+            {
+                try {
                     var check = Util.GetMockData<AccessPackageDelegationCheckResponse>($"{dataFolder}/AccessPackage/DelegationCheck/{packageId}.json");
                     res.Add(check);
+                } catch {
+                    res.Add(new AccessPackageDelegationCheckResponse()
+                    {
+                        CanDelegate = true,
+                        DetailCode = DetailCode.DelegationAccess,
+                        PackageId = packageId
+                    });
                 }
-                return Task.FromResult(res);
             }
-            catch
-            {
-                return Task.FromResult(new List<AccessPackageDelegationCheckResponse>());
-            }
+            return Task.FromResult(res);
         }
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/AccessPackageClientMock.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/AccessPackageClientMock.cs
@@ -110,5 +110,24 @@ namespace Altinn.AccessManagement.UI.Mocks.Mocks
                 });
             }
         }
+        
+        /// <inheritdoc />
+        public Task<List<AccessPackageDelegationCheckResponse>> AccessPackageDelegationCheck(DelegationCheckRequest delegationCheckRequest)
+        {
+            try
+            {
+                var res = new List<AccessPackageDelegationCheckResponse>();
+                foreach (var packageId in delegationCheckRequest.PackageIds)
+                {
+                    var check = Util.GetMockData<AccessPackageDelegationCheckResponse>($"{dataFolder}/AccessPackage/DelegationCheck/{packageId}.json");
+                    res.Add(check);
+                }
+                return Task.FromResult(res);
+            }
+            catch
+            {
+                return Task.FromResult(new List<AccessPackageDelegationCheckResponse>());
+            }
+        }
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/AccessPackageClientMock.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/AccessPackageClientMock.cs
@@ -114,14 +114,13 @@ namespace Altinn.AccessManagement.UI.Mocks.Mocks
         /// <inheritdoc />
         public Task<List<AccessPackageDelegationCheckResponse>> AccessPackageDelegationCheck(DelegationCheckRequest delegationCheckRequest)
         {
-            if (delegationCheckRequest.ReporteeUuid.ToString() == "167536b5-f8ed-4c5a-8f48-0279507e53ae")
-            {
-                throw new Exception("Reportee uuid is not valid");
-            }
-
             var res = new List<AccessPackageDelegationCheckResponse>();
             foreach (var packageId in delegationCheckRequest.PackageIds)
-            {
+            {   
+                if(packageId.ToString() == "fa84bffc-ac17-40cd-af9c-61c89f92e44c")
+                {
+                    throw new Exception("Package id is not valid");
+                }
                 try {
                     var check = Util.GetMockData<AccessPackageDelegationCheckResponse>($"{dataFolder}/AccessPackage/DelegationCheck/{packageId}.json");
                     res.Add(check);

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/AccessPackageControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/AccessPackageControllerTest.cs
@@ -2,6 +2,7 @@
 using System.Net.Http.Headers;
 using System.Text.Json;
 using Altinn.AccessManagement.UI.Controllers;
+using Altinn.AccessManagement.UI.Core.Models;
 using Altinn.AccessManagement.UI.Core.Models.AccessPackage.Frontend;
 using Altinn.AccessManagement.UI.Mocks.Utils;
 using Altinn.AccessManagement.UI.Tests.Utils;
@@ -257,5 +258,103 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             Assert.False(response.IsSuccessStatusCode);
         }
 
-    }
+        /// <summary>
+        ///    Test case: Checks if the user can delegate a a list of Roles
+        ///    Expected: Returns a list of AccessPackageDelegationCheckResponse
+        ///    with the result of the delegation check
+        /// </summary>
+        [Fact]
+        public async Task PackageDelegationCheck_handles_list()
+        {
+            // Arrange
+            string reporteeUuid = "cd35779b-b174-4ecc-bbef-ece13611be7f";
+            var packageIds = new List<string>
+            {
+                "0bb5963e-df17-4f35-b913-3ce10a34b866",
+                "04c5a001-5249-4765-ae8e-58617c404223",
+                "5eb07bdc-5c3c-4c85-add3-5405b214b8a3",
+                "9d2ec6e9-5148-4f47-9ae4-4536f6c9c1cb",
+                "78c21107-7d2d-4e85-af82-47ea0e47ceca",
+                "906aec0d-ad1f-496b-a0bb-40f81b3303cb",
+                "a03af7d5-74b9-4f18-aead-5d47edc36be5",
+                "cfe074fa-0a66-4a4b-974a-5d1db8eb94e6",
+                "f7e02568-90b6-477d-8abb-44984ddeb1f9",
+                "fa84bffc-ac17-40cd-af9c-61c89f92e44c"
+            };
+            List<AccessPackageDelegationCheckResponse> expectedResult = Util.GetMockData<List<AccessPackageDelegationCheckResponse>>(_expectedDataPath + "/AccessPackage/PackageDelegationCheck_returns_list.json");
+
+
+            // Act
+            HttpResponseMessage response = await _client.PostAsync(
+                $"accessmanagement/api/v1/accesspackage/delegationcheck", 
+                new StringContent(
+                        JsonSerializer.Serialize(new { packageIds, reporteeUuid }), 
+                        System.Text.Encoding.UTF8, "application/json"
+                    )
+                );
+            
+            var content = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.NotNull(response.Content);
+
+            List<AccessPackageDelegationCheckResponse> actual = JsonSerializer.Deserialize<List<AccessPackageDelegationCheckResponse>>(await response.Content.ReadAsStringAsync(), options);
+            AssertionUtil.AssertCollections(actual, expectedResult, AssertionUtil.AssertEqual);  
+        }
+
+        /// <summary>
+        ///    Test case: Handles empty list of packageIds
+        ///    Expected: Returns a bad request status code
+        /// </summary>
+        [Fact]
+        public async Task PackageDelegationCheck_BadRequest()
+        {
+            // Arrange
+            string reporteeUuid = "cd35779b-b174-4ecc-bbef-ece13611be7f";
+            var packageIds = new List<string>();
+            
+            // Act
+            HttpResponseMessage response = await _client.PostAsync(
+                $"accessmanagement/api/v1/accesspackage/delegationcheck", 
+                new StringContent(
+                        JsonSerializer.Serialize(new { packageIds, reporteeUuid }), 
+                        System.Text.Encoding.UTF8, "application/json"
+                    )
+                );
+            
+            var content = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        }
+
+         /// <summary>
+        ///    Test case: Handles unexpected error
+        ///    Expected: Returns internal server error
+        /// </summary>
+        [Fact]
+        public async Task PackageDelegationCheck_UnexpectedError()
+        {
+            // Arrange
+            string reporteeUuid = "167536b5-f8ed-4c5a-8f48-0279507e53ae"; // valid reportee that will trigger an unexpected exception in mock client
+            var packageIds = new List<string>
+            {
+                "0bb5963e-df17-4f35-b913-3ce10a34b866"
+            };
+            
+            // Act
+            HttpResponseMessage response = await _client.PostAsync(
+                $"accessmanagement/api/v1/accesspackage/delegationcheck", 
+                new StringContent(
+                        JsonSerializer.Serialize(new { packageIds, reporteeUuid }), 
+                        System.Text.Encoding.UTF8, "application/json"
+                    )
+                );
+            
+
+            // Assert
+            Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+        }
+    }   
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/AccessPackageControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/AccessPackageControllerTest.cs
@@ -278,8 +278,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
                 "906aec0d-ad1f-496b-a0bb-40f81b3303cb",
                 "a03af7d5-74b9-4f18-aead-5d47edc36be5",
                 "cfe074fa-0a66-4a4b-974a-5d1db8eb94e6",
-                "f7e02568-90b6-477d-8abb-44984ddeb1f9",
-                "fa84bffc-ac17-40cd-af9c-61c89f92e44c"
+                "f7e02568-90b6-477d-8abb-44984ddeb1f9"
             };
             List<AccessPackageDelegationCheckResponse> expectedResult = Util.GetMockData<List<AccessPackageDelegationCheckResponse>>(_expectedDataPath + "/AccessPackage/PackageDelegationCheck_returns_list.json");
 
@@ -337,10 +336,10 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         public async Task PackageDelegationCheck_UnexpectedError()
         {
             // Arrange
-            string reporteeUuid = "167536b5-f8ed-4c5a-8f48-0279507e53ae"; // valid reportee that will trigger an unexpected exception in mock client
+            string reporteeUuid = "cd35779b-b174-4ecc-bbef-ece13611be7f";
             var packageIds = new List<string>
             {
-                "0bb5963e-df17-4f35-b913-3ce10a34b866"
+                "fa84bffc-ac17-40cd-af9c-61c89f92e44c"  // valid package id that will trigger an unexpected exception in mock client
             };
             
             // Act

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/AccessPackage/GetDelegations/167536b5-f8ed-4c5a-8f48-0279507e53ae.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/AccessPackage/GetDelegations/167536b5-f8ed-4c5a-8f48-0279507e53ae.json
@@ -1,24 +1,24 @@
 {
   "fc93d25e-80bc-469a-aa43-a6cee80eb3e2": [
     {
-      "accessPackageId": "7b8a3aaa-c8ed-4ac4-923a-335f4f9eb45a",
-      "delegationDetails": {
-        "delegatedFrom": "cd35779b-b174-4ecc-bbef-ece13611be7f",
-        "delegatedTo": "167536b5-f8ed-4c5a-8f48-0279507e53ae",
-        "lastChangedOn": "2024-11-22T14:57:39.2568955+01:00"
+      "AccessPackageId": "7b8a3aaa-c8ed-4ac4-923a-335f4f9eb45a",
+      "DelegationDetails": {
+        "DelegatedFrom": "cd35779b-b174-4ecc-bbef-ece13611be7f",
+        "DelegatedTo": "167536b5-f8ed-4c5a-8f48-0279507e53ae",
+        "LastChangedOn": "2024-11-22T14:57:39.2568955+01:00"
       },
-      "inherited": false,
-      "inheritedFrom": null
+      "Inherited": false,
+      "InheritedFrom": null
     },
     {
-      "accessPackageId": "c5bbbc3f-605a-4dcb-a587-32124d7bb76d",
-      "delegationDetails": {
-        "delegatedFrom": "cd35779b-b174-4ecc-bbef-ece13611be7f",
-        "delegatedTo": "87ebc0fe-3b79-49b5-81f8-d084c4e38c84",
-        "lastChangedOn": "2024-10-22T15:57:39.2568955+02:00"
+      "AccessPackageId": "c5bbbc3f-605a-4dcb-a587-32124d7bb76d",
+      "DelegationDetails": {
+        "DelegatedFrom": "cd35779b-b174-4ecc-bbef-ece13611be7f",
+        "DelegatedTo": "87ebc0fe-3b79-49b5-81f8-d084c4e38c84",
+        "LastChangedOn": "2024-10-22T15:57:39.2568955+02:00"
       },
-      "inherited": true,
-      "inheritedFrom": {
+      "Inherited": true,
+      "InheritedFrom": {
         "partyId": 51398461,
         "partyUuid": "87ebc0fe-3b79-49b5-81f8-d084c4e38c84",
         "partyTypeName": 2,
@@ -51,37 +51,14 @@
   ],
   "a8834a7c-ed89-4c73-b5d5-19a2347f3b13": [
     {
-      "accessPackageId": "bacc9294-56fd-457f-930e-59ee4a7a3894",
-      "delegationDetails": {
-        "delegatedFrom": "cd35779b-b174-4ecc-bbef-ece13611be7f",
-        "delegatedTo": "167536b5-f8ed-4c5a-8f48-0279507e53ae",
-        "lastChangedOn": "2024-10-22T15:57:39.2568955+02:00"
+      "AccessPackageId": "bacc9294-56fd-457f-930e-59ee4a7a3894",
+      "DelegationDetails": {
+        "DelegatedFrom": "cd35779b-b174-4ecc-bbef-ece13611be7f",
+        "DelegatedTo": "167536b5-f8ed-4c5a-8f48-0279507e53ae",
+        "LastChangedOn": "2024-10-22T15:57:39.2568955+02:00"
       },
-      "inherited": false,
-      "inheritedFrom": null
-    }, 
-    {
-      "accessPackageId": "91cf61ae-69ab-49d5-b51a-80591c91f255",
-      "delegationDetails": {
-        "delegatedFrom": "cd35779b-b174-4ecc-bbef-ece13611be7f",
-        "delegatedTo": "167536b5-f8ed-4c5a-8f48-0279507e53ae",
-        "lastChangedOn": "2024-10-22T15:57:39.2568955+02:00"
-      },
-      "inherited": false,
-      "inheritedFrom": null
-    }
-    
-  ],
-  "6F938DE8-34F2-4BAB-A0C6-3A3EB64AAD3B": [
-    {
-      "accessPackageId": "91cf61ae-69ab-49d5-b51a-80591c91f255",
-      "delegationDetails": {
-        "delegatedFrom": "cd35779b-b174-4ecc-bbef-ece13611be7f",
-        "delegatedTo": "87ebc0fe-3b79-49b5-81f8-d084c4e38c84",
-        "lastChangedOn": "2024-10-22T15:57:39.2568955+02:00"
-      },
-      "inherited": true,
-      "inheritedFrom": {
+      "Inherited": false,
+      "InheritedFrom": {
         "partyId": 51398461,
         "partyUuid": "87ebc0fe-3b79-49b5-81f8-d084c4e38c84",
         "partyTypeName": 2,
@@ -110,6 +87,18 @@
         },
         "childParties": null
       }
+    }
+  ],
+  "6F938DE8-34F2-4BAB-A0C6-3A3EB64AAD3B": [
+    {
+      "AccessPackageId": "91cf61ae-69ab-49d5-b51a-80591c91f255",
+      "DelegationDetails": {
+        "DelegatedFrom": "cd35779b-b174-4ecc-bbef-ece13611be7f",
+        "DelegatedTo": "87ebc0fe-3b79-49b5-81f8-d084c4e38c84",
+        "LastChangedOn": "2024-10-22T15:57:39.2568955+02:00"
+      },
+      "Inherited": true,
+      "InheritedFrom": null
     }
   ]
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/AccessPackage/GetDelegations/167536b5-f8ed-4c5a-8f48-0279507e53ae.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/AccessPackage/GetDelegations/167536b5-f8ed-4c5a-8f48-0279507e53ae.json
@@ -1,24 +1,24 @@
 {
   "fc93d25e-80bc-469a-aa43-a6cee80eb3e2": [
     {
-      "AccessPackageId": "7b8a3aaa-c8ed-4ac4-923a-335f4f9eb45a",
-      "DelegationDetails": {
-        "DelegatedFrom": "cd35779b-b174-4ecc-bbef-ece13611be7f",
-        "DelegatedTo": "167536b5-f8ed-4c5a-8f48-0279507e53ae",
-        "LastChangedOn": "2024-11-22T14:57:39.2568955+01:00"
+      "accessPackageId": "7b8a3aaa-c8ed-4ac4-923a-335f4f9eb45a",
+      "delegationDetails": {
+        "delegatedFrom": "cd35779b-b174-4ecc-bbef-ece13611be7f",
+        "delegatedTo": "167536b5-f8ed-4c5a-8f48-0279507e53ae",
+        "lastChangedOn": "2024-11-22T14:57:39.2568955+01:00"
       },
-      "Inherited": false,
-      "InheritedFrom": null
+      "inherited": false,
+      "inheritedFrom": null
     },
     {
-      "AccessPackageId": "c5bbbc3f-605a-4dcb-a587-32124d7bb76d",
-      "DelegationDetails": {
-        "DelegatedFrom": "cd35779b-b174-4ecc-bbef-ece13611be7f",
-        "DelegatedTo": "87ebc0fe-3b79-49b5-81f8-d084c4e38c84",
-        "LastChangedOn": "2024-10-22T15:57:39.2568955+02:00"
+      "accessPackageId": "c5bbbc3f-605a-4dcb-a587-32124d7bb76d",
+      "delegationDetails": {
+        "delegatedFrom": "cd35779b-b174-4ecc-bbef-ece13611be7f",
+        "delegatedTo": "87ebc0fe-3b79-49b5-81f8-d084c4e38c84",
+        "lastChangedOn": "2024-10-22T15:57:39.2568955+02:00"
       },
-      "Inherited": true,
-      "InheritedFrom": {
+      "inherited": true,
+      "inheritedFrom": {
         "partyId": 51398461,
         "partyUuid": "87ebc0fe-3b79-49b5-81f8-d084c4e38c84",
         "partyTypeName": 2,
@@ -51,14 +51,14 @@
   ],
   "a8834a7c-ed89-4c73-b5d5-19a2347f3b13": [
     {
-      "AccessPackageId": "bacc9294-56fd-457f-930e-59ee4a7a3894",
-      "DelegationDetails": {
-        "DelegatedFrom": "cd35779b-b174-4ecc-bbef-ece13611be7f",
-        "DelegatedTo": "167536b5-f8ed-4c5a-8f48-0279507e53ae",
-        "LastChangedOn": "2024-10-22T15:57:39.2568955+02:00"
+      "accessPackageId": "bacc9294-56fd-457f-930e-59ee4a7a3894",
+      "delegationDetails": {
+        "delegatedFrom": "cd35779b-b174-4ecc-bbef-ece13611be7f",
+        "delegatedTo": "167536b5-f8ed-4c5a-8f48-0279507e53ae",
+        "lastChangedOn": "2024-10-22T15:57:39.2568955+02:00"
       },
-      "Inherited": false,
-      "InheritedFrom": {
+      "inherited": false,
+      "inheritedFrom": {
         "partyId": 51398461,
         "partyUuid": "87ebc0fe-3b79-49b5-81f8-d084c4e38c84",
         "partyTypeName": 2,
@@ -91,14 +91,14 @@
   ],
   "6F938DE8-34F2-4BAB-A0C6-3A3EB64AAD3B": [
     {
-      "AccessPackageId": "91cf61ae-69ab-49d5-b51a-80591c91f255",
-      "DelegationDetails": {
-        "DelegatedFrom": "cd35779b-b174-4ecc-bbef-ece13611be7f",
-        "DelegatedTo": "87ebc0fe-3b79-49b5-81f8-d084c4e38c84",
-        "LastChangedOn": "2024-10-22T15:57:39.2568955+02:00"
+      "accessPackageId": "91cf61ae-69ab-49d5-b51a-80591c91f255",
+      "delegationDetails": {
+        "delegatedFrom": "cd35779b-b174-4ecc-bbef-ece13611be7f",
+        "delegatedTo": "87ebc0fe-3b79-49b5-81f8-d084c4e38c84",
+        "lastChangedOn": "2024-10-22T15:57:39.2568955+02:00"
       },
-      "Inherited": true,
-      "InheritedFrom": null
+      "inherited": true,
+      "inheritedFrom": null
     }
   ]
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/AccessPackage/GetDelegations/167536b5-f8ed-4c5a-8f48-0279507e53ae.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/AccessPackage/GetDelegations/167536b5-f8ed-4c5a-8f48-0279507e53ae.json
@@ -59,7 +59,18 @@
       },
       "inherited": false,
       "inheritedFrom": null
+    }, 
+    {
+      "accessPackageId": "91cf61ae-69ab-49d5-b51a-80591c91f255",
+      "delegationDetails": {
+        "delegatedFrom": "cd35779b-b174-4ecc-bbef-ece13611be7f",
+        "delegatedTo": "167536b5-f8ed-4c5a-8f48-0279507e53ae",
+        "lastChangedOn": "2024-10-22T15:57:39.2568955+02:00"
+      },
+      "inherited": false,
+      "inheritedFrom": null
     }
+    
   ],
   "6F938DE8-34F2-4BAB-A0C6-3A3EB64AAD3B": [
     {

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/AccessPackage/PackageDelegationCheck_returns_list.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/AccessPackage/PackageDelegationCheck_returns_list.json
@@ -37,7 +37,7 @@
   {
     "packageId": "cfe074fa-0a66-4a4b-974a-5d1db8eb94e6",
     "canDelegate": false,
-    "detailCode": "AlreadyDelegated"
+    "detailCode": "AccessListValidationFail"
   },
   {
     "packageId": "f7e02568-90b6-477d-8abb-44984ddeb1f9",

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/AccessPackage/PackageDelegationCheck_returns_list.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/AccessPackage/PackageDelegationCheck_returns_list.json
@@ -1,0 +1,52 @@
+[
+  {
+    "packageId": "0bb5963e-df17-4f35-b913-3ce10a34b866",
+    "canDelegate": false,
+    "detailCode": "Unknown"
+  },
+  {
+    "packageId": "04c5a001-5249-4765-ae8e-58617c404223",
+    "canDelegate": false,
+    "detailCode": "InsufficientAuthenticationLevel"
+  },
+  {
+    "packageId": "5eb07bdc-5c3c-4c85-add3-5405b214b8a3",
+    "canDelegate": false,
+    "detailCode": "MissingSrrRightAccess"
+  },
+  {
+    "packageId": "9d2ec6e9-5148-4f47-9ae4-4536f6c9c1cb",
+    "canDelegate": true,
+    "detailCode": "DelegationAccess"
+  },
+  {
+    "packageId": "78c21107-7d2d-4e85-af82-47ea0e47ceca",
+    "canDelegate": true,
+    "detailCode": "SrrRightAccess"
+  },
+  {
+    "packageId": "906aec0d-ad1f-496b-a0bb-40f81b3303cb",
+    "canDelegate": false,
+    "detailCode": "MissingRoleAccess"
+  },
+  {
+    "packageId": "a03af7d5-74b9-4f18-aead-5d47edc36be5",
+    "canDelegate": true,
+    "detailCode": "AccessListValidationPass"
+  },
+  {
+    "packageId": "cfe074fa-0a66-4a4b-974a-5d1db8eb94e6",
+    "canDelegate": false,
+    "detailCode": "AlreadyDelegated"
+  },
+  {
+    "packageId": "f7e02568-90b6-477d-8abb-44984ddeb1f9",
+    "canDelegate": false,
+    "detailCode": "MissingDelegationAccess"
+  },
+  {
+    "packageId": "fa84bffc-ac17-40cd-af9c-61c89f92e44c",
+    "canDelegate": false,
+    "detailCode": "AccessListValidationFail"
+  }
+]

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/AccessPackage/PackageDelegationCheck_returns_list.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/AccessPackage/PackageDelegationCheck_returns_list.json
@@ -41,12 +41,7 @@
   },
   {
     "packageId": "f7e02568-90b6-477d-8abb-44984ddeb1f9",
-    "canDelegate": false,
-    "detailCode": "MissingDelegationAccess"
-  },
-  {
-    "packageId": "fa84bffc-ac17-40cd-af9c-61c89f92e44c",
-    "canDelegate": false,
-    "detailCode": "AccessListValidationFail"
+    "canDelegate": true,
+    "detailCode": "DelegationAccess"
   }
 ]

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/RightHolders/RightHolderAccess/5c0656db-cf51-43a4-bd64-6a91c8caacfb.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/RightHolders/RightHolderAccess/5c0656db-cf51-43a4-bd64-6a91c8caacfb.json
@@ -1,4 +1,4 @@
 {
-  "accessPackages": [ "test_package" ],
+  "accessPackages": [ "test_package", "6e152c10-0f63-4060-9b14-66808e7ac320" ],
   "services": [ "appid-502", "a3-app2" ]
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Utils/AssertionUtil.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Utils/AssertionUtil.cs
@@ -513,6 +513,18 @@ namespace Altinn.AccessManagement.UI.Tests.Utils
             Assert.Equal(expected.System.SystemId, actual.System.SystemId);
             Assert.Equal(expected.System.SystemVendorOrgName, actual.System.SystemVendorOrgName);
             Assert.Equal(expected.System.SystemVendorOrgNumber, actual.System.SystemVendorOrgNumber);
+        }        
+        
+        public static void AssertEqual(AccessPackageDelegationCheckResponse expected, AccessPackageDelegationCheckResponse actual)
+        {
+            Assert.NotNull(actual);
+            Assert.NotNull(expected);
+
+            Assert.Equal(expected.CanDelegate , actual.CanDelegate);
+            Assert.Equal(expected.DetailCode, actual.DetailCode);
+            Assert.Equal(expected.PackageId, actual.PackageId);
         }
+
+
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/AccessPackageController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/AccessPackageController.cs
@@ -168,5 +168,35 @@ namespace Altinn.AccessManagement.UI.Controllers
                 return new ObjectResult(ProblemDetailsFactory.CreateProblemDetails(HttpContext, (int?)ex.StatusCode, "Unexpected HttpStatus response", detail: responseContent));
             }
         }
+
+        /// <summary>
+        ///     Check if a set of package can be delegated
+        /// </summary>
+        /// <returns>If the role can be delegated and the DetailCode for why</returns>
+        [HttpPost]
+        [Authorize]
+        [Route("delegationcheck")]
+        public async Task<ActionResult<List<AccessPackageDelegationCheckResponse>>> RoleDelegationCheck([FromBody] DelegationCheckRequest delegationCheckRequest)
+        {
+            if (delegationCheckRequest.PackageIds == null || delegationCheckRequest.PackageIds.Length == 0)
+            {
+                return BadRequest("Role IDs cannot be null or empty.");
+            }
+
+            try
+            {
+                return await _accessPackageService.DelegationCheck(delegationCheckRequest);
+            }
+            catch (HttpStatusException ex)
+            {
+                if (ex.StatusCode == HttpStatusCode.NoContent)
+                {
+                    return NoContent();
+                }
+
+                string responseContent = ex.Message;
+                return new ObjectResult(ProblemDetailsFactory.CreateProblemDetails(HttpContext, (int?)ex.StatusCode, "Unexpected HttpStatus response", detail: responseContent));
+            }
+        }
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/AccessPackageController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/AccessPackageController.cs
@@ -170,9 +170,9 @@ namespace Altinn.AccessManagement.UI.Controllers
         }
 
         /// <summary>
-        ///     Check if a set of package can be delegated
+        ///     Check if a set of packages can be delegated
         /// </summary>
-        /// <returns>If the role can be delegated and the DetailCode for why</returns>
+        /// <returns>If the packages can be delegated and the DetailCode for why</returns>
         [HttpPost]
         [Authorize]
         [Route("delegationcheck")]

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/AccessPackageController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/AccessPackageController.cs
@@ -178,22 +178,17 @@ namespace Altinn.AccessManagement.UI.Controllers
         [Route("delegationcheck")]
         public async Task<ActionResult<List<AccessPackageDelegationCheckResponse>>> RoleDelegationCheck([FromBody] DelegationCheckRequest delegationCheckRequest)
         {
-            if (delegationCheckRequest.PackageIds == null || delegationCheckRequest.PackageIds.Length == 0)
+            if (!ModelState.IsValid || delegationCheckRequest.PackageIds == null || delegationCheckRequest.PackageIds.Length == 0)
             {
-                return BadRequest("Role IDs cannot be null or empty.");
+                return BadRequest(ModelState);
             }
-
+            
             try
             {
                 return await _accessPackageService.DelegationCheck(delegationCheckRequest);
             }
             catch (HttpStatusException ex)
             {
-                if (ex.StatusCode == HttpStatusCode.NoContent)
-                {
-                    return NoContent();
-                }
-
                 string responseContent = ex.Message;
                 return new ObjectResult(ProblemDetailsFactory.CreateProblemDetails(HttpContext, (int?)ex.StatusCode, "Unexpected HttpStatus response", detail: responseContent));
             }

--- a/src/features/amUI/common/AccessPackageList/AccessPackageList.tsx
+++ b/src/features/amUI/common/AccessPackageList/AccessPackageList.tsx
@@ -1,23 +1,19 @@
-import { ListBase, Button } from '@altinn/altinn-components';
+import { ListBase } from '@altinn/altinn-components';
 import { useState } from 'react';
-import { MinusCircleIcon, PlusCircleIcon } from '@navikt/aksel-icons';
-import { useTranslation } from 'react-i18next';
-import { Paragraph } from '@digdir/designsystemet-react';
 
 import type { Party } from '@/rtk/features/lookupApi';
 import { useGetUserDelegationsQuery, useSearchQuery } from '@/rtk/features/accessPackageApi';
 import type { AccessPackage } from '@/rtk/features/accessPackageApi';
 import type { ActionError } from '@/resources/hooks/useActionError';
 
-import { ButtonWithConfirmPopup } from '../ButtonWithConfirmPopup/ButtonWithConfirmPopup';
-import { DelegationAction } from '../DelegationModal/EditModal';
+import type { DelegationAction } from '../DelegationModal/EditModal';
 
 import classes from './AccessPackageList.module.css';
 import { useAreaPackageList } from './useAreaPackageList';
 import { AreaItem } from './AreaItem';
-import { PackageItem } from './PackageItem';
 import { useAccessPackageActions } from './useAccessPackageActions';
 import { SkeletonAccessPackageList } from './SkeletonAccessPackageList';
+import { AreaItemContent } from './AreaItemContent';
 
 interface AccessPackageListProps {
   showAllPackages?: boolean;
@@ -57,9 +53,9 @@ export const AccessPackageList = ({
     from: fromPartyUuid,
     to: toPartyUuid,
   });
-  const { t } = useTranslation();
 
   const [expandedAreas, setExpandedAreas] = useState<string[]>([]);
+
   const toggleExpandedArea = (areaId: string) => {
     if (expandedAreas.some((id) => id === areaId)) {
       const newExpandedState = expandedAreas.filter((id) => id !== areaId);
@@ -95,7 +91,6 @@ export const AccessPackageList = ({
       ) : (
         <ListBase>
           {sortedAreas.map((area) => {
-            const { packages } = area;
             const expanded = expandedAreas.some((areaId) => areaId === area.id);
 
             return (
@@ -106,89 +101,15 @@ export const AccessPackageList = ({
                 toggleExpandedArea={toggleExpandedArea}
                 showBadge={showAllPackages}
               >
-                <div className={classes.accessAreaContent}>
-                  <Paragraph>{area.description}</Paragraph>
-                  {packages.assigned.length > 0 && (
-                    <ListBase>
-                      {packages.assigned.map((pkg) => (
-                        <PackageItem
-                          key={pkg.id}
-                          pkg={pkg}
-                          onSelect={onSelect}
-                          hasAccess
-                          controls={
-                            availableActions?.includes(DelegationAction.REVOKE) &&
-                            useDeleteConfirm ? (
-                              <ButtonWithConfirmPopup
-                                triggerButtonContent={t('common.delete_poa')}
-                                triggerButtonProps={{
-                                  icon: MinusCircleIcon,
-                                  variant: 'text',
-                                  size: 'sm',
-                                  disabled: pkg.inherited,
-                                }}
-                                popoverProps={{
-                                  color: 'neutral',
-                                }}
-                                message={t('user_rights_page.delete_confirm_message', {
-                                  name: pkg.name,
-                                })}
-                                data-size='sm'
-                                onConfirm={() => onRevoke(pkg)}
-                              />
-                            ) : (
-                              <Button
-                                icon={MinusCircleIcon}
-                                variant='text'
-                                size='sm'
-                                disabled={pkg.inherited}
-                                onClick={() => onRevoke(pkg)}
-                              >
-                                {t('common.delete_poa')}
-                              </Button>
-                            )
-                          }
-                        />
-                      ))}
-                    </ListBase>
-                  )}
-                  {packages.available.length > 0 && (
-                    <ListBase>
-                      {packages.available.map((pkg) => (
-                        <PackageItem
-                          key={pkg.id}
-                          pkg={pkg}
-                          onSelect={onSelect}
-                          controls={
-                            <>
-                              {availableActions?.includes(DelegationAction.DELEGATE) && (
-                                <Button
-                                  icon={PlusCircleIcon}
-                                  variant='text'
-                                  size='sm'
-                                  onClick={() => onDelegate(pkg)}
-                                >
-                                  {t('common.give_poa')}
-                                </Button>
-                              )}
-                              {availableActions?.includes(DelegationAction.REQUEST) && (
-                                <Button
-                                  icon={PlusCircleIcon}
-                                  variant='text'
-                                  size='sm'
-                                  disabled
-                                  onClick={() => onRequest(pkg)}
-                                >
-                                  {t('common.request_poa')}
-                                </Button>
-                              )}
-                            </>
-                          }
-                        />
-                      ))}
-                    </ListBase>
-                  )}
-                </div>
+                <AreaItemContent
+                  area={area}
+                  availableActions={availableActions}
+                  onSelect={onSelect}
+                  onDelegate={onDelegate}
+                  onRevoke={onRevoke}
+                  onRequest={onRequest}
+                  useDeleteConfirm={useDeleteConfirm}
+                />
               </AreaItem>
             );
           })}

--- a/src/features/amUI/common/AccessPackageList/AreaItemContent.tsx
+++ b/src/features/amUI/common/AccessPackageList/AreaItemContent.tsx
@@ -2,6 +2,7 @@ import { Paragraph } from '@digdir/designsystemet-react';
 import { Button, ListBase } from '@altinn/altinn-components';
 import { MinusCircleIcon, PlusCircleIcon } from '@navikt/aksel-icons';
 import { useTranslation } from 'react-i18next';
+import { useEffect, useMemo } from 'react';
 
 import { useDelegationCheckMutation, type AccessPackage } from '@/rtk/features/accessPackageApi';
 
@@ -34,96 +35,94 @@ export const AreaItemContent = ({
   const { packages } = area;
   const { t } = useTranslation();
 
-  const { canDelegatePackage: canDelegate } = useDelegationCheck(
-    packages.available.map((pkg) => pkg.id),
+  const availablePackageIds = useMemo(
+    () => packages.available.map((pkg) => pkg.id),
+    [packages.available],
   );
+
+  const canDelegate = useDelegationCheck(availablePackageIds);
 
   return (
     <div className={classes.accessAreaContent}>
       <Paragraph>{area.description}</Paragraph>
       {packages.assigned.length > 0 && (
         <ListBase>
-          {packages.assigned.map((pkg) => {
-            return (
-              <PackageItem
-                key={pkg.id}
-                pkg={pkg}
-                onSelect={onSelect}
-                hasAccess
-                controls={
-                  availableActions?.includes(DelegationAction.REVOKE) && useDeleteConfirm ? (
-                    <ButtonWithConfirmPopup
-                      triggerButtonContent={t('common.delete_poa')}
-                      triggerButtonProps={{
-                        icon: MinusCircleIcon,
-                        variant: 'text',
-                        size: 'sm',
-                        disabled: pkg.inherited,
-                      }}
-                      popoverProps={{
-                        color: 'neutral',
-                      }}
-                      message={t('user_rights_page.delete_confirm_message', {
-                        name: pkg.name,
-                      })}
-                      data-size='sm'
-                      onConfirm={() => onRevoke(pkg)}
-                    />
-                  ) : (
-                    <Button
-                      icon={MinusCircleIcon}
-                      variant='text'
-                      size='sm'
-                      disabled={pkg.inherited}
-                      onClick={() => onRevoke(pkg)}
-                    >
-                      {t('common.delete_poa')}
-                    </Button>
-                  )
-                }
-              />
-            );
-          })}
+          {packages.assigned.map((pkg) => (
+            <PackageItem
+              key={pkg.id}
+              pkg={pkg}
+              onSelect={onSelect}
+              hasAccess
+              controls={
+                availableActions?.includes(DelegationAction.REVOKE) && useDeleteConfirm ? (
+                  <ButtonWithConfirmPopup
+                    triggerButtonContent={t('common.delete_poa')}
+                    triggerButtonProps={{
+                      icon: MinusCircleIcon,
+                      variant: 'text',
+                      size: 'sm',
+                      disabled: pkg.inherited,
+                    }}
+                    popoverProps={{
+                      color: 'neutral',
+                    }}
+                    message={t('user_rights_page.delete_confirm_message', {
+                      name: pkg.name,
+                    })}
+                    data-size='sm'
+                    onConfirm={() => onRevoke(pkg)}
+                  />
+                ) : (
+                  <Button
+                    icon={MinusCircleIcon}
+                    variant='text'
+                    size='sm'
+                    disabled={pkg.inherited}
+                    onClick={() => onRevoke(pkg)}
+                  >
+                    {t('common.delete_poa')}
+                  </Button>
+                )
+              }
+            />
+          ))}
         </ListBase>
       )}
       {packages.available.length > 0 && (
         <ListBase>
-          {packages.available.map((pkg) => {
-            const delegationCheck = canDelegate(pkg.id);
-            return (
-              <PackageItem
-                key={pkg.id}
-                pkg={pkg}
-                onSelect={onSelect}
-                controls={
-                  <>
-                    {availableActions?.includes(DelegationAction.DELEGATE) && (
-                      <Button
-                        icon={PlusCircleIcon}
-                        variant='text'
-                        size='sm'
-                        disabled={delegationCheck}
-                        onClick={() => onDelegate(pkg)}
-                      >
-                        {t('common.give_poa')}
-                      </Button>
-                    )}
-                    {availableActions?.includes(DelegationAction.REQUEST) && (
-                      <Button
-                        icon={PlusCircleIcon}
-                        variant='text'
-                        size='sm'
-                        disabled
-                        onClick={() => onRequest(pkg)}
-                      >
-                        {t('common.request_poa')}
-                      </Button>
-                    )}
-                  </>
-                }
-              />
-            );
-          })}
+          {packages.available.map((pkg) => (
+            <PackageItem
+              key={pkg.id}
+              pkg={pkg}
+              onSelect={onSelect}
+              controls={
+                <>
+                  {availableActions?.includes(DelegationAction.DELEGATE) && (
+                    <Button
+                      icon={PlusCircleIcon}
+                      variant='text'
+                      size='sm'
+                      disabled={canDelegate(pkg.id)}
+                      onClick={() => onDelegate(pkg)}
+                    >
+                      {t('common.give_poa')}
+                    </Button>
+                  )}
+                  {availableActions?.includes(DelegationAction.REQUEST) && (
+                    <Button
+                      icon={PlusCircleIcon}
+                      variant='text'
+                      size='sm'
+                      disabled
+                      onClick={() => onRequest(pkg)}
+                    >
+                      {t('common.request_poa')}
+                    </Button>
+                  )}
+                </>
+              }
+            />
+          ))}
         </ListBase>
       )}
     </div>
@@ -131,14 +130,16 @@ export const AreaItemContent = ({
 };
 
 const useDelegationCheck = (accessPackageIds: string[]) => {
-  const [delegationCheck, { isLoading, data: delegationChecks }] = useDelegationCheckMutation();
+  const [delegationCheck, { isLoading, data }] = useDelegationCheckMutation();
 
-  const canDelegatePackage = (packageId: string) => {
-    const check = delegationChecks?.find((c) => c.packageId === packageId);
-    return isLoading || !!check?.canDelegate;
-  };
+  useEffect(() => {
+    if (accessPackageIds.length > 0) {
+      delegationCheck({ packageIds: accessPackageIds });
+    }
+  }, [accessPackageIds]);
 
-  delegationCheck({ packageIds: accessPackageIds });
+  const canDelegate = (id: string) =>
+    !isLoading && data?.find((d) => d.packageId === id)?.canDelegate;
 
-  return { canDelegatePackage, isLoading };
+  return canDelegate;
 };

--- a/src/features/amUI/common/AccessPackageList/AreaItemContent.tsx
+++ b/src/features/amUI/common/AccessPackageList/AreaItemContent.tsx
@@ -2,9 +2,9 @@ import { Paragraph } from '@digdir/designsystemet-react';
 import { Button, ListBase } from '@altinn/altinn-components';
 import { MinusCircleIcon, PlusCircleIcon } from '@navikt/aksel-icons';
 import { useTranslation } from 'react-i18next';
-import { useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 
-import { useDelegationCheckMutation, type AccessPackage } from '@/rtk/features/accessPackageApi';
+import type { AccessPackage } from '@/rtk/features/accessPackageApi';
 
 import { ButtonWithConfirmPopup } from '../ButtonWithConfirmPopup/ButtonWithConfirmPopup';
 import { DelegationAction } from '../DelegationModal/EditModal';
@@ -12,6 +12,7 @@ import { DelegationAction } from '../DelegationModal/EditModal';
 import classes from './AccessPackageList.module.css';
 import type { ExtendedAccessArea } from './useAreaPackageList';
 import { PackageItem } from './PackageItem';
+import { useDelegationCheck } from '@/resources/hooks/useAccessPackageDelegationCheck';
 
 interface AreaItemContentProps {
   area: ExtendedAccessArea;
@@ -128,19 +129,4 @@ export const AreaItemContent = ({
       )}
     </div>
   );
-};
-
-const useDelegationCheck = (accessPackageIds: string[], shouldShowDelegationCheck: boolean) => {
-  const [delegationCheck, { isLoading, data }] = useDelegationCheckMutation();
-
-  useEffect(() => {
-    if (accessPackageIds.length > 0 && shouldShowDelegationCheck) {
-      delegationCheck({ packageIds: accessPackageIds });
-    }
-  }, [accessPackageIds]);
-
-  const canDelegate = (id: string) =>
-    !isLoading && data?.find((d) => d.packageId === id)?.canDelegate;
-
-  return canDelegate;
 };

--- a/src/features/amUI/common/AccessPackageList/AreaItemContent.tsx
+++ b/src/features/amUI/common/AccessPackageList/AreaItemContent.tsx
@@ -40,7 +40,8 @@ export const AreaItemContent = ({
     [packages.available],
   );
 
-  const canDelegate = useDelegationCheck(availablePackageIds);
+  const shouldShowDelegationCheck = !!availableActions?.includes(DelegationAction.DELEGATE);
+  const canDelegate = useDelegationCheck(availablePackageIds, shouldShowDelegationCheck);
 
   return (
     <div className={classes.accessAreaContent}>
@@ -102,7 +103,7 @@ export const AreaItemContent = ({
                       icon={PlusCircleIcon}
                       variant='text'
                       size='sm'
-                      disabled={canDelegate(pkg.id)}
+                      disabled={!canDelegate(pkg.id)}
                       onClick={() => onDelegate(pkg)}
                     >
                       {t('common.give_poa')}
@@ -129,11 +130,11 @@ export const AreaItemContent = ({
   );
 };
 
-const useDelegationCheck = (accessPackageIds: string[]) => {
+const useDelegationCheck = (accessPackageIds: string[], shouldShowDelegationCheck: boolean) => {
   const [delegationCheck, { isLoading, data }] = useDelegationCheckMutation();
 
   useEffect(() => {
-    if (accessPackageIds.length > 0) {
+    if (accessPackageIds.length > 0 && shouldShowDelegationCheck) {
       delegationCheck({ packageIds: accessPackageIds });
     }
   }, [accessPackageIds]);

--- a/src/features/amUI/common/AccessPackageList/AreaItemContent.tsx
+++ b/src/features/amUI/common/AccessPackageList/AreaItemContent.tsx
@@ -1,5 +1,5 @@
 import { Alert, Heading, Paragraph } from '@digdir/designsystemet-react';
-import { Button, Header, ListBase } from '@altinn/altinn-components';
+import { Button, ListBase } from '@altinn/altinn-components';
 import { MinusCircleIcon, PlusCircleIcon } from '@navikt/aksel-icons';
 import { useTranslation } from 'react-i18next';
 import { useMemo, useState } from 'react';

--- a/src/features/amUI/common/AccessPackageList/AreaItemContent.tsx
+++ b/src/features/amUI/common/AccessPackageList/AreaItemContent.tsx
@@ -1,0 +1,132 @@
+import { Paragraph } from '@digdir/designsystemet-react';
+import { Button, ListBase } from '@altinn/altinn-components';
+import { MinusCircleIcon, PlusCircleIcon } from '@navikt/aksel-icons';
+import { useTranslation } from 'react-i18next';
+import { use } from 'chai';
+
+import { ButtonWithConfirmPopup } from '../ButtonWithConfirmPopup/ButtonWithConfirmPopup';
+import { DelegationAction } from '../DelegationModal/EditModal';
+
+import classes from './AccessPackageList.module.css';
+import type { ExtendedAccessArea } from './useAreaPackageList';
+import { PackageItem } from './PackageItem';
+
+import { useDelegationCheckQuery, type AccessPackage } from '@/rtk/features/accessPackageApi';
+
+interface AreaItemContentProps {
+  area: ExtendedAccessArea;
+  availableActions?: DelegationAction[];
+  onSelect?: (accessPackage: AccessPackage) => void;
+  onDelegate: (accessPackage: AccessPackage) => void;
+  onRevoke: (accessPackage: AccessPackage) => void;
+  onRequest: (accessPackage: AccessPackage) => void;
+  useDeleteConfirm?: boolean;
+}
+
+export const AreaItemContent = ({
+  area,
+  availableActions,
+  onSelect,
+  onDelegate,
+  onRevoke,
+  onRequest,
+  useDeleteConfirm,
+}: AreaItemContentProps) => {
+  const { packages } = area;
+  const { t } = useTranslation();
+
+  const { data: delegationChecks } = useDelegationCheckQuery({
+    packageIds: area.packages.available.map((p) => p.id),
+  });
+
+  return (
+    <div className={classes.accessAreaContent}>
+      <Paragraph>{area.description}</Paragraph>
+      {packages.assigned.length > 0 && (
+        <ListBase>
+          {packages.assigned.map((pkg) => {
+            return (
+              <PackageItem
+                key={pkg.id}
+                pkg={pkg}
+                onSelect={onSelect}
+                hasAccess
+                controls={
+                  availableActions?.includes(DelegationAction.REVOKE) && useDeleteConfirm ? (
+                    <ButtonWithConfirmPopup
+                      triggerButtonContent={t('common.delete_poa')}
+                      triggerButtonProps={{
+                        icon: MinusCircleIcon,
+                        variant: 'text',
+                        size: 'sm',
+                        disabled: pkg.inherited,
+                      }}
+                      popoverProps={{
+                        color: 'neutral',
+                      }}
+                      message={t('user_rights_page.delete_confirm_message', {
+                        name: pkg.name,
+                      })}
+                      data-size='sm'
+                      onConfirm={() => onRevoke(pkg)}
+                    />
+                  ) : (
+                    <Button
+                      icon={MinusCircleIcon}
+                      variant='text'
+                      size='sm'
+                      disabled={pkg.inherited}
+                      onClick={() => onRevoke(pkg)}
+                    >
+                      {t('common.delete_poa')}
+                    </Button>
+                  )
+                }
+              />
+            );
+          })}
+        </ListBase>
+      )}
+      {packages.available.length > 0 && (
+        <ListBase>
+          {packages.available.map((pkg) => {
+            const delegationCheck = delegationChecks?.find((dc) => dc.packageId === pkg.id);
+            console.log('🚀 ~ {packages.available.map ~ delegationCheck:', delegationCheck);
+            return (
+              <PackageItem
+                key={pkg.id}
+                pkg={pkg}
+                onSelect={onSelect}
+                controls={
+                  <>
+                    {availableActions?.includes(DelegationAction.DELEGATE) && (
+                      <Button
+                        icon={PlusCircleIcon}
+                        variant='text'
+                        size='sm'
+                        onClick={() => onDelegate(pkg)}
+                      >
+                        {t('common.give_poa')}
+                      </Button>
+                    )}
+                    {availableActions?.includes(DelegationAction.REQUEST) && (
+                      <Button
+                        icon={PlusCircleIcon}
+                        variant='text'
+                        size='sm'
+                        disabled
+                        onClick={() => onRequest(pkg)}
+                      >
+                        {t('common.request_poa')}
+                      </Button>
+                    )}
+                  </>
+                }
+              />
+            );
+          })}
+        </ListBase>
+      )}
+    </div>
+  );
+};

--- a/src/features/amUI/common/AccessPackageList/AreaItemContent.tsx
+++ b/src/features/amUI/common/AccessPackageList/AreaItemContent.tsx
@@ -12,7 +12,7 @@ import { DelegationAction } from '../DelegationModal/EditModal';
 import classes from './AccessPackageList.module.css';
 import type { ExtendedAccessArea } from './useAreaPackageList';
 import { PackageItem } from './PackageItem';
-import { useDelegationCheck } from '@/resources/hooks/useAccessPackageDelegationCheck';
+import { useAccessPackageDelegationCheck } from '@/resources/hooks/useAccessPackageDelegationCheck';
 import { ActionError } from '@/resources/hooks/useActionError';
 import { TechnicalErrorParagraphs } from '../TechnicalErrorParagraphs';
 
@@ -46,7 +46,7 @@ export const AreaItemContent = ({
     setDelegationCheckError(error);
   };
   const shouldShowDelegationCheck = !!availableActions?.includes(DelegationAction.DELEGATE);
-  const canDelegate = useDelegationCheck(
+  const { canDelegate, isLoading } = useAccessPackageDelegationCheck(
     availablePackageIds,
     shouldShowDelegationCheck,
     handleDelegationCheckFailure,
@@ -126,7 +126,7 @@ export const AreaItemContent = ({
                       icon={PlusCircleIcon}
                       variant='text'
                       size='sm'
-                      disabled={!canDelegate(pkg.id)}
+                      disabled={!canDelegate(pkg.id) || isLoading}
                       onClick={() => onDelegate(pkg)}
                     >
                       {t('common.give_poa')}

--- a/src/features/amUI/common/DelegationModal/AccessPackages/AccessPackageInfo.module.css
+++ b/src/features/amUI/common/DelegationModal/AccessPackages/AccessPackageInfo.module.css
@@ -51,3 +51,14 @@
   color: var(--ds-color-info-base-default);
   margin-right: 0.3rem;
 }
+
+.delegationCheckInfo {
+  display: flex;
+  gap: 5px;
+  align-items: center;
+}
+
+.delegationCheckInfoIcon {
+  color: var(--ds-color-warning-base-default);
+  margin-right: 0.3rem;
+}

--- a/src/features/amUI/common/DelegationModal/AccessPackages/AccessPackageInfo.tsx
+++ b/src/features/amUI/common/DelegationModal/AccessPackages/AccessPackageInfo.tsx
@@ -9,16 +9,11 @@ import {
   MenuElipsisHorizontalIcon,
   PackageIcon,
 } from '@navikt/aksel-icons';
-import { useEffect } from 'react';
 
 import { TechnicalErrorParagraphs } from '@/features/amUI/common/TechnicalErrorParagraphs';
 import { useGetPartyByUUIDQuery } from '@/rtk/features/lookupApi';
 import type { IdNamePair } from '@/dataObjects/dtos/IdNamePair';
-import {
-  useDelegationCheckMutation,
-  useGetUserDelegationsQuery,
-  type AccessPackage,
-} from '@/rtk/features/accessPackageApi';
+import { useGetUserDelegationsQuery, type AccessPackage } from '@/rtk/features/accessPackageApi';
 import { useAccessPackageActions } from '@/features/amUI/common/AccessPackageList/useAccessPackageActions';
 import type { ActionError } from '@/resources/hooks/useActionError';
 
@@ -26,6 +21,7 @@ import { useDelegationModalContext } from '../DelegationModalContext';
 import { DelegationAction } from '../EditModal';
 
 import classes from './AccessPackageInfo.module.css';
+import { useDelegationCheck } from '@/resources/hooks/useAccessPackageDelegationCheck';
 
 export interface PackageInfoProps {
   accessPackage: AccessPackage;
@@ -65,7 +61,7 @@ export const AccessPackageInfo = ({
   }, [activeDelegations, isFetching, accessPackage.id]);
 
   const shouldShowDelegationCheck = availableActions.includes(DelegationAction.DELEGATE);
-  const canDelegate = useDelegationCheck(accessPackage.id, shouldShowDelegationCheck);
+  const canDelegate = useDelegationCheck([accessPackage.id], shouldShowDelegationCheck);
 
   const { listItems } = useMinimizableResourceList(accessPackage.resources);
 
@@ -196,21 +192,4 @@ const useMinimizableResourceList = (list: IdNamePair[]) => {
     .slice(0, showAll ? list.length : MINIMIZED_LIST_SIZE)
     .map(mapResourceToListItem);
   return { listItems: showAll ? minimizedList : [...minimizedList, showMoreListItem] };
-};
-
-const useDelegationCheck = (accessPackageId: string, shouldShowDelegationCheck: boolean) => {
-  const [delegationCheck, { isLoading, data }] = useDelegationCheckMutation();
-
-  useEffect(() => {
-    if (accessPackageId && shouldShowDelegationCheck) {
-      delegationCheck({ packageIds: [accessPackageId] });
-    }
-  }, [accessPackageId]);
-
-  const canDelegate = React.useMemo(
-    () => !isLoading && data?.find((d) => d.packageId === accessPackageId)?.canDelegate,
-    [data, isLoading, accessPackageId],
-  );
-
-  return canDelegate;
 };

--- a/src/features/amUI/common/DelegationModal/AccessPackages/AccessPackageInfo.tsx
+++ b/src/features/amUI/common/DelegationModal/AccessPackages/AccessPackageInfo.tsx
@@ -21,7 +21,7 @@ import { useDelegationModalContext } from '../DelegationModalContext';
 import { DelegationAction } from '../EditModal';
 
 import classes from './AccessPackageInfo.module.css';
-import { useDelegationCheck } from '@/resources/hooks/useAccessPackageDelegationCheck';
+import { useAccessPackageDelegationCheck } from '@/resources/hooks/useAccessPackageDelegationCheck';
 import { useState } from 'react';
 
 export interface PackageInfoProps {
@@ -75,11 +75,16 @@ export const AccessPackageInfo = ({
     [accessPackage],
   );
 
-  const canDelegate = useDelegationCheck(
+  const { canDelegate, isLoading } = useAccessPackageDelegationCheck(
     accessPackageIds,
     shouldShowDelegationCheck,
     handleDelegationCheckFailure,
   );
+  const showMissingRightsMessage =
+    shouldShowDelegationCheck &&
+    !delegationCheckError &&
+    !canDelegate(accessPackage.id) &&
+    !isLoading;
 
   const { listItems } = useMinimizableResourceList(accessPackage.resources);
 
@@ -148,7 +153,7 @@ export const AccessPackageInfo = ({
           </Paragraph>
         </div>
       )}
-      {shouldShowDelegationCheck && !canDelegate && (
+      {showMissingRightsMessage && (
         <div className={classes.delegationCheckInfo}>
           <ExclamationmarkTriangleFillIcon
             fontSize='1.5rem'

--- a/src/features/amUI/common/TechnicalErrorParagraphs/TechnicalErrorParagraphs.tsx
+++ b/src/features/amUI/common/TechnicalErrorParagraphs/TechnicalErrorParagraphs.tsx
@@ -10,12 +10,15 @@ export interface TechnicalErrorParagraphsProps {
   time: string;
   /*** The size of the paragraph text */
   size?: ParagraphProps['data-size'];
+  /*** Optional override of message to display */
+  message?: string;
 }
 
 export const TechnicalErrorParagraphs = ({
   status,
   time,
   size = 'sm',
+  message = undefined,
 }: TechnicalErrorParagraphsProps) => {
   const { t } = useTranslation();
   return (
@@ -24,7 +27,7 @@ export const TechnicalErrorParagraphs = ({
         data-size={size}
         variant='long'
       >
-        {t('common.technical_error')}
+        {message ? message : t('common.technical_error')}
       </Paragraph>
       <Paragraph data-size={size}>
         {t('common.time_of_error', {

--- a/src/features/amUI/common/TechnicalErrorParagraphs/TechnicalErrorParagraphs.tsx
+++ b/src/features/amUI/common/TechnicalErrorParagraphs/TechnicalErrorParagraphs.tsx
@@ -18,7 +18,7 @@ export const TechnicalErrorParagraphs = ({
   status,
   time,
   size = 'sm',
-  message = undefined,
+  message,
 }: TechnicalErrorParagraphsProps) => {
   const { t } = useTranslation();
   return (
@@ -27,7 +27,7 @@ export const TechnicalErrorParagraphs = ({
         data-size={size}
         variant='long'
       >
-        {message ? message : t('common.technical_error')}
+        {message ?? t('common.technical_error')}
       </Paragraph>
       <Paragraph data-size={size}>
         {t('common.time_of_error', {

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -302,6 +302,7 @@
     "edit_success": "The power of attorney was updated",
     "package_services": "Grants access to {{count}} services",
     "inherited_role_org_message": "<b>{{user_name}}</b> has access to this through their role in <b>{{org_name}}</b>. Therefore, it cannot be deleted.",
+    "delegation_check_not_delegable": "You do not have the right to delegate this package",
     "specific_rights": {
       "missing_role_message": "You cannot delegate the entire service because you lack some of the rights yourself. The general manager or chief administrator can grant you access.",
       "missing_srr_right_message": "{{reportee}} is not given permission from {{resourceOwner}} to delegate the whole service. Contact them if you want to change this."

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -302,7 +302,7 @@
     "edit_success": "The power of attorney was updated",
     "package_services": "Grants access to {{count}} services",
     "inherited_role_org_message": "<b>{{user_name}}</b> has access to this through their role in <b>{{org_name}}</b>. Therefore, it cannot be deleted.",
-    "delegation_check_not_delegable": "You do not have the right to delegate this package",
+    "delegation_check_not_delegable": "You cannot grant this access package because you  lack access yourself.",
     "specific_rights": {
       "missing_role_message": "You cannot delegate the entire service because you lack some of the rights yourself. The general manager or chief administrator can grant you access.",
       "missing_srr_right_message": "{{reportee}} is not given permission from {{resourceOwner}} to delegate the whole service. Contact them if you want to change this."

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -254,7 +254,12 @@
     "package_deletion_success": "Power of attorney over {{accessPackage}} has been successfully revoked for {{name}}.",
     "package_deletion_error": "Failed to revoke {{name}}'s power of attorney over {{accessPackage}}.",
     "delegated_packages_count_badge": "{{delegated}} of {{total}}",
-    "package_number_of_resources": "{{count}} services"
+    "package_number_of_resources": "{{count}} services",
+    "delegation_check": {
+      "delegation_check_error_heading": "Technical error",
+      "delegation_check_error_message_singular": "A technical error prevents you from giving the user the access package. Please contact Altinn user service if the problem persists.",
+      "delegation_check_error_message_plural": "A technical error prevents you from giving the user one or more access packages. Please contact Altinn user service if the problem persists."
+    }
   },
   "role": {
     "current_roles_title": "Power of attorney to {{count}} roles(s)",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -301,7 +301,7 @@
     "edit_success": "Fullmakt oppdatert",
     "package_services": "Gir tilgang til {{count}} tjenester",
     "inherited_role_org_message": "<b>{{user_name}}</b> har tilgang til denne gjennom sin rolle i <b>{{org_name}}</b>. Den kan derfor ikke slettes.",
-    "delegation_check_not_delegable": "Du har ikke rettigheter til å delegere denne pakken",
+    "delegation_check_not_delegable": "Du kan ikke gi denne tilgangspakken fordi du mangler tilgang til den selv.",
     "technical_error_message": {
       "heading": "Oi! Noe gikk galt",
       "message": "Pga en teknisk feil ble ikke tjenesten delegert. Vennligst prøv på nytt eller kontakt Altinn brukerservice hvis feilen fortsetter.",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -301,6 +301,7 @@
     "edit_success": "Fullmakt oppdatert",
     "package_services": "Gir tilgang til {{count}} tjenester",
     "inherited_role_org_message": "<b>{{user_name}}</b> har tilgang til denne gjennom sin rolle i <b>{{org_name}}</b>. Den kan derfor ikke slettes.",
+    "delegation_check_not_delegable": "Du har ikke rettigheter til å delegere denne pakken",
     "technical_error_message": {
       "heading": "Oi! Noe gikk galt",
       "message": "Pga en teknisk feil ble ikke tjenesten delegert. Vennligst prøv på nytt eller kontakt Altinn brukerservice hvis feilen fortsetter.",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -253,7 +253,12 @@
     "package_deletion_success": "Fullmakten til {{accessPackage}} er fjernet fra {{name}}.",
     "package_deletion_error": "Det var ikke mulig å fjerne fullmakten til {{accessPackage}} fra {{name}}.",
     "delegated_packages_count_badge": "{{delegated}} av {{total}}",
-    "package_number_of_resources": "{{count}} tjenester"
+    "package_number_of_resources": "{{count}} tjenester",
+    "delegation_check": {
+      "delegation_check_error_heading": "Teknisk feil",
+      "delegation_check_error_message_singular": "En teknisk feil sperrer deg fra å gi fullmakt til tilgangspakken. Vennligst kontakt Altinn brukerservice hvis problemet vedvarer.",
+      "delegation_check_error_message_plural": "En teknisk feil sperrer deg fra å gi fullmakt til en eller flere tilgangspakker. Vennligst kontakt Altinn brukerservice hvis problemet vedvarer."
+    }
   },
   "role": {
     "current_roles_title": "Fullmakt til {{count}} rolle(r)",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -298,6 +298,7 @@
     "edit_success": "Fullmakt oppdatert",
     "package_services": "Gir tilgang til {{count}} tenester",
     "inherited_role_org_message": "<b>{{user_name}}</b> har tilgang til denne gjennom sin rolle i <b>{{org_name}}</b>. Den kan derfor ikke slettes.",
+    "delegation_check_not_delegable": "Du har ikkje rett til å delegere denne pakka",
     "specific_rights": {
       "missing_role_message": "Du får ikkje delegert heile tenesta, fordi du manglar nokre av rettane sjølv. Dagleg leiar eller hovudadministrator kan gi deg tilgang.",
       "missing_srr_right_message": "{{reportee}} har ikkje fått løyve frå {{resourceOwner}} til å delegere heile tenesta. Ta kontakt med dei dersom du ynskjer å endre dette."

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -298,7 +298,7 @@
     "edit_success": "Fullmakt oppdatert",
     "package_services": "Gir tilgang til {{count}} tenester",
     "inherited_role_org_message": "<b>{{user_name}}</b> har tilgang til denne gjennom sin rolle i <b>{{org_name}}</b>. Den kan derfor ikke slettes.",
-    "delegation_check_not_delegable": "Du har ikkje rett til å delegere denne pakka",
+    "delegation_check_not_delegable": "Du kan ikkje gi denne tilgangspakka fordi du manglar tilgang til den selv.",
     "specific_rights": {
       "missing_role_message": "Du får ikkje delegert heile tenesta, fordi du manglar nokre av rettane sjølv. Dagleg leiar eller hovudadministrator kan gi deg tilgang.",
       "missing_srr_right_message": "{{reportee}} har ikkje fått løyve frå {{resourceOwner}} til å delegere heile tenesta. Ta kontakt med dei dersom du ynskjer å endre dette."

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -250,7 +250,12 @@
     "package_deletion_success": "Fullmakta til {{accessPackage}} er fjerna frå {{name}}.",
     "package_deletion_error": "Det var ikkje mogleg å fjerne fullmakta til {{accessPackage}} frå {{name}}.",
     "delegated_packages_count_badge": "{{delegated}} av {{total}}",
-    "package_number_of_resources": "{{count}} tenester"
+    "package_number_of_resources": "{{count}} tenester",
+    "delegation_check": {
+      "delegation_check_error_heading": "Teknisk feil",
+      "delegation_check_error_message_singular": "En teknisk feil sperrer deg fra å gi fullmakt til tilgangspakken. Ver venleg å kontakte Altinn brukarteneste om problemet held fram.",
+      "delegation_check_error_message_plural": "En teknisk feil sperrer deg fra å gi fullmakt til ein eller fleire tilgangspakkar. Ver venleg å kontakte Altinn brukarteneste om problemet held fram."
+    }
   },
   "role": {
     "current_roles_title": "Fullmakt til {{count}} rolle(r)",

--- a/src/resources/hooks/useAccessPackageDelegationCheck.ts
+++ b/src/resources/hooks/useAccessPackageDelegationCheck.ts
@@ -10,7 +10,7 @@ import { ActionError } from './useActionError';
  * @param {function} handleDelegationCheckFailure - Callback function to handle delegation check failure.
  * @returns {function} - Function to check if a specific package ID can be delegated.
  */
-export const useDelegationCheck = (
+export const useAccessPackageDelegationCheck = (
   accessPackageIds: string[],
   shouldShowDelegationCheck: boolean,
   handleDelegationCheckFailure: (error: ActionError) => void,
@@ -39,5 +39,5 @@ export const useDelegationCheck = (
   const canDelegate = (id: string) =>
     !isLoading && data?.find((d) => d.packageId === id)?.canDelegate;
 
-  return canDelegate;
+  return { canDelegate, isLoading };
 };

--- a/src/resources/hooks/useAccessPackageDelegationCheck.ts
+++ b/src/resources/hooks/useAccessPackageDelegationCheck.ts
@@ -1,18 +1,41 @@
 import { useDelegationCheckMutation } from '@/rtk/features/accessPackageApi';
 import { useEffect } from 'react';
+import { ActionError } from './useActionError';
 
+/**
+ * Custom hook to check delegation status for access packages.
+ *
+ * @param {string[]} accessPackageIds - Array of access package IDs to check.
+ * @param {boolean} shouldShowDelegationCheck - Flag to determine if the delegation check should be performed.
+ * @param {function} handleDelegationCheckFailure - Callback function to handle delegation check failure.
+ * @returns {function} - Function to check if a specific package ID can be delegated.
+ */
 export const useDelegationCheck = (
   accessPackageIds: string[],
   shouldShowDelegationCheck: boolean,
+  handleDelegationCheckFailure: (error: ActionError) => void,
 ) => {
   const [delegationCheck, { isLoading, data }] = useDelegationCheckMutation();
 
   useEffect(() => {
     if (accessPackageIds.length > 0 && shouldShowDelegationCheck) {
-      delegationCheck({ packageIds: accessPackageIds });
+      delegationCheck({ packageIds: accessPackageIds })
+        .unwrap()
+        .catch((response) => {
+          handleDelegationCheckFailure({
+            httpStatus: response.status,
+            timestamp: new Date().toISOString(),
+          });
+        });
     }
   }, [accessPackageIds, shouldShowDelegationCheck]);
 
+  /**
+   * Function to check if a specific package ID can be delegated.
+   *
+   * @param {string} id - The package ID to check.
+   * @returns {boolean} - True if the package can be delegated, false otherwise.
+   */
   const canDelegate = (id: string) =>
     !isLoading && data?.find((d) => d.packageId === id)?.canDelegate;
 

--- a/src/resources/hooks/useAccessPackageDelegationCheck.ts
+++ b/src/resources/hooks/useAccessPackageDelegationCheck.ts
@@ -1,0 +1,20 @@
+import { useDelegationCheckMutation } from '@/rtk/features/accessPackageApi';
+import { useEffect } from 'react';
+
+export const useDelegationCheck = (
+  accessPackageIds: string[],
+  shouldShowDelegationCheck: boolean,
+) => {
+  const [delegationCheck, { isLoading, data }] = useDelegationCheckMutation();
+
+  useEffect(() => {
+    if (accessPackageIds.length > 0 && shouldShowDelegationCheck) {
+      delegationCheck({ packageIds: accessPackageIds });
+    }
+  }, [accessPackageIds, shouldShowDelegationCheck]);
+
+  const canDelegate = (id: string) =>
+    !isLoading && data?.find((d) => d.packageId === id)?.canDelegate;
+
+  return canDelegate;
+};

--- a/src/rtk/features/accessPackageApi.ts
+++ b/src/rtk/features/accessPackageApi.ts
@@ -36,6 +36,11 @@ export interface DelegationDetails {
   lastChangedOn: Date;
 }
 
+export interface DelegationCheckResponse {
+  packageId: string;
+  canDelegate: boolean;
+}
+
 const baseUrl = `${import.meta.env.BASE_URL}accessmanagement/api/v1/accesspackage`;
 
 export const accessPackageApi = createApi({
@@ -82,6 +87,19 @@ export const accessPackageApi = createApi({
         };
       },
     }),
+    delegationCheck: builder.query<DelegationCheckResponse[], { packageIds: string[] }>({
+      query: ({ packageIds }) => {
+        const body = {
+          packageIds: packageIds,
+          reporteeUuid: getCookie('AltinnPartyId'),
+        };
+        return {
+          url: `delegationcheck`,
+          method: 'POST',
+          body,
+        };
+      },
+    }),
   }),
 });
 
@@ -90,6 +108,7 @@ export const {
   useGetUserDelegationsQuery,
   useRevokeDelegationMutation,
   useDelegatePackageMutation,
+  useDelegationCheckQuery,
 } = accessPackageApi;
 
 export const { endpoints, reducerPath, reducer, middleware } = accessPackageApi;

--- a/src/rtk/features/accessPackageApi.ts
+++ b/src/rtk/features/accessPackageApi.ts
@@ -89,14 +89,14 @@ export const accessPackageApi = createApi({
     }),
     delegationCheck: builder.query<DelegationCheckResponse[], { packageIds: string[] }>({
       query: ({ packageIds }) => {
-        const body = {
+        const delegationCheckRequest = {
           packageIds: packageIds,
-          reporteeUuid: getCookie('AltinnPartyId'),
+          reporteeUuid: getCookie('AltinnPartyUuid'),
         };
         return {
           url: `delegationcheck`,
           method: 'POST',
-          body,
+          body: JSON.stringify(delegationCheckRequest),
         };
       },
     }),

--- a/src/rtk/features/accessPackageApi.ts
+++ b/src/rtk/features/accessPackageApi.ts
@@ -87,7 +87,7 @@ export const accessPackageApi = createApi({
         };
       },
     }),
-    delegationCheck: builder.query<DelegationCheckResponse[], { packageIds: string[] }>({
+    delegationCheck: builder.mutation<DelegationCheckResponse[], { packageIds: string[] }>({
       query: ({ packageIds }) => {
         const delegationCheckRequest = {
           packageIds: packageIds,
@@ -108,7 +108,7 @@ export const {
   useGetUserDelegationsQuery,
   useRevokeDelegationMutation,
   useDelegatePackageMutation,
-  useDelegationCheckQuery,
+  useDelegationCheckMutation,
 } = accessPackageApi;
 
 export const { endpoints, reducerPath, reducer, middleware } = accessPackageApi;


### PR DESCRIPTION
- Adding delegation check for access packages.
- The delegation check endpoint will (hopefully) support list queries. I have checked with JK, and this would be preferred over checking individually in terms of resource use in the back end.
- We check packages when an area is expanded.
- We check again when a modal is opened. 
- We only perform a delegation check if the package can be delegated. We don't check unless the user does not already have the package and if it has to be requested.

Update: 
- Add error handling on delegation check technical error
- Add test data to demo error handling for testuser: ALBATROSS INTELLIGENT
  - The error appears on the area "Miljø, ulykke og sikkerhet" and in the package "Yrkesskade"
 
<img width="755" alt="Screenshot 2025-03-14 at 16 10 46" src="https://github.com/user-attachments/assets/454a698b-eecd-49f5-842b-30074f9b5c73" />
<img width="824" alt="Screenshot 2025-03-14 at 16 10 56" src="https://github.com/user-attachments/assets/617a498e-7f2d-46e9-b627-ef7df8d086d6" />

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #[402](https://github.com/Altinn/altinn-authorization-tmp/issues/402)

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
