### PR TITLE
Context for storing FROM, TO and SELF

### DIFF
--- a/.mock/handlers/lookup.ts
+++ b/.mock/handlers/lookup.ts
@@ -7,6 +7,39 @@ export const lookupHandlers = (ACCESSMANAGEMENT_BASE_URL: string) => [
       name: 'Digitaliseringsdirektoratet',
     });
   }),
+  http.get(`${ACCESSMANAGEMENT_BASE_URL}/lookup/party/:id`, ({ params }) => {
+    const { id } = params;
+
+    return HttpResponse.json({
+      partyId: 51329012,
+      partyUuid: id,
+      partyTypeName: 2,
+      orgNumber: '310202398',
+      unitType: 'AS',
+      name: 'DISKRET NÆR TIGER AS',
+      isDeleted: false,
+      onlyHierarchyElementWithNoAccess: false,
+      person: null,
+      organization: {
+        orgNumber: '310202398',
+        name: 'DISKRET NÆR TIGER AS',
+        unitType: 'AS',
+        telephoneNumber: null,
+        mobileNumber: null,
+        faxNumber: null,
+        eMailAddress: '',
+        internetAddress: null,
+        mailingAddress: null,
+        mailingPostalCode: null,
+        mailingPostalCity: null,
+        businessAddress: null,
+        businessPostalCode: null,
+        businessPostalCity: null,
+        unitStatus: 'N',
+      },
+      childParties: null,
+    });
+  }),
   http.get(`${ACCESSMANAGEMENT_BASE_URL}/lookup/party`, () => {
     return HttpResponse.json({
       partyId: 51329012,

--- a/.mock/handlers/singleright.ts
+++ b/.mock/handlers/singleright.ts
@@ -509,4 +509,24 @@ export const singlerightHandlers = (ACCESSMANAGEMENT_BASE_URL: string) => [
       ]);
     },
   ),
+  http.get(
+    `${ACCESSMANAGEMENT_BASE_URL}/singleright/:partyuuid/delegationcheck/:resourceid`,
+    ({ params }) => {
+      const { resourceid } = params;
+      return HttpResponse.json([
+        {
+          rightKey: resourceid + '/read',
+          action: 'read',
+          status: 'Delegable',
+          reasonCodes: ['DelegationAccess'],
+        },
+        {
+          rightKey: resourceid + '/write',
+          action: 'write',
+          status: 'Delegable',
+          reasonCodes: ['DelegationAccess'],
+        },
+      ]);
+    },
+  ),
 ];

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -19,6 +19,11 @@ import { Router } from 'react-router';
 import { worker } from '../.mock/browser';
 worker.start();
 
+// Set altinn cookies when Storybook starts
+document.cookie = 'AltinnPartyUuid=mocked-party-uuid; path=/; SameSite=Lax';
+document.cookie = 'AltinnPartyId=mocked-party-id; path=/; SameSite=Lax';
+document.cookie = 'XSRF-TOKEN=mocked-xsrf-token; path=/; SameSite=Lax';
+
 // Initialise i18next;
 i18n
   .use(LanguageDetector)

--- a/src/features/amUI/common/AccessPackageList/AccessPackageList.stories.tsx
+++ b/src/features/amUI/common/AccessPackageList/AccessPackageList.stories.tsx
@@ -4,6 +4,7 @@ import { Provider } from 'react-redux';
 import store from '@/rtk/app/store';
 
 import { AccessPackageList } from './AccessPackageList';
+import { PartyRepresentationProvider } from '../PartyRepresentationContext/PartyRepresentationContext';
 
 type AreaListPropsAndCustomArgs = React.ComponentProps<typeof AccessPackageList>;
 
@@ -12,18 +13,16 @@ export default {
   component: AccessPackageList,
   render: (args) => (
     <Provider store={store}>
-      <AccessPackageList
-        fromPartyUuid={''}
-        toPartyUuid={''}
-        {...args}
-      />
+      <PartyRepresentationProvider
+        fromPartyUuid='123'
+        toPartyUuid='456'
+      >
+        <AccessPackageList {...args} />
+      </PartyRepresentationProvider>
     </Provider>
   ),
 } as Meta;
 
 export const Default: StoryObj<AreaListPropsAndCustomArgs> = {
-  args: {
-    fromPartyUuid: '123',
-    toPartyUuid: '456',
-  },
+  args: {},
 };

--- a/src/features/amUI/common/AccessPackageList/AccessPackageList.tsx
+++ b/src/features/amUI/common/AccessPackageList/AccessPackageList.tsx
@@ -14,11 +14,10 @@ import { AreaItem } from './AreaItem';
 import { useAccessPackageActions } from './useAccessPackageActions';
 import { SkeletonAccessPackageList } from './SkeletonAccessPackageList';
 import { AreaItemContent } from './AreaItemContent';
+import { usePartyRepresentation } from '../PartyRepresentationContext/PartyRepresentationContext';
 
 interface AccessPackageListProps {
   showAllPackages?: boolean;
-  fromPartyUuid: string;
-  toPartyUuid: string;
   showAllAreas?: boolean;
   isLoading?: boolean;
   availableActions?: DelegationAction[];
@@ -43,15 +42,14 @@ export const AccessPackageList = ({
   onRevokeSuccess,
   onRevokeError,
   searchString,
-  fromPartyUuid,
-  toPartyUuid,
 }: AccessPackageListProps) => {
   const { data: allPackageAreas, isLoading: loadingPackageAreas } = useSearchQuery(
     searchString ?? '',
   );
+  const { fromParty, toParty } = usePartyRepresentation();
   const { data: activeDelegations, isLoading: loadingDelegations } = useGetUserDelegationsQuery({
-    from: fromPartyUuid,
-    to: toPartyUuid,
+    from: fromParty?.partyUuid ?? '',
+    to: toParty?.partyUuid ?? '',
   });
 
   const [expandedAreas, setExpandedAreas] = useState<string[]>([]);
@@ -73,7 +71,7 @@ export const AccessPackageList = ({
   });
 
   const { onDelegate, onRevoke, onRequest } = useAccessPackageActions({
-    toUuid: toPartyUuid,
+    toUuid: toParty?.partyUuid || '',
     onDelegateSuccess,
     onDelegateError,
     onRevokeSuccess,

--- a/src/features/amUI/common/DelegationModal/AccessPackages/AccessPackageInfo.tsx
+++ b/src/features/amUI/common/DelegationModal/AccessPackages/AccessPackageInfo.tsx
@@ -23,33 +23,27 @@ import { DelegationAction } from '../EditModal';
 import classes from './AccessPackageInfo.module.css';
 import { useAccessPackageDelegationCheck } from '@/resources/hooks/useAccessPackageDelegationCheck';
 import { useState } from 'react';
+import { usePartyRepresentation } from '../../PartyRepresentationContext/PartyRepresentationContext';
 
 export interface PackageInfoProps {
   accessPackage: AccessPackage;
-  toPartyUuid: string;
-  fromPartyUuid: string;
   availableActions?: DelegationAction[];
 }
 
-export const AccessPackageInfo = ({
-  accessPackage,
-  toPartyUuid,
-  fromPartyUuid,
-  availableActions = [],
-}: PackageInfoProps) => {
+export const AccessPackageInfo = ({ accessPackage, availableActions = [] }: PackageInfoProps) => {
   const { t } = useTranslation();
-  const { data: toParty } = useGetPartyByUUIDQuery(toPartyUuid);
+  const { fromParty, toParty, selfParty } = usePartyRepresentation();
 
   const { onDelegate, onRevoke } = useAccessPackageActions({
-    toUuid: toPartyUuid,
+    toUuid: toParty?.partyUuid || '',
     onDelegateError: (_, error: ActionError) => setActionError(error),
     onRevokeError: (_, error: ActionError) => setActionError(error),
   });
   const { actionError, setActionError } = useDelegationModalContext();
 
   const { data: activeDelegations, isFetching } = useGetUserDelegationsQuery({
-    to: toPartyUuid,
-    from: fromPartyUuid,
+    to: toParty?.partyUuid ?? '',
+    from: fromParty?.partyUuid ?? '',
   });
 
   const userHasPackage = React.useMemo(() => {

--- a/src/features/amUI/common/DelegationModal/AccessPackages/PackageSearch.tsx
+++ b/src/features/amUI/common/DelegationModal/AccessPackages/PackageSearch.tsx
@@ -75,8 +75,6 @@ export const PackageSearch = ({
           </div>
           <div className={classes.searchResults}>
             <AccessPackageList
-              fromPartyUuid={getCookie('AltinnPartyUuid')}
-              toPartyUuid={toParty.partyUuid}
               showAllAreas={true}
               showAllPackages={true}
               onSelect={onSelection}

--- a/src/features/amUI/common/DelegationModal/DelegationModal.stories.tsx
+++ b/src/features/amUI/common/DelegationModal/DelegationModal.stories.tsx
@@ -28,9 +28,7 @@ export default {
             fromPartyUuid='123'
             toPartyUuid='123'
           >
-            <Provider store={store}>
               <DelegationModal {...(props as DelegationModalProps)} />
-            </Provider>
           </PartyRepresentationProvider>
         </Provider>
       </DelegationModalProvider>

--- a/src/features/amUI/common/DelegationModal/DelegationModal.stories.tsx
+++ b/src/features/amUI/common/DelegationModal/DelegationModal.stories.tsx
@@ -28,7 +28,7 @@ export default {
             fromPartyUuid='123'
             toPartyUuid='123'
           >
-              <DelegationModal {...(props as DelegationModalProps)} />
+            <DelegationModal {...(props as DelegationModalProps)} />
           </PartyRepresentationProvider>
         </Provider>
       </DelegationModalProvider>

--- a/src/features/amUI/common/DelegationModal/DelegationModal.stories.tsx
+++ b/src/features/amUI/common/DelegationModal/DelegationModal.stories.tsx
@@ -6,6 +6,7 @@ import store from '@/rtk/app/store';
 import { SnackbarProvider } from '../Snackbar';
 
 import { DelegationModal, DelegationType } from './DelegationModal';
+import { PartyRepresentationProvider } from '../PartyRepresentationContext/PartyRepresentationContext';
 
 type DelegationModalProps = React.ComponentProps<typeof DelegationModal>;
 
@@ -20,16 +21,20 @@ export default {
   },
   render: (props) => (
     <SnackbarProvider>
-      <Provider store={store}>
-        <DelegationModal {...(props as DelegationModalProps)} />
-      </Provider>
+      <PartyRepresentationProvider
+        fromPartyUuid='123'
+        toPartyUuid='123'
+      >
+        <Provider store={store}>
+          <DelegationModal {...(props as DelegationModalProps)} />
+        </Provider>
+      </PartyRepresentationProvider>
     </SnackbarProvider>
   ),
 } as Meta;
 
 export const Default: StoryObj<DelegationModalProps> = {
   args: {
-    toPartyUuid: '123',
     delegationType: DelegationType.SingleRights,
   },
 };

--- a/src/features/amUI/common/DelegationModal/DelegationModal.stories.tsx
+++ b/src/features/amUI/common/DelegationModal/DelegationModal.stories.tsx
@@ -7,6 +7,7 @@ import { SnackbarProvider } from '../Snackbar';
 
 import { DelegationModal, DelegationType } from './DelegationModal';
 import { PartyRepresentationProvider } from '../PartyRepresentationContext/PartyRepresentationContext';
+import { DelegationModalProvider } from './DelegationModalContext';
 
 type DelegationModalProps = React.ComponentProps<typeof DelegationModal>;
 
@@ -21,14 +22,18 @@ export default {
   },
   render: (props) => (
     <SnackbarProvider>
-      <PartyRepresentationProvider
-        fromPartyUuid='123'
-        toPartyUuid='123'
-      >
+      <DelegationModalProvider>
         <Provider store={store}>
-          <DelegationModal {...(props as DelegationModalProps)} />
+          <PartyRepresentationProvider
+            fromPartyUuid='123'
+            toPartyUuid='123'
+          >
+            <Provider store={store}>
+              <DelegationModal {...(props as DelegationModalProps)} />
+            </Provider>
+          </PartyRepresentationProvider>
         </Provider>
-      </PartyRepresentationProvider>
+      </DelegationModalProvider>
     </SnackbarProvider>
   ),
 } as Meta;

--- a/src/features/amUI/common/DelegationModal/DelegationModal.tsx
+++ b/src/features/amUI/common/DelegationModal/DelegationModal.tsx
@@ -10,23 +10,14 @@ export enum DelegationType {
   Role = 'Role',
 }
 export interface DelegationModalProps {
-  toPartyUuid: string;
-  fromPartyUuid: string;
   delegationType: DelegationType;
   availableActions?: DelegationAction[];
 }
 
-export const DelegationModal = ({
-  toPartyUuid,
-  fromPartyUuid,
-  delegationType,
-  availableActions,
-}: DelegationModalProps) => {
+export const DelegationModal = ({ delegationType, availableActions }: DelegationModalProps) => {
   return (
     <DelegationModalProvider>
       <DelegationModalContent
-        toPartyUuid={toPartyUuid}
-        fromPartyUuid={fromPartyUuid}
         delegationType={delegationType}
         availableActions={availableActions}
       />

--- a/src/features/amUI/common/DelegationModal/DelegationModalContent.tsx
+++ b/src/features/amUI/common/DelegationModal/DelegationModalContent.tsx
@@ -6,11 +6,8 @@ import type { JSX } from 'react';
 import { useEffect, useRef } from 'react';
 import { Button } from '@altinn/altinn-components';
 
-import { useGetPartyByUUIDQuery } from '@/rtk/features/lookupApi';
 import type { ServiceResource } from '@/rtk/features/singleRights/singleRightsApi';
 import type { AccessPackage } from '@/rtk/features/accessPackageApi';
-
-import { SnackbarProvider } from '../Snackbar';
 
 import classes from './DelegationModal.module.css';
 import { ResourceSearch } from './SingleRights/ResourceSearch';
@@ -20,17 +17,14 @@ import { DelegationType } from './DelegationModal';
 import { PackageSearch } from './AccessPackages/PackageSearch';
 import { AccessPackageInfo } from './AccessPackages/AccessPackageInfo';
 import type { DelegationAction } from './EditModal';
+import { usePartyRepresentation } from '../PartyRepresentationContext/PartyRepresentationContext';
 
 export interface DelegationModalProps {
-  toPartyUuid: string;
-  fromPartyUuid: string;
   delegationType: DelegationType;
   availableActions?: DelegationAction[];
 }
 
 export const DelegationModalContent = ({
-  toPartyUuid,
-  fromPartyUuid,
   delegationType,
   availableActions,
 }: DelegationModalProps) => {
@@ -45,6 +39,7 @@ export const DelegationModalContent = ({
     reset,
     setActionError,
   } = useDelegationModalContext();
+  const { toParty } = usePartyRepresentation();
 
   const onResourceSelection = (resource?: ServiceResource) => {
     setInfoView(true);
@@ -60,8 +55,6 @@ export const DelegationModalContent = ({
   };
 
   const modalRef = useRef<HTMLDialogElement>(null);
-
-  const { data: toParty } = useGetPartyByUUIDQuery(toPartyUuid);
 
   const onClosing = () => {
     reset();
@@ -99,8 +92,6 @@ export const DelegationModalContent = ({
       infoViewContent = packageToView && (
         <AccessPackageInfo
           accessPackage={packageToView}
-          toPartyUuid={toPartyUuid}
-          fromPartyUuid={fromPartyUuid}
           availableActions={availableActions}
         />
       );
@@ -113,13 +104,7 @@ export const DelegationModalContent = ({
           toParty={toParty}
         />
       );
-      infoViewContent = resourceToView && (
-        <ResourceInfo
-          resource={resourceToView}
-          toPartyUuid={toPartyUuid}
-          fromPartyUuid={fromPartyUuid}
-        />
-      );
+      infoViewContent = resourceToView && <ResourceInfo resource={resourceToView} />;
       triggerButtonText = t('single_rights.give_new_single_right');
   }
 
@@ -132,30 +117,28 @@ export const DelegationModalContent = ({
       >
         {triggerButtonText} <PlusIcon />
       </Dialog.Trigger>
-      <SnackbarProvider>
-        <Dialog
-          className={classes.modalDialog}
-          closedby='any'
-          closeButton={t('common.close')}
-          onClose={reset}
-          ref={modalRef}
-        >
-          <>
-            {infoView && (
-              <Button
-                className={classes.backButton}
-                variant='text'
-                data-color='neutral'
-                onClick={() => setInfoView(false)}
-                icon={ArrowLeftIcon}
-              >
-                {t('common.back')}
-              </Button>
-            )}
-            <div className={classes.content}>{infoView ? infoViewContent : searchViewContent}</div>
-          </>
-        </Dialog>
-      </SnackbarProvider>
+      <Dialog
+        className={classes.modalDialog}
+        closedby='any'
+        closeButton={t('common.close')}
+        onClose={reset}
+        ref={modalRef}
+      >
+        <>
+          {infoView && (
+            <Button
+              className={classes.backButton}
+              variant='text'
+              data-color='neutral'
+              onClick={() => setInfoView(false)}
+              icon={ArrowLeftIcon}
+            >
+              {t('common.back')}
+            </Button>
+          )}
+          <div className={classes.content}>{infoView ? infoViewContent : searchViewContent}</div>
+        </>
+      </Dialog>
     </Dialog.TriggerContext>
   );
 };

--- a/src/features/amUI/common/DelegationModal/EditModal.tsx
+++ b/src/features/amUI/common/DelegationModal/EditModal.tsx
@@ -7,8 +7,6 @@ import type { AccessPackage } from '@/rtk/features/accessPackageApi';
 import type { ServiceResource } from '@/rtk/features/singleRights/singleRightsApi';
 import type { ActionError } from '@/resources/hooks/useActionError';
 
-import { SnackbarProvider } from '../Snackbar';
-
 import { ResourceInfo } from './SingleRights/ResourceInfo';
 import classes from './DelegationModal.module.css';
 import { AccessPackageInfo } from './AccessPackages/AccessPackageInfo';
@@ -70,11 +68,9 @@ export const EditModal = forwardRef<HTMLDialogElement, EditModalProps>(
           onClosing();
         }}
       >
-        <SnackbarProvider>
-          <div className={classes.content}>
-            {renderModalContent(resource, accessPackage, role, availableActions)}
-          </div>
-        </SnackbarProvider>
+        <div className={classes.content}>
+          {renderModalContent(resource, accessPackage, role, availableActions)}
+        </div>
       </Dialog>
     );
   },

--- a/src/features/amUI/common/DelegationModal/EditModal.tsx
+++ b/src/features/amUI/common/DelegationModal/EditModal.tsx
@@ -25,27 +25,13 @@ export interface EditModalProps {
   resource?: ServiceResource;
   accessPackage?: AccessPackage;
   role?: Role;
-  toPartyUuid: string;
-  fromPartyUuid: string;
   availableActions?: DelegationAction[];
   openWithError?: ActionError | null;
   onClose?: () => void;
 }
 
 export const EditModal = forwardRef<HTMLDialogElement, EditModalProps>(
-  (
-    {
-      toPartyUuid,
-      fromPartyUuid,
-      resource,
-      accessPackage,
-      role,
-      availableActions,
-      openWithError,
-      onClose,
-    },
-    ref,
-  ) => {
+  ({ resource, accessPackage, role, availableActions, openWithError, onClose }, ref) => {
     const { setActionError, reset } = useDelegationModalContext();
 
     const onClosing = () => {
@@ -86,14 +72,7 @@ export const EditModal = forwardRef<HTMLDialogElement, EditModalProps>(
       >
         <SnackbarProvider>
           <div className={classes.content}>
-            {renderModalContent(
-              toPartyUuid,
-              fromPartyUuid,
-              resource,
-              accessPackage,
-              role,
-              availableActions,
-            )}
+            {renderModalContent(resource, accessPackage, role, availableActions)}
           </div>
         </SnackbarProvider>
       </Dialog>
@@ -102,28 +81,18 @@ export const EditModal = forwardRef<HTMLDialogElement, EditModalProps>(
 );
 
 const renderModalContent = (
-  toPartyUuid: string,
-  fromPartyUuid: string,
   resource?: ServiceResource,
   accessPackage?: AccessPackage,
   role?: Role,
   availableActions?: DelegationAction[],
 ) => {
   if (resource) {
-    return (
-      <ResourceInfo
-        resource={resource}
-        toPartyUuid={toPartyUuid}
-        fromPartyUuid={fromPartyUuid}
-      />
-    );
+    return <ResourceInfo resource={resource} />;
   }
   if (accessPackage) {
     return (
       <AccessPackageInfo
         accessPackage={accessPackage}
-        toPartyUuid={toPartyUuid}
-        fromPartyUuid={fromPartyUuid}
         availableActions={availableActions}
       />
     );
@@ -132,8 +101,6 @@ const renderModalContent = (
     return (
       <RoleInfo
         role={role}
-        toPartyUuid={toPartyUuid}
-        fromPartyUuid={fromPartyUuid}
         availableActions={availableActions}
       />
     );

--- a/src/features/amUI/common/DelegationModal/Role/RoleInfo.tsx
+++ b/src/features/amUI/common/DelegationModal/Role/RoleInfo.tsx
@@ -10,7 +10,6 @@ import {
   useGetRolesForUserQuery,
   type Role,
 } from '@/rtk/features/roleApi';
-import { useGetPartyByUUIDQuery } from '@/rtk/features/lookupApi';
 
 import { RevokeRoleButton } from '../../RoleList/RevokeRoleButton';
 import { DelegateRoleButton } from '../../RoleList/DelegateRoleButton';
@@ -18,33 +17,25 @@ import { RequestRoleButton } from '../../RoleList/RequestRoleButton';
 import { DelegationAction } from '../EditModal';
 
 import classes from './RoleInfo.module.css';
+import { usePartyRepresentation } from '../../PartyRepresentationContext/PartyRepresentationContext';
 
 export interface PackageInfoProps {
   role: Role;
-  toPartyUuid: string;
-  fromPartyUuid: string;
   onDelegate?: () => void;
   availableActions?: DelegationAction[];
 }
 
-export const RoleInfo = ({
-  role,
-  toPartyUuid,
-  fromPartyUuid,
-  availableActions = [],
-}: PackageInfoProps) => {
+export const RoleInfo = ({ role, availableActions = [] }: PackageInfoProps) => {
   const { t } = useTranslation();
 
-  const { data: toParty } = useGetPartyByUUIDQuery(toPartyUuid);
-  const { data: fromParty } = useGetPartyByUUIDQuery(fromPartyUuid);
-
+  const { fromParty, toParty } = usePartyRepresentation();
   const { data: activeDelegations, isFetching } = useGetRolesForUserQuery({
-    from: fromPartyUuid ?? '',
-    to: toPartyUuid ?? '',
+    from: fromParty?.partyUuid ?? '',
+    to: toParty?.partyUuid ?? '',
   });
 
   const { data: delegationCheckResult } = useDelegationCheckQuery({
-    rightownerUuid: fromPartyUuid ?? '',
+    rightownerUuid: fromParty?.partyUuid ?? '',
     roleUuid: role.id,
   });
 

--- a/src/features/amUI/common/PartyRepresentationContext/PartyRepresentationContext.tsx
+++ b/src/features/amUI/common/PartyRepresentationContext/PartyRepresentationContext.tsx
@@ -1,0 +1,53 @@
+import { createContext, JSX, useContext, useState } from 'react';
+
+import { useGetPartyByUUIDQuery, type Party } from '@/rtk/features/lookupApi';
+import { P } from 'vitest/dist/chunks/environment.d8YfPkTm';
+import { useGetUserInfoQuery } from '@/rtk/features/userInfoApi';
+
+interface PartyRepresentationProviderProps {
+  children: JSX.Element | JSX.Element[];
+  fromPartyUuid: string;
+  toPartyUuid: string;
+}
+
+export interface PartyRepresentationContextOutput {
+  fromParty?: Party;
+  toParty?: Party;
+  selfParty?: Party;
+  isLoading: boolean;
+}
+
+export const PartyRepresentationContext = createContext<PartyRepresentationContextOutput | null>(
+  null,
+);
+
+export const PartyRepresentationProvider = ({
+  children,
+  fromPartyUuid,
+  toPartyUuid,
+}: PartyRepresentationProviderProps) => {
+  const { data: currentUser, isLoading: currentUserIsLoading } = useGetUserInfoQuery();
+  const { data: fromParty, isLoading: fromPartyIsLoading } = useGetPartyByUUIDQuery(fromPartyUuid);
+  const { data: toParty, isLoading: toPartyIsLoading } = useGetPartyByUUIDQuery(toPartyUuid);
+
+  return (
+    <PartyRepresentationContext.Provider
+      value={{
+        fromParty,
+        toParty,
+        selfParty: currentUser?.party,
+        isLoading: fromPartyIsLoading || toPartyIsLoading || currentUserIsLoading,
+      }}
+    >
+      {children}
+    </PartyRepresentationContext.Provider>
+  );
+};
+
+export const usePartyRepresentation = (): PartyRepresentationContextOutput => {
+  const context = useContext(PartyRepresentationContext);
+  if (!context) {
+    throw new Error('usePartyRepresentation must be used within a PartyRepresentationProvider');
+  }
+  return context;
+};

--- a/src/features/amUI/common/RoleList/RoleInfoModal.tsx
+++ b/src/features/amUI/common/RoleList/RoleInfoModal.tsx
@@ -8,8 +8,6 @@ import { DelegationModalProvider } from '../DelegationModal/DelegationModalConte
 
 interface RoleInfoModalProps {
   modalRef: React.RefObject<HTMLDialogElement | null>;
-  toPartyUuid: string;
-  fromPartyUuid: string;
   role?: Role;
   onClose?: () => void;
   availableActions?: DelegationAction[];
@@ -17,8 +15,6 @@ interface RoleInfoModalProps {
 
 export const RoleInfoModal = ({
   modalRef,
-  toPartyUuid,
-  fromPartyUuid,
   role,
   onClose,
   availableActions,
@@ -34,8 +30,6 @@ export const RoleInfoModal = ({
     <DelegationModalProvider>
       <EditModal
         ref={modalRef}
-        toPartyUuid={toPartyUuid}
-        fromPartyUuid={fromPartyUuid}
         role={role}
         availableActions={availableActions}
       />

--- a/src/features/amUI/common/UserList/UserListItem.tsx
+++ b/src/features/amUI/common/UserList/UserListItem.tsx
@@ -30,13 +30,13 @@ export const UserListItem = ({ user, size = 'lg', ...props }: UserListItemProps)
         size={size}
         title={user.name}
         description={
-          user.partyType === 'Organization'
+          user.partyType.toString() === 'Organization'
             ? user.unitType
             : user.registryRoles.map((role) => t(`user_role.${role}`)).join(', ')
         }
         avatar={{
           name: user.name,
-          type: user.partyType === 'Organization' ? 'company' : 'person',
+          type: user.partyType.toString() === 'Organization' ? 'company' : 'person',
         }}
         expanded={isExpanded}
         collapsible={hasInheritingUsers}

--- a/src/features/amUI/reporteeRightsPage/ReporteeAccessPackageSection.tsx
+++ b/src/features/amUI/reporteeRightsPage/ReporteeAccessPackageSection.tsx
@@ -43,8 +43,6 @@ export const ReporteeAccessPackageSection = ({
         {t('access_packages.current_access_packages_title', { count: numberOfAccesses })}
       </Heading>
       <AccessPackageList
-        fromPartyUuid={reporteeUuid ?? ''}
-        toPartyUuid={getCookie('AltinnPartyUuid')}
         availableActions={[DelegationAction.REVOKE, DelegationAction.REQUEST]}
         useDeleteConfirm
         showAllPackages

--- a/src/features/amUI/reporteeRightsPage/ReporteeAccessPackageSection.tsx
+++ b/src/features/amUI/reporteeRightsPage/ReporteeAccessPackageSection.tsx
@@ -66,8 +66,6 @@ export const ReporteeAccessPackageSection = ({
       {party && (
         <AccessPackageInfoModal
           modalRef={modalRef}
-          toPartyUuid={getCookie('AltinnPartyUuid')}
-          fromPartyUuid={reporteeUuid ?? ''}
           modalItem={modalItem}
           modalActions={[DelegationAction.REVOKE, DelegationAction.REQUEST]}
         />

--- a/src/features/amUI/reporteeRightsPage/ReporteeRightsPage.tsx
+++ b/src/features/amUI/reporteeRightsPage/ReporteeRightsPage.tsx
@@ -20,6 +20,8 @@ import { PageContainer } from '../common/PageContainer/PageContainer';
 
 import { ReporteeAccessPackageSection } from './ReporteeAccessPackageSection';
 import { ReporteeRoleSection } from './ReporteeRoleSection';
+import { DelegationModalProvider } from '../common/DelegationModal/DelegationModalContext';
+import { PartyRepresentationProvider } from '../common/PartyRepresentationContext/PartyRepresentationContext';
 
 export const ReporteeRightsPage = () => {
   const { t } = useTranslation();
@@ -42,48 +44,53 @@ export const ReporteeRightsPage = () => {
 
   return (
     <SnackbarProvider>
-      <PageWrapper>
-        <PageLayoutWrapper>
-          <PageContainer onNavigateBack={() => navigate(`/${amUIPath.Reportees}`)}>
-            <>
-              <UserPageHeader
-                userName={name}
-                userType={party?.partyTypeName}
-                subHeading={t('reportee_rights_page.heading_subtitle', { name: reportee?.name })}
-                roles={
-                  !!reportee?.partyUuid &&
-                  !!party?.partyUuid && (
-                    <UserRoles
-                      rightOwnerUuid={reportee.partyUuid}
-                      rightHolderUuid={party.partyUuid}
+      <PartyRepresentationProvider
+        fromPartyUuid={reporteeUuid ?? ''}
+        toPartyUuid={getCookie('AltinnPartyUuid')}
+      >
+        <PageWrapper>
+          <PageLayoutWrapper>
+            <PageContainer onNavigateBack={() => navigate(`/${amUIPath.Reportees}`)}>
+              <DelegationModalProvider>
+                <UserPageHeader
+                  userName={name}
+                  userType={party?.partyTypeName}
+                  subHeading={t('reportee_rights_page.heading_subtitle', { name: reportee?.name })}
+                  roles={
+                    !!reportee?.partyUuid &&
+                    !!party?.partyUuid && (
+                      <UserRoles
+                        rightOwnerUuid={reportee.partyUuid}
+                        rightHolderUuid={party.partyUuid}
+                      />
+                    )
+                  }
+                />
+                <RightsTabs
+                  tabBadge={{
+                    accessPackages: allAccesses?.accessPackages?.length ?? 0,
+                    services: allAccesses?.services?.length ?? 0,
+                    roles: filterDigdirRole(allAccesses?.roles).length ?? 0,
+                  }}
+                  packagesPanel={
+                    <ReporteeAccessPackageSection
+                      numberOfAccesses={allAccesses?.accessPackages?.length}
+                      reporteeUuid={reporteeUuid}
                     />
-                  )
-                }
-              />
-              <RightsTabs
-                tabBadge={{
-                  accessPackages: allAccesses?.accessPackages?.length ?? 0,
-                  services: allAccesses?.services?.length ?? 0,
-                  roles: filterDigdirRole(allAccesses?.roles).length ?? 0,
-                }}
-                packagesPanel={
-                  <ReporteeAccessPackageSection
-                    numberOfAccesses={allAccesses?.accessPackages?.length}
-                    reporteeUuid={reporteeUuid}
-                  />
-                }
-                singleRightsPanel={<div>SingleRightsSection</div>}
-                roleAssignmentsPanel={
-                  <ReporteeRoleSection
-                    numberOfAccesses={allAccesses?.roles?.length}
-                    reporteeUuid={reporteeUuid}
-                  />
-                }
-              />
-            </>
-          </PageContainer>
-        </PageLayoutWrapper>
-      </PageWrapper>
+                  }
+                  singleRightsPanel={<div>SingleRightsSection</div>}
+                  roleAssignmentsPanel={
+                    <ReporteeRoleSection
+                      numberOfAccesses={allAccesses?.roles?.length}
+                      reporteeUuid={reporteeUuid}
+                    />
+                  }
+                />
+              </DelegationModalProvider>
+            </PageContainer>
+          </PageLayoutWrapper>
+        </PageWrapper>
+      </PartyRepresentationProvider>
     </SnackbarProvider>
   );
 };

--- a/src/features/amUI/reporteeRightsPage/ReporteeRoleSection.tsx
+++ b/src/features/amUI/reporteeRightsPage/ReporteeRoleSection.tsx
@@ -46,8 +46,6 @@ export const ReporteeRoleSection = ({
       </div>
       <RoleInfoModal
         modalRef={modalRef}
-        toPartyUuid={toUuid}
-        fromPartyUuid={reporteeUuid ?? ''}
         role={modalItem}
         onClose={() => setModalItem(undefined)}
         availableActions={[DelegationAction.REVOKE, DelegationAction.REQUEST]}

--- a/src/features/amUI/reporteeRightsPage/RoleInfoModal.tsx
+++ b/src/features/amUI/reporteeRightsPage/RoleInfoModal.tsx
@@ -29,8 +29,6 @@ export const RoleInfoModal = ({ modalRef, toParty, role, onClose }: RoleInfoModa
   return (
     <EditModal
       ref={modalRef}
-      toPartyUuid={getCookie('AltinnPartyUuid')}
-      fromPartyUuid={toParty.partyUuid}
       role={role}
       availableActions={[
         !isCurrentUser ? DelegationAction.DELEGATE : DelegationAction.REQUEST,

--- a/src/features/amUI/reporteeRightsPage/RoleInfoModal.tsx
+++ b/src/features/amUI/reporteeRightsPage/RoleInfoModal.tsx
@@ -3,18 +3,17 @@ import { useEffect } from 'react';
 import type { Party } from '@/rtk/features/lookupApi';
 import type { Role } from '@/rtk/features/roleApi';
 import { useGetUserInfoQuery } from '@/rtk/features/userInfoApi';
-import { getCookie } from '@/resources/Cookie/CookieMethods';
 
 import { DelegationAction, EditModal } from '../common/DelegationModal/EditModal';
+import { usePartyRepresentation } from '../common/PartyRepresentationContext/PartyRepresentationContext';
 
 interface RoleInfoModalProps {
   modalRef: React.RefObject<HTMLDialogElement>;
-  toParty: Party;
   role?: Role;
   onClose?: () => void;
 }
 
-export const RoleInfoModal = ({ modalRef, toParty, role, onClose }: RoleInfoModalProps) => {
+export const RoleInfoModal = ({ modalRef, role, onClose }: RoleInfoModalProps) => {
   useEffect(() => {
     const handleClose = () => onClose?.();
 
@@ -22,9 +21,9 @@ export const RoleInfoModal = ({ modalRef, toParty, role, onClose }: RoleInfoModa
     return () => modalRef.current?.removeEventListener('close', handleClose);
   }, [onClose, modalRef]);
 
-  const { data: currentUser } = useGetUserInfoQuery();
+  const { selfParty, toParty } = usePartyRepresentation();
 
-  const isCurrentUser = currentUser?.uuid === toParty.partyUuid;
+  const isCurrentUser = selfParty && toParty && selfParty.partyUuid === toParty.partyUuid;
 
   return (
     <EditModal

--- a/src/features/amUI/userRightsPage/AccessPackageSection/AccessPackageInfoModal.tsx
+++ b/src/features/amUI/userRightsPage/AccessPackageSection/AccessPackageInfoModal.tsx
@@ -28,25 +28,21 @@ export const AccessPackageInfoModal = ({
   const isCurrentUser = currentUser?.uuid === toPartyUuid;
 
   return (
-    <DelegationModalProvider>
-      <EditModal
-        ref={modalRef}
-        toPartyUuid={toPartyUuid}
-        fromPartyUuid={fromPartyUuid}
-        accessPackage={modalItem}
-        openWithError={openWithError}
-        onClose={onClose}
-        availableActions={
-          Array.isArray(modalActions)
-            ? modalActions
-            : modalActions !== undefined
-              ? [modalActions]
-              : [
-                  !isCurrentUser ? DelegationAction.DELEGATE : DelegationAction.REQUEST,
-                  DelegationAction.REVOKE,
-                ]
-        }
-      />
-    </DelegationModalProvider>
+    <EditModal
+      ref={modalRef}
+      accessPackage={modalItem}
+      openWithError={openWithError}
+      onClose={onClose}
+      availableActions={
+        Array.isArray(modalActions)
+          ? modalActions
+          : modalActions !== undefined
+            ? [modalActions]
+            : [
+                !isCurrentUser ? DelegationAction.DELEGATE : DelegationAction.REQUEST,
+                DelegationAction.REVOKE,
+              ]
+      }
+    />
   );
 };

--- a/src/features/amUI/userRightsPage/AccessPackageSection/AccessPackageSection.tsx
+++ b/src/features/amUI/userRightsPage/AccessPackageSection/AccessPackageSection.tsx
@@ -4,24 +4,20 @@ import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 
 import { useGetPartyByUUIDQuery } from '@/rtk/features/lookupApi';
-import { getCookie } from '@/resources/Cookie/CookieMethods';
-import { useGetUserInfoQuery } from '@/rtk/features/userInfoApi';
 
 import { DelegationModal, DelegationType } from '../../common/DelegationModal/DelegationModal';
 import { DelegationAction } from '../../common/DelegationModal/EditModal';
 
 import classes from './AccessPackageSection.module.css';
 import { ActiveDelegations } from './ActiveDelegations';
+import { usePartyRepresentation } from '../../common/PartyRepresentationContext/PartyRepresentationContext';
 
 export const AccessPackageSection = ({ numberOfAccesses }: { numberOfAccesses: number }) => {
   const { t } = useTranslation();
   const { id } = useParams();
-
+  const { selfParty } = usePartyRepresentation();
   const { data: party } = useGetPartyByUUIDQuery(id ?? '');
-  const partyUuid = getCookie('AltinnPartyUuid');
-  const { data: currentUser } = useGetUserInfoQuery();
-
-  const isCurrentUser = currentUser?.uuid === id;
+  const isCurrentUser = selfParty?.partyUuid === id;
 
   return (
     party && (
@@ -34,15 +30,13 @@ export const AccessPackageSection = ({ numberOfAccesses }: { numberOfAccesses: n
           {t('access_packages.current_access_packages_title', { count: numberOfAccesses })}
         </Heading>
         <DelegationModal
-          toPartyUuid={party.partyUuid ?? ''}
-          fromPartyUuid={partyUuid}
           delegationType={DelegationType.AccessPackage}
           availableActions={[
             DelegationAction.REVOKE,
             isCurrentUser ? DelegationAction.REQUEST : DelegationAction.DELEGATE,
           ]}
         />
-        <ActiveDelegations toParty={party} />
+        <ActiveDelegations />
       </div>
     )
   );

--- a/src/features/amUI/userRightsPage/AccessPackageSection/ActiveDelegations.tsx
+++ b/src/features/amUI/userRightsPage/AccessPackageSection/ActiveDelegations.tsx
@@ -1,35 +1,33 @@
 import React, { useRef, useState } from 'react';
 
 import type { AccessPackage } from '@/rtk/features/accessPackageApi';
-import type { Party } from '@/rtk/features/lookupApi';
 import { getCookie } from '@/resources/Cookie/CookieMethods';
-import { useGetUserInfoQuery } from '@/rtk/features/userInfoApi';
 import { useActionError } from '@/resources/hooks/useActionError';
 
 import { AccessPackageList } from '../../common/AccessPackageList/AccessPackageList';
 import { DelegationAction } from '../../common/DelegationModal/EditModal';
 
 import { AccessPackageInfoModal } from './AccessPackageInfoModal';
+import { usePartyRepresentation } from '../../common/PartyRepresentationContext/PartyRepresentationContext';
 
-export const ActiveDelegations = ({ toParty }: { toParty: Party }) => {
+export const ActiveDelegations = () => {
   const modalRef = useRef<HTMLDialogElement>(null);
   const [modalItem, setModalItem] = useState<AccessPackage | undefined>(undefined);
   const { error: actionError, setError: setActionError } = useActionError();
-  const { data: currentUser, isLoading: currentUserLoading } = useGetUserInfoQuery();
-
-  const isCurrentUser = currentUser?.uuid === toParty.partyUuid;
+  const { toParty, selfParty, isLoading } = usePartyRepresentation();
+  const isCurrentUser = selfParty?.partyUuid === toParty?.partyUuid;
 
   return (
     <>
       <AccessPackageList
-        isLoading={currentUserLoading}
+        isLoading={isLoading}
         showAllPackages
         onSelect={(accessPackage) => {
           setModalItem(accessPackage);
           modalRef.current?.showModal();
         }}
         fromPartyUuid={getCookie('AltinnPartyUuid')}
-        toPartyUuid={toParty.partyUuid}
+        toPartyUuid={toParty?.partyUuid ?? ''}
         useDeleteConfirm={isCurrentUser}
         availableActions={[
           DelegationAction.REVOKE,
@@ -48,7 +46,7 @@ export const ActiveDelegations = ({ toParty }: { toParty: Party }) => {
       />
       <AccessPackageInfoModal
         modalRef={modalRef}
-        toPartyUuid={toParty.partyUuid}
+        toPartyUuid={toParty?.partyUuid ?? ''}
         fromPartyUuid={getCookie('AltinnPartyUuid')}
         modalItem={modalItem}
         onClose={() => {

--- a/src/features/amUI/userRightsPage/AccessPackageSection/ActiveDelegations.tsx
+++ b/src/features/amUI/userRightsPage/AccessPackageSection/ActiveDelegations.tsx
@@ -9,11 +9,12 @@ import { DelegationAction } from '../../common/DelegationModal/EditModal';
 
 import { AccessPackageInfoModal } from './AccessPackageInfoModal';
 import { usePartyRepresentation } from '../../common/PartyRepresentationContext/PartyRepresentationContext';
+import { useDelegationModalContext } from '../../common/DelegationModal/DelegationModalContext';
 
 export const ActiveDelegations = () => {
   const modalRef = useRef<HTMLDialogElement>(null);
   const [modalItem, setModalItem] = useState<AccessPackage | undefined>(undefined);
-  const { error: actionError, setError: setActionError } = useActionError();
+  const { setActionError } = useDelegationModalContext();
   const { toParty, selfParty, isLoading } = usePartyRepresentation();
   const isCurrentUser = selfParty?.partyUuid === toParty?.partyUuid;
 

--- a/src/features/amUI/userRightsPage/AccessPackageSection/ActiveDelegations.tsx
+++ b/src/features/amUI/userRightsPage/AccessPackageSection/ActiveDelegations.tsx
@@ -27,8 +27,6 @@ export const ActiveDelegations = () => {
           setModalItem(accessPackage);
           modalRef.current?.showModal();
         }}
-        fromPartyUuid={getCookie('AltinnPartyUuid')}
-        toPartyUuid={toParty?.partyUuid ?? ''}
         useDeleteConfirm={isCurrentUser}
         availableActions={[
           DelegationAction.REVOKE,

--- a/src/features/amUI/userRightsPage/RoleSection/RoleSection.tsx
+++ b/src/features/amUI/userRightsPage/RoleSection/RoleSection.tsx
@@ -54,8 +54,6 @@ export const RoleSection = ({ numberOfAccesses }: RoleSectionProps) => {
         {party && (
           <RoleInfoModal
             modalRef={modalRef}
-            toPartyUuid={rightHolderUuid ?? ''}
-            fromPartyUuid={reportee?.partyUuid ?? ''}
             role={modalItem}
             onClose={() => setModalItem(undefined)}
             availableActions={[

--- a/src/features/amUI/userRightsPage/SingleRightsSection/SingleRightItem.tsx
+++ b/src/features/amUI/userRightsPage/SingleRightsSection/SingleRightItem.tsx
@@ -51,14 +51,10 @@ const SingleRightItem: FC<SingleRightItemProps> = ({ resource, toParty }) => {
           }}
         ></div> */}
       </li>
-      <DelegationModalProvider>
-        <EditModal
-          ref={modalRef}
-          toPartyUuid={toParty.partyUuid}
-          fromPartyUuid={getCookie('AltinnPartyUuid')}
-          resource={resource}
-        />
-      </DelegationModalProvider>
+      <EditModal
+        ref={modalRef}
+        resource={resource}
+      />
     </>
   );
 };

--- a/src/features/amUI/userRightsPage/SingleRightsSection/SingleRightItem.tsx
+++ b/src/features/amUI/userRightsPage/SingleRightsSection/SingleRightItem.tsx
@@ -51,10 +51,12 @@ const SingleRightItem: FC<SingleRightItemProps> = ({ resource, toParty }) => {
           }}
         ></div> */}
       </li>
-      <EditModal
-        ref={modalRef}
-        resource={resource}
-      />
+      <DelegationModalProvider>
+        <EditModal
+          ref={modalRef}
+          resource={resource}
+        />
+      </DelegationModalProvider>
     </>
   );
 };

--- a/src/features/amUI/userRightsPage/SingleRightsSection/SingleRightsSection.tsx
+++ b/src/features/amUI/userRightsPage/SingleRightsSection/SingleRightsSection.tsx
@@ -41,11 +41,7 @@ export const SingleRightsSection = () => {
         >
           {t('single_rights.current_services_title', { count: singleRights?.length })}
         </Heading>
-        <DelegationModal
-          toPartyUuid={toParty.partyUuid ?? ''}
-          fromPartyUuid={fromPartyId}
-          delegationType={DelegationType.SingleRights}
-        />
+        <DelegationModal delegationType={DelegationType.SingleRights} />
         {isError && <div>{t('user_rights_page.error')}</div>}
         {isLoading && <div>{t('user_rights_page.loading')}</div>}
 

--- a/src/features/amUI/userRightsPage/UserRightsPage.tsx
+++ b/src/features/amUI/userRightsPage/UserRightsPage.tsx
@@ -26,6 +26,8 @@ import { RightsTabs } from '../common/RightsTabs/RightsTabs';
 import { AccessPackageSection } from './AccessPackageSection/AccessPackageSection';
 import { SingleRightsSection } from './SingleRightsSection/SingleRightsSection';
 import { RoleSection } from './RoleSection/RoleSection';
+import { DelegationModalProvider } from '../common/DelegationModal/DelegationModalContext';
+import { PartyRepresentationProvider } from '../common/PartyRepresentationContext/PartyRepresentationContext';
 
 export const UserRightsPage = () => {
   const { t } = useTranslation();
@@ -48,46 +50,55 @@ export const UserRightsPage = () => {
   return (
     <SnackbarProvider>
       <PageWrapper>
-        <PageLayoutWrapper>
-          <PageContainer onNavigateBack={() => navigate(`/${amUIPath.Users}`)}>
-            {!isLoading && allAccesses ? (
-              <>
-                <UserPageHeader
-                  userName={party?.name}
-                  userType={party?.partyTypeName}
-                  subHeading={`for ${reportee?.name}`}
-                  roles={
-                    !!reportee?.partyUuid &&
-                    !!party?.partyUuid && (
-                      <UserRoles
-                        rightOwnerUuid={reportee.partyUuid}
-                        rightHolderUuid={party.partyUuid}
-                      />
-                    )
-                  }
-                />
+        <PartyRepresentationProvider
+          fromPartyUuid={getCookie('AltinnPartyUuid')}
+          toPartyUuid={id ?? ''}
+        >
+          <DelegationModalProvider>
+            <PageLayoutWrapper>
+              <PageContainer onNavigateBack={() => navigate(`/${amUIPath.Users}`)}>
+                {!isLoading && allAccesses ? (
+                  <>
+                    <UserPageHeader
+                      userName={party?.name}
+                      userType={party?.partyTypeName}
+                      subHeading={`for ${reportee?.name}`}
+                      roles={
+                        !!reportee?.partyUuid &&
+                        !!party?.partyUuid && (
+                          <UserRoles
+                            rightOwnerUuid={reportee.partyUuid}
+                            rightHolderUuid={party.partyUuid}
+                          />
+                        )
+                      }
+                    />
 
-                <RightsTabs
-                  tabBadge={{
-                    accessPackages: allAccesses.accessPackages?.length ?? 0,
-                    services: allAccesses.services?.length ?? 0,
-                    roles: filterDigdirRole(allAccesses.roles).length ?? 0,
-                  }}
-                  packagesPanel={
-                    <AccessPackageSection numberOfAccesses={allAccesses.accessPackages?.length} />
-                  }
-                  singleRightsPanel={<SingleRightsSection />}
-                  roleAssignmentsPanel={
-                    <RoleSection numberOfAccesses={allAccesses.accessPackages?.length} />
-                  }
-                />
-              </>
-            ) : (
-              // TODO: Add proper aria-label for loading
-              <Spinner aria-label='loading' />
-            )}
-          </PageContainer>
-        </PageLayoutWrapper>
+                    <RightsTabs
+                      tabBadge={{
+                        accessPackages: allAccesses.accessPackages?.length ?? 0,
+                        services: allAccesses.services?.length ?? 0,
+                        roles: filterDigdirRole(allAccesses.roles).length ?? 0,
+                      }}
+                      packagesPanel={
+                        <AccessPackageSection
+                          numberOfAccesses={allAccesses.accessPackages?.length}
+                        />
+                      }
+                      singleRightsPanel={<SingleRightsSection />}
+                      roleAssignmentsPanel={
+                        <RoleSection numberOfAccesses={allAccesses.accessPackages?.length} />
+                      }
+                    />
+                  </>
+                ) : (
+                  // TODO: Add proper aria-label for loading
+                  <Spinner aria-label='loading' />
+                )}
+              </PageContainer>
+            </PageLayoutWrapper>
+          </DelegationModalProvider>
+        </PartyRepresentationProvider>
       </PageWrapper>
     </SnackbarProvider>
   );

--- a/src/features/amUI/userRightsPage/UserRightsPage.tsx
+++ b/src/features/amUI/userRightsPage/UserRightsPage.tsx
@@ -6,7 +6,11 @@ import { useNavigate, useParams } from 'react-router';
 import { useDocumentTitle } from '@/resources/hooks/useDocumentTitle';
 import { PageWrapper } from '@/components';
 import { useGetPartyByUUIDQuery } from '@/rtk/features/lookupApi';
-import { useGetReporteeQuery, useGetUserAccessesQuery } from '@/rtk/features/userInfoApi';
+import {
+  useGetReporteeQuery,
+  useGetUserAccessesQuery,
+  useGetUserInfoQuery,
+} from '@/rtk/features/userInfoApi';
 import { amUIPath } from '@/routes/paths';
 import { filterDigdirRole } from '@/resources/utils/roleUtils';
 import { getCookie } from '@/resources/Cookie/CookieMethods';

--- a/src/rtk/features/userInfoApi.ts
+++ b/src/rtk/features/userInfoApi.ts
@@ -1,17 +1,17 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 
 import { getCookie } from '@/resources/Cookie/CookieMethods';
+import { Party } from './lookupApi';
 
 interface UserInfoApiResponse {
-  party: {
-    name: string;
-  };
+  party: Party;
   userUuid: string;
 }
 
 interface UserInfo {
   name: string;
   uuid: string;
+  party: Party;
 }
 
 export interface ReporteeInfo {
@@ -63,7 +63,7 @@ export const userInfoApi = createApi({
       query: () => 'profile',
       keepUnusedDataFor: 300,
       transformResponse: (response: UserInfoApiResponse) => {
-        return { name: response.party.name, uuid: response.userUuid };
+        return { name: response.party.name, uuid: response.userUuid, party: response.party };
       },
     }),
     getReportee: builder.query<ReporteeInfo, void>({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Move fromUuid & toUuid to context reduce the need for passing these values as props

## Related Issue(s)
- #[1333](https://github.com/Altinn/altinn-access-management-frontend/issues/1333)

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
