### PR TITLE
Update agent delegation urls

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/ClientInterfaces/ISystemUserAgentDelegationClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/ClientInterfaces/ISystemUserAgentDelegationClient.cs
@@ -31,11 +31,10 @@ namespace Altinn.AccessManagement.UI.Core.ClientInterfaces
         /// <summary>
         /// Remove client from system user
         /// </summary>
-        /// <param name="partyId">The party id of the party owning system user to remove customer from</param>
-        /// <param name="systemUserGuid">The system user UUID to remove customer from</param>
-        /// <param name="assignmentId">The assignment id to remove</param>
+        /// <param name="facilitatorId">Facilitator uuid, uuid of partyId</param>
+        /// <param name="delegationId">The delegation id to remove</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Boolean result of remove</returns>
-        Task<Result<bool>> RemoveClient(int partyId, Guid systemUserGuid, Guid assignmentId, CancellationToken cancellationToken);
+        Task<Result<bool>> RemoveClient(Guid facilitatorId, Guid delegationId, CancellationToken cancellationToken);
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/Interfaces/ISystemUserAgentDelegationService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/Interfaces/ISystemUserAgentDelegationService.cs
@@ -43,11 +43,10 @@ namespace Altinn.AccessManagement.UI.Core.Services.Interfaces
         /// <summary>
         /// Remove client from system user
         /// </summary>
-        /// <param name="partyId">The party id of the party owning system user to remove customer from</param>
-        /// <param name="systemUserGuid">The system user UUID to remove customer from</param>
-        /// <param name="assignmentId">The assignment id to remove</param>
+        /// <param name="facilitatorId">The system user UUID to remove customer from</param>
+        /// <param name="delegationId">The delegation id to remove</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Boolean result of remove</returns>
-        Task<Result<bool>> RemoveClient(int partyId, Guid systemUserGuid, Guid assignmentId, CancellationToken cancellationToken);
+        Task<Result<bool>> RemoveClient(Guid facilitatorId, Guid delegationId, CancellationToken cancellationToken);
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/SystemUserAgentDelegationService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/SystemUserAgentDelegationService.cs
@@ -99,9 +99,9 @@ namespace Altinn.AccessManagement.UI.Core.Services
         }
 
         /// <inheritdoc />
-        public async Task<Result<bool>> RemoveClient(int partyId, Guid systemUserGuid, Guid assignmentId, CancellationToken cancellationToken)
+        public async Task<Result<bool>> RemoveClient(Guid facilitatorId, Guid delegationId, CancellationToken cancellationToken)
         {
-            Result<bool> response = await _systemUserAgentDelegationClient.RemoveClient(partyId, systemUserGuid, assignmentId, cancellationToken);
+            Result<bool> response = await _systemUserAgentDelegationClient.RemoveClient(facilitatorId, delegationId, cancellationToken);
             if (response.IsProblem)
             {
                 return new Result<bool>(response.Problem);

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/SystemUserAgentDelegationClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/SystemUserAgentDelegationClient.cs
@@ -101,12 +101,12 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
         }
 
         /// <inheritdoc/>
-        public async Task<Result<bool>> RemoveClient(int partyId, Guid systemUserGuid, Guid assignmentId, CancellationToken cancellationToken)
+        public async Task<Result<bool>> RemoveClient(Guid facilitatorId, Guid delegationId, CancellationToken cancellationToken)
         {
             try
             {
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
-                string endpointUrl = $"systemuser/agent/{partyId}/{systemUserGuid}/delegation/{assignmentId}";
+                string endpointUrl = $"systemuser/agent/{facilitatorId}/{delegationId}";
 
                 HttpResponseMessage response = await _client.DeleteAsync(token, endpointUrl);
                 string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/SystemUserAgentDelegationClientMock.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/SystemUserAgentDelegationClientMock.cs
@@ -64,9 +64,9 @@ namespace Altinn.AccessManagement.UI.Mocks.Mocks
             }));
         }
 
-        public Task<Result<bool>> RemoveClient(int partyId, Guid systemUserGuid, Guid assignmentId, CancellationToken cancellationToken)
+        public Task<Result<bool>> RemoveClient(Guid facilitatorId, Guid delegationId, CancellationToken cancellationToken)
         {
-            if (assignmentId.Equals(Guid.Parse("60f1ade9-ed48-4083-a369-178d45d6ffd1"))) 
+            if (delegationId.Equals(Guid.Parse("60f1ade9-ed48-4083-a369-178d45d6ffd1"))) 
             {
                 return Task.FromResult(new Result<bool>(TestErrors.CustomerNotFound));
             }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/SystemUserAgentDelegationControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/SystemUserAgentDelegationControllerTest.cs
@@ -261,7 +261,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             AgentDelegationRequest dto = new AgentDelegationRequest
             {
                 CustomerId = Guid.Parse(customerId),
-                FacilitatorId = Guid.Parse(systemUserId)
+                FacilitatorId = Guid.Parse(partyUuid)
             };
             string jsonDto = JsonSerializer.Serialize(dto);
             HttpContent content = new StringContent(jsonDto, Encoding.UTF8, "application/json");

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/SystemUserAgentDelegationControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/SystemUserAgentDelegationControllerTest.cs
@@ -182,13 +182,14 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         {
             // Arrange
             string partyId = "51329012";
+            string partyUuid = "cd35779b-b174-4ecc-bbef-ece13611be7f";
             string systemUserId = _regnskapsforerSystemUserId;
             string customerId = "6b0574ae-f569-4c0d-a8d4-8ad56f427890";
             
             AgentDelegationRequest dto = new AgentDelegationRequest
             {
                 CustomerId = Guid.Parse(customerId),
-                FacilitatorId = Guid.Parse(systemUserId)
+                FacilitatorId = Guid.Parse(partyUuid)
             };
             string jsonDto = JsonSerializer.Serialize(dto);
             HttpContent content = new StringContent(jsonDto, Encoding.UTF8, "application/json");
@@ -200,7 +201,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             };
 
             // Act
-            HttpResponseMessage httpResponse = await _client.PostAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/delegation", content);
+            HttpResponseMessage httpResponse = await _client.PostAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{partyUuid}/{systemUserId}/delegation", content);
             AgentDelegationFE actualResponse = await httpResponse.Content.ReadFromJsonAsync<AgentDelegationFE>();
 
             // Assert
@@ -217,13 +218,14 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         {
             // Arrange
             string partyId = "51329012";
+            string partyUuid = "cd35779b-b174-4ecc-bbef-ece13611be7f";
             string systemUserId = _revisorSystemUserId;
             string customerId = "cd35779b-b174-4ecc-bbef-ece13611be7f";
             
             AgentDelegationRequest dto = new AgentDelegationRequest
             {
                 CustomerId = Guid.Parse(customerId),
-                FacilitatorId = Guid.Parse(systemUserId)
+                FacilitatorId = Guid.Parse(partyUuid)
             };
             string jsonDto = JsonSerializer.Serialize(dto);
             HttpContent content = new StringContent(jsonDto, Encoding.UTF8, "application/json");
@@ -235,7 +237,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             };
 
             // Act
-            HttpResponseMessage httpResponse = await _client.PostAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/delegation", content);
+            HttpResponseMessage httpResponse = await _client.PostAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{partyUuid}/{systemUserId}/delegation", content);
             AgentDelegationFE actualResponse = await httpResponse.Content.ReadFromJsonAsync<AgentDelegationFE>();
 
             // Assert
@@ -252,6 +254,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         {
             // Arrange
             string partyId = "51329012";
+            string partyUuid = "cd35779b-b174-4ecc-bbef-ece13611be7f";
             string systemUserId = _regnskapsforerSystemUserId;
             string customerId = "82cc64c5-60ff-4184-8c07-964c3a1e6fc7";
             
@@ -266,7 +269,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             HttpStatusCode expectedResponse = HttpStatusCode.NotFound;
 
             // Act
-            HttpResponseMessage httpResponse = await _client.PostAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/delegation", content);
+            HttpResponseMessage httpResponse = await _client.PostAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{partyUuid}/{systemUserId}/delegation", content);
 
             // Assert
             Assert.Equal(expectedResponse, httpResponse.StatusCode);
@@ -281,13 +284,14 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         {
             // Arrange
             string partyId = "51329012";
+            string partyUuid = "cd35779b-b174-4ecc-bbef-ece13611be7f";
             string systemUserId = _regnskapsforerSystemUserId;
-            string assignmentId = "7da509f3-cff5-4253-946e-0336ae0bc48f";
+            string delegationId = "7da509f3-cff5-4253-946e-0336ae0bc48f";
             
             bool expectedResponse = true;
 
             // Act
-            HttpResponseMessage httpResponse = await _client.DeleteAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/delegation/{assignmentId}");
+            HttpResponseMessage httpResponse = await _client.DeleteAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{partyUuid}/{systemUserId}/delegation/{delegationId}");
             bool actualResponse = await httpResponse.Content.ReadFromJsonAsync<bool>();
 
             // Assert
@@ -304,13 +308,14 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         {
             // Arrange
             string partyId = "51329012";
+            string partyUuid = "cd35779b-b174-4ecc-bbef-ece13611be7f";
             string systemUserId = _regnskapsforerSystemUserId;
-            string assignmentId = "60f1ade9-ed48-4083-a369-178d45d6ffd1";
+            string delegationId = "60f1ade9-ed48-4083-a369-178d45d6ffd1";
             
             HttpStatusCode expectedResponse = HttpStatusCode.NotFound;
 
             // Act
-            HttpResponseMessage httpResponse = await _client.DeleteAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/delegation/{assignmentId}");
+            HttpResponseMessage httpResponse = await _client.DeleteAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{partyUuid}/{systemUserId}/delegation/{delegationId}");
 
             // Assert
             Assert.Equal(expectedResponse, httpResponse.StatusCode);

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/SystemUserAgentDelegationController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/SystemUserAgentDelegationController.cs
@@ -31,15 +31,15 @@ namespace Altinn.AccessManagement.UI.Controllers
         /// Get all customers for the party
         /// </summary>
         /// <param name="partyId">Party user represents</param>
-        /// <param name="partyUuid">Party uuid user represents</param>
+        /// <param name="facilitatorId">Party uuid user represents</param>
         /// <param name="systemUserGuid">System user to get customers from</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>List of customer party</returns>
         [Authorize]
-        [HttpGet("{partyId}/{partyUuid}/{systemUserGuid}/customers")]
-        public async Task<ActionResult> GetSystemUserCustomers([FromRoute] int partyId, [FromRoute] Guid partyUuid, [FromRoute] Guid systemUserGuid, CancellationToken cancellationToken)
+        [HttpGet("{partyId}/{facilitatorId}/{systemUserGuid}/customers")]
+        public async Task<ActionResult> GetSystemUserCustomers([FromRoute] int partyId, [FromRoute] Guid facilitatorId, [FromRoute] Guid systemUserGuid, CancellationToken cancellationToken)
         {
-            List<AgentDelegationPartyFE> customers = await _systemUserAgentDelegationService.GetSystemUserCustomers(partyId, partyUuid, systemUserGuid, cancellationToken);
+            List<AgentDelegationPartyFE> customers = await _systemUserAgentDelegationService.GetSystemUserCustomers(partyId, facilitatorId, systemUserGuid, cancellationToken);
             return Ok(customers);
         }
 
@@ -63,13 +63,14 @@ namespace Altinn.AccessManagement.UI.Controllers
         /// Add a customer as a new agent delegation to this systemuser
         /// </summary>
         /// <param name="partyId">Party id user represents</param>
+        /// <param name="facilitatorId">Facilitator uuid, uuid of partyId</param>
         /// <param name="systemUserGuid">System user id to get</param>
         /// <param name="delegationRequest">Delegation request which contains partyUuid of party owning systemuser + customerId to add </param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns></returns>
         [Authorize]
-        [HttpPost("{partyId}/{systemUserGuid}/delegation/")]
-        public async Task<ActionResult> AddClient([FromRoute] int partyId, [FromRoute] Guid systemUserGuid, [FromBody] AgentDelegationRequest delegationRequest, CancellationToken cancellationToken)
+        [HttpPost("{partyId}/{facilitatorId}/{systemUserGuid}/delegation/")]
+        public async Task<ActionResult> AddClient([FromRoute] int partyId, [FromRoute] Guid facilitatorId, [FromRoute] Guid systemUserGuid, [FromBody] AgentDelegationRequest delegationRequest, CancellationToken cancellationToken)
         {
             Result<AgentDelegationFE> result = await _systemUserAgentDelegationService.AddClient(partyId, systemUserGuid, delegationRequest, cancellationToken);
 
@@ -85,15 +86,16 @@ namespace Altinn.AccessManagement.UI.Controllers
         /// Remove an agent delegation from this systemuser
         /// </summary>
         /// <param name="partyId">Party user represents</param>
+        /// <param name="facilitatorId">Facilitator uuid, uuid of partyId</param>
         /// <param name="systemUserGuid">System user id to get</param>
-        /// <param name="assignmentId">Assignment id to remove from system user</param>
+        /// <param name="delegationId">Delegation id to remove from system user</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns></returns>
         [Authorize]
-        [HttpDelete("{partyId}/{systemUserGuid}/delegation/{assignmentId}")]
-        public async Task<ActionResult> RemoveClient([FromRoute] int partyId, [FromRoute] Guid systemUserGuid, [FromRoute] Guid assignmentId, CancellationToken cancellationToken)
+        [HttpDelete("{partyId}/{facilitatorId}/{systemUserGuid}/delegation/{delegationId}")]
+        public async Task<ActionResult> RemoveClient([FromRoute] int partyId, [FromRoute] Guid facilitatorId, [FromRoute] Guid systemUserGuid, [FromRoute] Guid delegationId, CancellationToken cancellationToken)
         {
-            Result<bool> result = await _systemUserAgentDelegationService.RemoveClient(partyId, systemUserGuid, assignmentId, cancellationToken);
+            Result<bool> result = await _systemUserAgentDelegationService.RemoveClient(facilitatorId, delegationId, cancellationToken);
 
             if (result.IsProblem)
             {

--- a/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPageContent.tsx
+++ b/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPageContent.tsx
@@ -98,6 +98,7 @@ export const SystemUserAgentDelegationPageContent = ({
     };
     removeCustomer({
       partyId,
+      partyUuid,
       systemUserId: id ?? '',
       delegationId: toRemove.delegationId,
     })

--- a/src/rtk/features/systemUserApi.ts
+++ b/src/rtk/features/systemUserApi.ts
@@ -103,7 +103,7 @@ export const systemUserApi = createApi({
       { partyId: string; systemUserId: string; partyUuid: string; customerId: string }
     >({
       query: ({ partyId, systemUserId, partyUuid, customerId }) => ({
-        url: `systemuser/agentdelegation/${partyId}/${systemUserId}/delegation`,
+        url: `systemuser/agentdelegation/${partyId}/${partyUuid}/${systemUserId}/delegation`,
         method: 'POST',
         body: {
           customerId: customerId,
@@ -113,10 +113,10 @@ export const systemUserApi = createApi({
     }),
     removeCustomer: builder.mutation<
       void,
-      { partyId: string; systemUserId: string; delegationId: string }
+      { partyId: string; systemUserId: string; partyUuid: string; delegationId: string }
     >({
-      query: ({ partyId, systemUserId, delegationId }) => ({
-        url: `systemuser/agentdelegation/${partyId}/${systemUserId}/delegation/${delegationId}`,
+      query: ({ partyId, systemUserId, partyUuid, delegationId }) => ({
+        url: `systemuser/agentdelegation/${partyId}/${partyUuid}/${systemUserId}/delegation/${delegationId}`,
         method: 'DELETE',
       }),
     }),


### PR DESCRIPTION
## Description
- Unify BFF urls for agent delegation
- Use new url to remove delegation in backend
- Replace `assignmentId` with `delegationId`

## Related Issue(s)
- this PR

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved delegation management endpoints by streamlining identifier usage for assignment and removal operations, including the introduction of `facilitatorId` and `delegationId`.
  - Updated API route structures to ensure more consistent and robust handling of delegation actions, incorporating `partyUuid` in relevant endpoints.

- **Tests**
  - Revised testing scenarios to validate the updated delegation workflows, including adjustments to utilize new parameters and ensure reliable performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->