### PR TITLE
Use new url to GET agent systemuser request

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/SystemUser/SystemUserAgentRequest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/SystemUser/SystemUserAgentRequest.cs
@@ -68,5 +68,12 @@ namespace Altinn.AccessManagement.UI.Core.Models.SystemUser
         /// </summary>
         [JsonIgnore]
         public DateTime Created { get; set; }
+
+        /// <summary>
+        /// The set of Access Packages requested for this agent system user. Must be equal to or less than the set defined in the Registered System.
+        /// </summary>
+        [Required]
+        [JsonPropertyName("accessPackages")]
+        public List<RegisteredSystemAccessPackage> AccessPackages { get; set; }
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/SystemUser/SystemUserAgentRequest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/SystemUser/SystemUserAgentRequest.cs
@@ -74,6 +74,6 @@ namespace Altinn.AccessManagement.UI.Core.Models.SystemUser
         /// </summary>
         [Required]
         [JsonPropertyName("accessPackages")]
-        public List<RegisteredSystemAccessPackage> AccessPackages { get; set; }
+        public List<RegisteredSystemAccessPackage> AccessPackages { get; set; } = [];
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/SystemUserAgentRequestClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/SystemUserAgentRequestClient.cs
@@ -53,7 +53,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
             try
             {
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
-                string endpoint = $"systemuser/request/{partyId}/{agentRequestId}";
+                string endpoint = $"systemuser/request/agent/{partyId}/{agentRequestId}";
                 HttpResponseMessage response = await _httpClient.GetAsync(token, endpoint);
                 
                 if (response.StatusCode == System.Net.HttpStatusCode.NotFound)

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/SystemUserAgentRequestController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/SystemUserAgentRequestController.cs
@@ -94,7 +94,7 @@ namespace Altinn.AccessManagement.UI.Controllers
             };
 
             // store cookie value for redirect
-            HttpContext.Response.Cookies.Append("AltinnLogoutInfo", $"SystemuserAgentRequestId={agentRequestId}", cookieOptions);
+            HttpContext.Response.Cookies.Append("AltinnLogoutInfo", $"SystemuserRequestId={agentRequestId}", cookieOptions);
             
             string logoutUrl = $"{_platformSettings.Value.ApiAuthenticationEndpoint}logout";
             return Redirect(logoutUrl);


### PR DESCRIPTION
## Description
- Use new url to GET agent systemuser request
- Serialize accessPackages in agent request model (not used yet, but will be in the future when the metadata API is ready)
- Use old query param in redirect after logout when creating agent system user

## Related Issue(s)
- this PR

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
