### PR TITLE
Move loading customers for agent system users to BFF

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/Interfaces/ISystemUserAgentDelegationService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/Interfaces/ISystemUserAgentDelegationService.cs
@@ -11,13 +11,14 @@ namespace Altinn.AccessManagement.UI.Core.Services.Interfaces
     public interface ISystemUserAgentDelegationService
     {
         /// <summary>
-        /// Return all customers of a specific type for party
+        /// Return all customers for given system user
         /// </summary>
-        /// <param name="partyUuid">The party UUID of the party to retrieve customers from</param>
-        /// <param name="customerType">Customer type to get</param>
+        /// <param name="partyId">The party id of the party owning system user</param>
+        /// <param name="partyUuid">The party uuid of the party owning system user</param>
+        /// <param name="systemUserGuid">The system user UUID to get customers from</param>
         /// <param name="cancellationToken">Cancellation token</param>
-        /// <returns>List of all party customers</returns>
-        Task<List<AgentDelegationPartyFE>> GetPartyCustomers(Guid partyUuid, CustomerRoleType customerType, CancellationToken cancellationToken);
+        /// <returns>List of all systemuser customers</returns>
+        Task<List<AgentDelegationPartyFE>> GetSystemUserCustomers(int partyId, Guid partyUuid, Guid systemUserGuid, CancellationToken cancellationToken);
 
         /// <summary>
         /// Return delegated customers for this system user

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/SystemUserAgentDelegationService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/SystemUserAgentDelegationService.cs
@@ -47,11 +47,11 @@ namespace Altinn.AccessManagement.UI.Core.Services
             {
                 customerType = CustomerRoleType.Regnskapsforer;
             } 
-            else if (accessPackageUrns.Any(x => regnskapsforerPackages.Contains(x))) 
+            else if (accessPackageUrns.Any(x => revisorPackages.Contains(x))) 
             {
                 customerType = CustomerRoleType.Revisor;
             } 
-            else if (accessPackageUrns.Any(x => regnskapsforerPackages.Contains(x))) 
+            else if (accessPackageUrns.Any(x => forretningsforerPackages.Contains(x))) 
             {
                 customerType = CustomerRoleType.Forretningsforer;
             } 

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/SystemUserAgentDelegationService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/SystemUserAgentDelegationService.cs
@@ -12,26 +12,56 @@ namespace Altinn.AccessManagement.UI.Core.Services
     public class SystemUserAgentDelegationService : ISystemUserAgentDelegationService
     {
         private readonly ISystemUserAgentDelegationClient _systemUserAgentDelegationClient;
+        private readonly ISystemUserClient _systemUserClient;
         private readonly IRegisterClient _registerClient;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SystemUserAgentDelegationService"/> class.
         /// </summary>
         /// <param name="systemUserAgentDelegationClient">The system user client administration client.</param>
+        /// <param name="systemUserClient">The system user client</param>
         /// <param name="registerClient">The register client</param>
         public SystemUserAgentDelegationService(
             ISystemUserAgentDelegationClient systemUserAgentDelegationClient,
+            ISystemUserClient systemUserClient,
             IRegisterClient registerClient)
         {
             _systemUserAgentDelegationClient = systemUserAgentDelegationClient;
+            _systemUserClient = systemUserClient;
             _registerClient = registerClient;
         }
-
-        /// <inheritdoc />
-        public async Task<List<AgentDelegationPartyFE>> GetPartyCustomers(Guid partyUuid, CustomerRoleType customerType, CancellationToken cancellationToken)
+        
+        /// <inheritdoc /> 
+        public async Task<List<AgentDelegationPartyFE>> GetSystemUserCustomers(int partyId, Guid partyUuid, Guid systemUserGuid, CancellationToken cancellationToken)
         {
-            CustomerList regnskapsforerCustomers = await _registerClient.GetPartyCustomers(partyUuid, customerType, cancellationToken);
-            return MapCustomerListToCustomerFE(regnskapsforerCustomers);
+            // get access packages from systemuser
+            SystemUser systemUser = await _systemUserClient.GetAgentSystemUser(partyId, systemUserGuid, cancellationToken);
+            IEnumerable<string> accessPackageUrns = systemUser.AccessPackages.Select(x => x.Urn);
+            CustomerRoleType customerType;
+
+            List<string> regnskapsforerPackages = ["urn:altinn:accesspackage:regnskapsforer-med-signeringsrettighet", "urn:altinn:accesspackage:regnskapsforer-uten-signeringsrettighet", "urn:altinn:accesspackage:regnskapsforer-lonn"];
+            List<string> revisorPackages = ["urn:altinn:accesspackage:ansvarlig-revisor", "urn:altinn:accesspackage:revisormedarbeider"];
+            List<string> forretningsforerPackages = ["urn:altinn:accesspackage:skattegrunnlag"];
+            
+            if (accessPackageUrns.Any(x => regnskapsforerPackages.Contains(x))) 
+            {
+                customerType = CustomerRoleType.Regnskapsforer;
+            } 
+            else if (accessPackageUrns.Any(x => regnskapsforerPackages.Contains(x))) 
+            {
+                customerType = CustomerRoleType.Revisor;
+            } 
+            else if (accessPackageUrns.Any(x => regnskapsforerPackages.Contains(x))) 
+            {
+                customerType = CustomerRoleType.Forretningsforer;
+            } 
+            else 
+            {
+                customerType = CustomerRoleType.None;
+            }
+
+            CustomerList customers = await _registerClient.GetPartyCustomers(partyUuid, customerType, cancellationToken);
+            return MapCustomerListToCustomerFE(customers);
         }
 
         /// <inheritdoc />

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/SystemUserAgentDelegationControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/SystemUserAgentDelegationControllerTest.cs
@@ -44,11 +44,13 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         {
             // Arrange
             string partyUuid = "cd35779b-b174-4ecc-bbef-ece13611be7f";
+            string partyId = "51329012";
+            string systemUserId = _regnskapsforerSystemUserId;
             string path = Path.Combine(_expectedDataPath, "SystemUser", "regnskapsforerCustomers.json");
             List<AgentDelegationPartyFE> expectedResponse = Util.GetMockData<List<AgentDelegationPartyFE>>(path);
 
             // Act
-            HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyUuid}/customers/regnskapsforer");
+            HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{partyUuid}/{systemUserId}/customers");
             List<AgentDelegationPartyFE> actualResponse = await httpResponse.Content.ReadFromJsonAsync<List<AgentDelegationPartyFE>>();
 
             // Assert
@@ -65,11 +67,13 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         {
             // Arrange
             string partyUuid = "cd35779b-b174-4ecc-bbef-ece13611be7f";
+            string partyId = "51329012";
+            string systemUserId = _revisorSystemUserId;
             string path = Path.Combine(_expectedDataPath, "SystemUser", "revisorCustomers.json");
             List<AgentDelegationPartyFE> expectedResponse = Util.GetMockData<List<AgentDelegationPartyFE>>(path);
 
             // Act
-            HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyUuid}/customers/revisor");
+            HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{partyUuid}/{systemUserId}/customers");
             List<AgentDelegationPartyFE> actualResponse = await httpResponse.Content.ReadFromJsonAsync<List<AgentDelegationPartyFE>>();
 
             // Assert
@@ -85,12 +89,14 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         public async Task GetForretningsforerCustomers_ReturnsCustomers()
         {
             // Arrange
-            string partyUuid = "cd35779b-b174-4ecc-bbef-ece13611be7f";
+             string partyUuid = "cd35779b-b174-4ecc-bbef-ece13611be7f";
+            string partyId = "51329012";
+            string systemUserId = _forretningsforerSystemUserId;
             string path = Path.Combine(_expectedDataPath, "SystemUser", "forretningsforerCustomers.json");
             List<AgentDelegationPartyFE> expectedResponse = Util.GetMockData<List<AgentDelegationPartyFE>>(path);
 
             // Act
-            HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyUuid}/customers/forretningsforer");
+            HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{partyUuid}/{systemUserId}/customers");
             List<AgentDelegationPartyFE> actualResponse = await httpResponse.Content.ReadFromJsonAsync<List<AgentDelegationPartyFE>>();
 
             // Assert

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/SystemUserAgentDelegationControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/SystemUserAgentDelegationControllerTest.cs
@@ -89,7 +89,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         public async Task GetForretningsforerCustomers_ReturnsCustomers()
         {
             // Arrange
-             string partyUuid = "cd35779b-b174-4ecc-bbef-ece13611be7f";
+            string partyUuid = "cd35779b-b174-4ecc-bbef-ece13611be7f";
             string partyId = "51329012";
             string systemUserId = _forretningsforerSystemUserId;
             string path = Path.Combine(_expectedDataPath, "SystemUser", "forretningsforerCustomers.json");

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/SystemUserAgentDelegationController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/SystemUserAgentDelegationController.cs
@@ -28,44 +28,18 @@ namespace Altinn.AccessManagement.UI.Controllers
         }
 
         /// <summary>
-        /// Get all regnskapsforer customers for the party
+        /// Get all customers for the party
         /// </summary>
-        /// <param name="partyUuid">Party user represents</param>
+        /// <param name="partyId">Party user represents</param>
+        /// <param name="partyUuid">Party uuid user represents</param>
+        /// <param name="systemUserGuid">System user to get customers from</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>List of customer party</returns>
         [Authorize]
-        [HttpGet("{partyUuid}/customers/regnskapsforer")]
-        public async Task<ActionResult> GetPartyRegnskapsforerCustomers([FromRoute] Guid partyUuid, CancellationToken cancellationToken)
+        [HttpGet("{partyId}/{partyUuid}/{systemUserGuid}/customers")]
+        public async Task<ActionResult> GetSystemUserCustomers([FromRoute] int partyId, [FromRoute] Guid partyUuid, [FromRoute] Guid systemUserGuid, CancellationToken cancellationToken)
         {
-            List<AgentDelegationPartyFE> customers = await _systemUserAgentDelegationService.GetPartyCustomers(partyUuid, CustomerRoleType.Regnskapsforer, cancellationToken);
-            return Ok(customers);
-        }
-
-        /// <summary>
-        /// Get all revisor customers for the party
-        /// </summary>
-        /// <param name="partyUuid">Party user represents</param>
-        /// <param name="cancellationToken">Cancellation token</param>
-        /// <returns>List of customer party</returns>
-        [Authorize]
-        [HttpGet("{partyUuid}/customers/revisor")]
-        public async Task<ActionResult> GetPartyRevisorCustomers([FromRoute] Guid partyUuid, CancellationToken cancellationToken)
-        {
-            List<AgentDelegationPartyFE> customers = await _systemUserAgentDelegationService.GetPartyCustomers(partyUuid, CustomerRoleType.Revisor, cancellationToken);
-            return Ok(customers);
-        }
-
-        /// <summary>
-        /// Get all forretningsforer customers for the party
-        /// </summary>
-        /// <param name="partyUuid">Party user represents</param>
-        /// <param name="cancellationToken">Cancellation token</param>
-        /// <returns>List of customer party</returns>
-        [Authorize]
-        [HttpGet("{partyUuid}/customers/forretningsforer")]
-        public async Task<ActionResult> GetPartyForretningsforerCustomers([FromRoute] Guid partyUuid, CancellationToken cancellationToken)
-        {
-            List<AgentDelegationPartyFE> customers = await _systemUserAgentDelegationService.GetPartyCustomers(partyUuid, CustomerRoleType.Forretningsforer, cancellationToken);
+            List<AgentDelegationPartyFE> customers = await _systemUserAgentDelegationService.GetSystemUserCustomers(partyId, partyUuid, systemUserGuid, cancellationToken);
             return Ok(customers);
         }
 

--- a/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPage.tsx
@@ -6,48 +6,14 @@ import { useParams } from 'react-router';
 import {
   useGetAssignedCustomersQuery,
   useGetAgentSystemUserQuery,
-  useGetRegnskapsforerCustomersQuery,
-  useGetRevisorCustomersQuery,
-  useGetForretningsforerCustomersQuery,
+  useGetCustomersQuery,
 } from '@/rtk/features/systemUserApi';
 import { getCookie } from '@/resources/Cookie/CookieMethods';
 import { PageWrapper } from '@/components';
 import { useDocumentTitle } from '@/resources/hooks/useDocumentTitle';
 import { PageLayoutWrapper } from '@/features/amUI/common/PageLayoutWrapper';
 
-import type { SystemUser } from '../types';
-
 import { SystemUserAgentDelegationPageContent } from './SystemUserAgentDelegationPageContent';
-
-const regnskapsforerUrns = [
-  'urn:altinn:accesspackage:regnskapsforer-med-signeringsrettighet',
-  'urn:altinn:accesspackage:regnskapsforer-uten-signeringsrettighet',
-  'urn:altinn:accesspackage:regnskapsforer-lonn',
-];
-const revisorUrns = [
-  'urn:altinn:accesspackage:ansvarlig-revisor',
-  'urn:altinn:accesspackage:revisormedarbeider',
-];
-const forretningsforerUrns = ['urn:altinn:accesspackage:skattegrunnlag'];
-
-enum SystemUserCustomerType {
-  UNKNOWN = 'UNKNOWN',
-  REGNSKAPSFORER = 'REGNSKAPSFORER',
-  REVISOR = 'REVISOR',
-  FORRETNINGSFORER = 'FORRETNINGSFORER',
-}
-
-const getSystemUserCustomerType = (systemUser: SystemUser | undefined): SystemUserCustomerType => {
-  const accessPackageUrns = systemUser?.accessPackages.map((ap) => ap.urn) ?? [];
-  if (accessPackageUrns.some((urn) => regnskapsforerUrns.includes(urn))) {
-    return SystemUserCustomerType.REGNSKAPSFORER;
-  } else if (accessPackageUrns.some((urn) => revisorUrns.includes(urn))) {
-    return SystemUserCustomerType.REVISOR;
-  } else if (accessPackageUrns.some((urn) => forretningsforerUrns.includes(urn))) {
-    return SystemUserCustomerType.FORRETNINGSFORER;
-  }
-  return SystemUserCustomerType.UNKNOWN;
-};
 
 export const SystemUserAgentDelegationPage = (): React.ReactNode => {
   const { id } = useParams();
@@ -64,28 +30,10 @@ export const SystemUserAgentDelegationPage = (): React.ReactNode => {
   } = useGetAgentSystemUserQuery({ partyId, systemUserId: id || '' });
 
   const {
-    data: regnskapsforerCustomers,
-    isError: isLoadRegnskapsforerCustomersError,
-    isLoading: isLoadingRegnskapsforerCustomers,
-  } = useGetRegnskapsforerCustomersQuery(partyUuid, {
-    skip: getSystemUserCustomerType(systemUser) !== SystemUserCustomerType.REGNSKAPSFORER,
-  });
-
-  const {
-    data: revisorCustomers,
-    isError: isLoadRevisorCustomersError,
-    isLoading: isLoadingRevisorCustomers,
-  } = useGetRevisorCustomersQuery(partyUuid, {
-    skip: getSystemUserCustomerType(systemUser) !== SystemUserCustomerType.REVISOR,
-  });
-
-  const {
-    data: forretningsforerCustomers,
-    isError: isLoadForretningsforerCustomersError,
-    isLoading: isLoadingForretningsforerCustomers,
-  } = useGetForretningsforerCustomersQuery(partyUuid, {
-    skip: getSystemUserCustomerType(systemUser) !== SystemUserCustomerType.FORRETNINGSFORER,
-  });
+    data: customers,
+    isError: isLoadCustomersError,
+    isLoading: isLoadingCustomers,
+  } = useGetCustomersQuery({ partyId, partyUuid, systemUserId: id ?? '' });
 
   const {
     data: agentDelegations,
@@ -93,24 +41,16 @@ export const SystemUserAgentDelegationPage = (): React.ReactNode => {
     isLoading: isLoadingAssignedCustomers,
   } = useGetAssignedCustomersQuery({ partyId, systemUserId: id || '' });
 
-  const customers = regnskapsforerCustomers || revisorCustomers || forretningsforerCustomers;
-
   return (
     <PageWrapper>
       <PageLayoutWrapper>
-        {(isLoadingSystemUser ||
-          isLoadingRegnskapsforerCustomers ||
-          isLoadingRevisorCustomers ||
-          isLoadingForretningsforerCustomers ||
-          isLoadingAssignedCustomers) && (
+        {(isLoadingSystemUser || isLoadingCustomers || isLoadingAssignedCustomers) && (
           <Spinner aria-label={t('systemuser_detailpage.loading_systemuser')} />
         )}
         {isLoadSystemUserError && (
           <Alert data-color='danger'>{t('systemuser_detailpage.load_systemuser_error')}</Alert>
         )}
-        {(isLoadRevisorCustomersError ||
-          isLoadRegnskapsforerCustomersError ||
-          isLoadForretningsforerCustomersError) && (
+        {isLoadCustomersError && (
           <Alert data-color='danger'>{t('systemuser_agent_delegation.load_customers_error')}</Alert>
         )}
         {isLoadAssignedCustomersError && (

--- a/src/rtk/features/systemUserApi.ts
+++ b/src/rtk/features/systemUserApi.ts
@@ -83,16 +83,12 @@ export const systemUserApi = createApi({
     getAgentSystemUser: builder.query<SystemUser, { partyId: string; systemUserId: string }>({
       query: ({ partyId, systemUserId }) => `systemuser/agent/${partyId}/${systemUserId}`,
     }),
-    getRegnskapsforerCustomers: builder.query<AgentDelegationCustomer[], string>({
-      query: (partyUuid) => `systemuser/agentdelegation/${partyUuid}/customers/regnskapsforer`,
-      keepUnusedDataFor: Infinity,
-    }),
-    getRevisorCustomers: builder.query<AgentDelegationCustomer[], string>({
-      query: (partyUuid) => `systemuser/agentdelegation/${partyUuid}/customers/revisor`,
-      keepUnusedDataFor: Infinity,
-    }),
-    getForretningsforerCustomers: builder.query<AgentDelegationCustomer[], string>({
-      query: (partyUuid) => `systemuser/agentdelegation/${partyUuid}/customers/forretningsforer`,
+    getCustomers: builder.query<
+      AgentDelegationCustomer[],
+      { partyId: string; partyUuid: string; systemUserId: string }
+    >({
+      query: ({ partyId, partyUuid, systemUserId }) =>
+        `systemuser/agentdelegation/${partyId}/${partyUuid}/${systemUserId}/customers`,
       keepUnusedDataFor: Infinity,
     }),
     getAssignedCustomers: builder.query<
@@ -200,9 +196,7 @@ export const {
   useDeleteSystemuserMutation,
   useGetSystemUserQuery,
   useGetSystemUsersQuery,
-  useGetRegnskapsforerCustomersQuery,
-  useGetRevisorCustomersQuery,
-  useGetForretningsforerCustomersQuery,
+  useGetCustomersQuery,
   useGetAssignedCustomersQuery,
   useAssignCustomerMutation,
   useRemoveCustomerMutation,


### PR DESCRIPTION
## Description
- To prepare for systemuser v6, the BFF should send a list of access packages to backend to load customers. Move loading customer list to BFF to make transition easier in systemuser v6

## Related Issue(s)
- this PR

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a unified customer lookup that leverages system user information for more precise customer retrieval.

- **Refactor**
	- Consolidated multiple customer queries into a single, streamlined process, resulting in improved consistency in data loading and error handling.
	- Updated API endpoints to support new parameters for enhanced customer data retrieval.
	- Removed outdated methods and replaced them with a more versatile method for retrieving customer data.

These changes simplify the customer management experience and enhance overall responsiveness for end-users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->