### PR TITLE
Map access packages for agent request

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/SystemUser/Frontend/SystemUserAgentRequestFE.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/SystemUser/Frontend/SystemUserAgentRequestFE.cs
@@ -1,5 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
+using Altinn.AccessManagement.UI.Core.Models.AccessPackage.Frontend;
+using Altinn.AccessManagement.UI.Core.Models.ResourceRegistry.Frontend;
 
 namespace Altinn.AccessManagement.UI.Core.Models.SystemUser.Frontend
 {
@@ -35,5 +37,17 @@ namespace Altinn.AccessManagement.UI.Core.Models.SystemUser.Frontend
         /// </summary>
         [JsonPropertyName("system")]
         public RegisteredSystemFE System { get; set; }
+
+        /// <summary>
+        /// List of resources information
+        /// </summary>
+        [JsonPropertyName("resources")]
+        public List<ServiceResourceFE> Resources { get; set; } = new List<ServiceResourceFE>();
+
+        /// <summary>
+        /// List of access package information (with resources)
+        /// </summary>
+        [JsonPropertyName("accessPackages")]
+        public List<AccessPackageFE> AccessPackages { get; set; } = new List<AccessPackageFE>();
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/SystemUser/Frontend/SystemUserAgentRequestFE.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/SystemUser/Frontend/SystemUserAgentRequestFE.cs
@@ -39,12 +39,6 @@ namespace Altinn.AccessManagement.UI.Core.Models.SystemUser.Frontend
         public RegisteredSystemFE System { get; set; }
 
         /// <summary>
-        /// List of resources information
-        /// </summary>
-        [JsonPropertyName("resources")]
-        public List<ServiceResourceFE> Resources { get; set; } = new List<ServiceResourceFE>();
-
-        /// <summary>
         /// List of access package information (with resources)
         /// </summary>
         [JsonPropertyName("accessPackages")]

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/SystemRegister/systems.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/SystemRegister/systems.json
@@ -158,5 +158,27 @@
       }
     ],
     "isVisible": false
+  },
+  {
+    "systemId": "ff_system",
+    "systemVendorOrgNumber": "918098372",
+    "systemVendorOrgName": "",
+    "name": {
+      "en": "Forretningsfører-system",
+      "nb": "Forretningsfører-system",
+      "nn": "Forretningsfører-system"
+    },
+    "description": {
+      "en": "Forretningsfører-system",
+      "nb": "Forretningsfører-system",
+      "nn": "Forretningsfører-system"
+    },
+    "rights": [],
+    "accessPackages": [
+      {
+        "urn": "urn:altinn:accesspackage:skattegrunnlag"
+      }
+    ],
+    "isVisible": false
   }
 ]

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/SystemUser/systemUserAgentRequest.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/SystemUser/systemUserAgentRequest.json
@@ -3,5 +3,10 @@
   "status": "New",
   "systemId": "910493353_fiken_demo_product",
   "partyOrgNo": "51329012",
-  "redirectUrl": "https://smartcloudaltinn.azurewebsites.net/receipt"
+  "redirectUrl": "https://smartcloudaltinn.azurewebsites.net/receipt",
+  "accessPackages": [
+    {
+      "urn": "urn:altinn:accesspackage:ansvarlig-revisor"
+    }
+  ]
 }


### PR DESCRIPTION
## Description
- Map access packages in agent request, so frontend can display these later

## Related Issue(s)
- this PR

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Expanded system user request details to include additional resource and access package information.
	- Enhanced the processing logic to enrich and accurately map access package data.
	- Updated sample configuration data to reflect these extended details.
	- Introduced a new system entry with specific identifiers and attributes related to access management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->