### PR TITLE
Refactor: move system user delete popover out as a new component

### DIFF
--- a/src/features/amUI/systemUser/SystemUserDetailPage/SystemUserDetailsPage.module.css
+++ b/src/features/amUI/systemUser/SystemUserDetailPage/SystemUserDetailsPage.module.css
@@ -9,13 +9,3 @@
   font-style: italic;
   align-self: flex-end;
 }
-
-.deletePopover {
-  max-width: 23rem;
-}
-
-.systemUserDeleteButtonContainer {
-  display: flex;
-  justify-content: flex-end;
-  flex: 1;
-}

--- a/src/features/amUI/systemUser/SystemUserDetailPage/SystemUserDetailsPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserDetailPage/SystemUserDetailsPage.tsx
@@ -1,6 +1,5 @@
-import React, { useState } from 'react';
-import { Button, Alert, Spinner, Paragraph, Popover } from '@digdir/designsystemet-react';
-import { TrashIcon } from '@navikt/aksel-icons';
+import React from 'react';
+import { Alert, Spinner, Paragraph } from '@digdir/designsystemet-react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router';
 
@@ -12,9 +11,9 @@ import { SystemUserPath } from '@/routes/paths';
 import { useDocumentTitle } from '@/resources/hooks/useDocumentTitle';
 import { PageContainer } from '@/features/amUI/common/PageContainer/PageContainer';
 
-import { ButtonRow } from '../components/ButtonRow/ButtonRow';
 import { RightsList } from '../components/RightsList/RightsList';
 import { SystemUserHeader } from '../components/SystemUserHeader/SystemUserHeader';
+import { DeleteSystemUserPopover } from '../components/DeleteSystemUserPopover/DeleteSystemuserPopover';
 
 import classes from './SystemUserDetailsPage.module.css';
 
@@ -24,8 +23,6 @@ export const SystemUserDetailsPage = (): React.ReactNode => {
   const navigate = useNavigate();
   useDocumentTitle(t('systemuser_overviewpage.page_title'));
   const partyId = getCookie('AltinnPartyId');
-
-  const [isPopoverOpen, setIsPopoverOpen] = useState<boolean>(false);
 
   const {
     data: systemUser,
@@ -40,7 +37,6 @@ export const SystemUserDetailsPage = (): React.ReactNode => {
     deleteSystemUser({ partyId, systemUserId: id || '' })
       .unwrap()
       .then(() => {
-        setIsPopoverOpen(false);
         handleNavigateBack();
       });
   };
@@ -52,60 +48,21 @@ export const SystemUserDetailsPage = (): React.ReactNode => {
   const numberOfRights =
     (systemUser?.resources?.length || 0) + (systemUser?.accessPackages?.length || 0);
 
-  const deletePopover = (
-    <div className={classes.systemUserDeleteButtonContainer}>
-      <Popover.TriggerContext>
-        <Popover.Trigger
-          variant='tertiary'
-          data-color='danger'
-          onClick={() => setIsPopoverOpen(true)}
-        >
-          <TrashIcon aria-hidden />
-          {t('systemuser_detailpage.delete_systemuser')}
-        </Popover.Trigger>
-        <Popover
-          open={isPopoverOpen}
-          data-color='danger'
-          className={classes.deletePopover}
-          onClose={() => setIsPopoverOpen(false)}
-        >
-          {t('systemuser_detailpage.delete_systemuser_body', {
-            title: systemUser?.integrationTitle,
-          })}
-          {isDeleteError && (
-            <Alert
-              data-color='danger'
-              role='alert'
-            >
-              {t('systemuser_detailpage.delete_systemuser_error')}
-            </Alert>
-          )}
-          <ButtonRow>
-            <Button
-              data-color='danger'
-              disabled={isDeletingSystemUser}
-              onClick={handleDeleteSystemUser}
-            >
-              {t('systemuser_detailpage.delete_systemuser')}
-            </Button>
-            <Button
-              variant='tertiary'
-              onClick={() => setIsPopoverOpen(false)}
-            >
-              {t('common.cancel')}
-            </Button>
-          </ButtonRow>
-        </Popover>
-      </Popover.TriggerContext>
-    </div>
-  );
-
   return (
     <PageWrapper>
       <PageLayoutWrapper>
         <PageContainer
           onNavigateBack={handleNavigateBack}
-          pageActions={deletePopover}
+          pageActions={
+            systemUser && (
+              <DeleteSystemUserPopover
+                integrationTitle={systemUser?.integrationTitle ?? ''}
+                isDeleteError={isDeleteError}
+                isDeletingSystemUser={isDeletingSystemUser}
+                handleDeleteSystemUser={handleDeleteSystemUser}
+              />
+            )
+          }
         >
           {isLoadingSystemUser && (
             <Spinner aria-label={t('systemuser_detailpage.loading_systemuser')} />

--- a/src/features/amUI/systemUser/components/DeleteSystemUserPopover/DeleteSystemUserPopover.module.css
+++ b/src/features/amUI/systemUser/components/DeleteSystemUserPopover/DeleteSystemUserPopover.module.css
@@ -1,0 +1,9 @@
+.systemUserDeleteButtonContainer {
+  display: flex;
+  justify-content: flex-end;
+  flex: 1;
+}
+
+.deletePopover {
+  max-width: 23rem;
+}

--- a/src/features/amUI/systemUser/components/DeleteSystemUserPopover/DeleteSystemuserPopover.tsx
+++ b/src/features/amUI/systemUser/components/DeleteSystemUserPopover/DeleteSystemuserPopover.tsx
@@ -1,0 +1,81 @@
+import { Alert, Button, Paragraph, Popover } from '@digdir/designsystemet-react';
+import { TrashIcon } from '@navikt/aksel-icons';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { ButtonRow } from '../ButtonRow/ButtonRow';
+
+import classes from './DeleteSystemUserPopover.module.css';
+
+interface DeleteSystemUserPopoverProps {
+  integrationTitle: string;
+  isDeleteError: boolean;
+  isDeletingSystemUser: boolean;
+  handleDeleteSystemUser: () => void;
+  hasClientDelegations?: boolean;
+}
+
+export const DeleteSystemUserPopover = ({
+  integrationTitle,
+  isDeleteError,
+  isDeletingSystemUser,
+  handleDeleteSystemUser,
+  hasClientDelegations,
+}: DeleteSystemUserPopoverProps): React.ReactNode => {
+  const { t } = useTranslation();
+  const [isPopoverOpen, setIsPopoverOpen] = useState<boolean>(false);
+
+  return (
+    <div className={classes.systemUserDeleteButtonContainer}>
+      <Popover.TriggerContext>
+        <Popover.Trigger
+          variant='tertiary'
+          data-color='danger'
+          onClick={() => setIsPopoverOpen(true)}
+        >
+          <TrashIcon aria-hidden />
+          {t('systemuser_detailpage.delete_systemuser')}
+        </Popover.Trigger>
+        <Popover
+          open={isPopoverOpen}
+          data-color='danger'
+          className={classes.deletePopover}
+          onClose={() => setIsPopoverOpen(false)}
+        >
+          {hasClientDelegations ? (
+            <Paragraph>{t('systemuser_detailpage.delete_has_customer_warning')}</Paragraph>
+          ) : (
+            <>
+              {t('systemuser_detailpage.delete_systemuser_body', {
+                title: integrationTitle,
+              })}
+              {isDeleteError && (
+                <Alert
+                  data-color='danger'
+                  role='alert'
+                >
+                  {t('systemuser_detailpage.delete_systemuser_error')}
+                </Alert>
+              )}
+              <ButtonRow>
+                <Button
+                  data-color='danger'
+                  disabled={isDeletingSystemUser}
+                  onClick={handleDeleteSystemUser}
+                >
+                  {t('systemuser_detailpage.delete_systemuser')}
+                </Button>
+                <Button
+                  variant='tertiary'
+                  onClick={() => setIsPopoverOpen(false)}
+                >
+                  {t('common.cancel')}
+                </Button>
+              </ButtonRow>
+            </>
+          )}
+        </Popover>
+      </Popover.TriggerContext>
+    </div>
+  );
+};

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -447,6 +447,7 @@
     "delete_systemuser_header": "Delete system access",
     "delete_systemuser_body": "Are you sure you want to delete the system access \"{{title}}\"?",
     "delete_systemuser_error": "Could not delete system access",
+    "delete_has_customer_warning": "The system access cannot be deleted until all customers are removed from the system access.",
     "update_systemuser_error": "Failed to update system access",
     "systemuser_deleted": "System access deleted",
     "save_systemuser": "Save changes",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -446,6 +446,7 @@
     "delete_systemuser_header": "Slette systemtilgang",
     "delete_systemuser_body": "Er du sikker på at du vil slette systemtilgangen \"{{title}}\"?",
     "delete_systemuser_error": "Kunne ikke slette systemtilgang",
+    "delete_has_customer_warning": "Systemtilgangen kan ikke slettes før alle kunder er fjernet fra systemtilgangen.",
     "update_systemuser_error": "Kunne ikke oppdatere systemtilgang",
     "systemuser_deleted": "Systemtilgang slettet",
     "save_systemuser": "Lagre endringer",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -444,6 +444,7 @@
     "delete_systemuser_header": "Slette systemtilgang",
     "delete_systemuser_body": "Er du sikker på at du vil slette systemtilgangen \"{{title}}\"?",
     "delete_systemuser_error": "Kunne ikkje slette systemtilgang",
+    "delete_has_customer_warning": "Systemtilgangen kan ikkje slettes før alle kunder er fjerna fra systemtilgangen.",
     "update_systemuser_error": "Kunne ikkje oppdatere systemtilgang",
     "systemuser_deleted": "Systemtilgang sletta",
     "save_systemuser": "Lagre endringar",


### PR DESCRIPTION
## Description
- For agent system users we will also need the delete popover, move the component out to a new file to allow reuse in the future (hence the `hasClientDelegations` prop. It will not be allowed to delete an agen systemuser with existing client delegations)

## Related Issue(s)
- this PR

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
