### PR TITLE
Refactor: look up partyUuid from partyId in systemuser

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/ClientInterfaces/IRegisterClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/ClientInterfaces/IRegisterClient.cs
@@ -19,6 +19,15 @@ namespace Altinn.AccessManagement.UI.Core.ClientInterfaces
                 Task<Party> GetPartyForOrganization(string organizationNumber);
 
                 /// <summary>
+                /// Looks up party information for an organization based on the partyId
+                /// </summary>
+                /// <param name="partyId">The partyId</param>
+                /// <returns>
+                /// Party information
+                /// </returns>
+                Task<Party> GetPartyByPartyId(int partyId);
+
+                /// <summary>
                 /// Looks up party information for a person based on the ssn
                 /// </summary>
                 /// <param name="ssn">The persons ssn</param>

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/ClientInterfaces/ISystemUserClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/ClientInterfaces/ISystemUserClient.cs
@@ -68,6 +68,6 @@ namespace Altinn.AccessManagement.UI.Core.ClientInterfaces
         /// <param name="facilitatorId">Id of facilitator owning systemuser</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Boolean whether delete was successful or not</returns>
-        Task<bool> DeleteAgentSystemUser(int partyId, Guid systemUserId, Guid facilitatorId, CancellationToken cancellationToken);
+        Task<Result<bool>> DeleteAgentSystemUser(int partyId, Guid systemUserId, Guid facilitatorId, CancellationToken cancellationToken);
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/SystemUser/Frontend/AgentDelegationRequestFE.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/SystemUser/Frontend/AgentDelegationRequestFE.cs
@@ -1,0 +1,13 @@
+namespace Altinn.AccessManagement.UI.Core.Models.SystemUser
+{
+    /// <summary>
+    /// Payload when adding a party to agent system user
+    /// </summary>
+    public class AgentDelegationRequestFE
+    {
+        /// <summary>
+        /// The party uuid to add
+        /// </summary>
+        public Guid CustomerId { get; set; }
+    }
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/SystemUser/Frontend/CustomerPartyFE.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/SystemUser/Frontend/CustomerPartyFE.cs
@@ -3,7 +3,7 @@ namespace Altinn.AccessManagement.UI.Core.Models.SystemUser.Frontend
     /// <summary>
     /// Specific SystemUser frontend model of PartyRecord
     /// </summary>
-    public class AgentDelegationPartyFE
+    public class CustomerPartyFE
     {
         /// <summary>
         /// Party UUID  

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/Interfaces/ISystemUserAgentDelegationService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/Interfaces/ISystemUserAgentDelegationService.cs
@@ -33,10 +33,10 @@ namespace Altinn.AccessManagement.UI.Core.Services.Interfaces
         /// </summary>
         /// <param name="partyId">The party id of the party owning system user to add customer to</param>
         /// <param name="systemUserGuid">The system user UUID to add customer to</param>
-        /// <param name="customerId">Customer to add to client</param>
+        /// <param name="delegationRequest">Payload to send to add client</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>AgentDelegationFE with assignment id and customer id</returns>
-        Task<Result<AgentDelegationFE>> AddClient(int partyId, Guid systemUserGuid, Guid customerId, CancellationToken cancellationToken);
+        Task<Result<AgentDelegationFE>> AddClient(int partyId, Guid systemUserGuid, AgentDelegationRequestFE delegationRequest, CancellationToken cancellationToken);
 
         /// <summary>
         /// Remove client from system user

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/Interfaces/ISystemUserAgentDelegationService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/Interfaces/ISystemUserAgentDelegationService.cs
@@ -33,10 +33,10 @@ namespace Altinn.AccessManagement.UI.Core.Services.Interfaces
         /// </summary>
         /// <param name="partyId">The party id of the party owning system user to add customer to</param>
         /// <param name="systemUserGuid">The system user UUID to add customer to</param>
-        /// <param name="delegationRequest">Payload to send to add client</param>
+        /// <param name="delegationRequestFe">Payload to send to add client</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>AgentDelegationFE with assignment id and customer id</returns>
-        Task<Result<AgentDelegationFE>> AddClient(int partyId, Guid systemUserGuid, AgentDelegationRequestFE delegationRequest, CancellationToken cancellationToken);
+        Task<Result<AgentDelegationFE>> AddClient(int partyId, Guid systemUserGuid, AgentDelegationRequestFE delegationRequestFe, CancellationToken cancellationToken);
 
         /// <summary>
         /// Remove client from system user

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/Interfaces/ISystemUserAgentDelegationService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/Interfaces/ISystemUserAgentDelegationService.cs
@@ -14,40 +14,37 @@ namespace Altinn.AccessManagement.UI.Core.Services.Interfaces
         /// Return all customers for given system user
         /// </summary>
         /// <param name="partyId">The party id of the party owning system user</param>
-        /// <param name="partyUuid">The party uuid of the party owning system user</param>
         /// <param name="systemUserGuid">The system user UUID to get customers from</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>List of all systemuser customers</returns>
-        Task<List<AgentDelegationPartyFE>> GetSystemUserCustomers(int partyId, Guid partyUuid, Guid systemUserGuid, CancellationToken cancellationToken);
+        Task<Result<List<CustomerPartyFE>>> GetSystemUserCustomers(int partyId, Guid systemUserGuid, CancellationToken cancellationToken);
 
         /// <summary>
         /// Return delegated customers for this system user
         /// </summary>
         /// <param name="partyId">The party UUID of the party owning system user to retrieve delegated customers from</param>
-        /// <param name="facilitatorId">Facilitator uuid, uuid of partyId</param>
         /// <param name="systemUserGuid">The system user UUID to retrieve delegated customers from</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>List of delegated customers for system user</returns>
-        Task<List<AgentDelegationFE>> GetSystemUserAgentDelegations(int partyId, Guid facilitatorId, Guid systemUserGuid, CancellationToken cancellationToken);
+        Task<Result<List<AgentDelegationFE>>> GetSystemUserAgentDelegations(int partyId, Guid systemUserGuid, CancellationToken cancellationToken);
 
         /// <summary>
         /// Add client to system user
         /// </summary>
         /// <param name="partyId">The party id of the party owning system user to add customer to</param>
         /// <param name="systemUserGuid">The system user UUID to add customer to</param>
-        /// <param name="delegationRequest">Payload to send to add client</param>
+        /// <param name="customerId">Customer to add to client</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>AgentDelegationFE with assignment id and customer id</returns>
-        Task<Result<AgentDelegationFE>> AddClient(int partyId, Guid systemUserGuid, AgentDelegationRequest delegationRequest, CancellationToken cancellationToken);
+        Task<Result<AgentDelegationFE>> AddClient(int partyId, Guid systemUserGuid, Guid customerId, CancellationToken cancellationToken);
 
         /// <summary>
         /// Remove client from system user
         /// </summary>
         /// <param name="partyId">The party id of the party owning system user to remove customer from</param>
-        /// <param name="facilitatorId">The system user UUID to remove customer from</param>
         /// <param name="delegationId">The delegation id to remove</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Boolean result of remove</returns>
-        Task<Result<bool>> RemoveClient(int partyId, Guid facilitatorId, Guid delegationId, CancellationToken cancellationToken);
+        Task<Result<bool>> RemoveClient(int partyId, Guid delegationId, CancellationToken cancellationToken);
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/Interfaces/ISystemUserService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/Interfaces/ISystemUserService.cs
@@ -54,7 +54,7 @@ namespace Altinn.AccessManagement.UI.Core.Services.Interfaces
         /// <param name="systemUserId">Id of system user to delete</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Boolean whether delete was successful or not</returns>
-        Task<bool> DeleteAgentSystemUser(int partyId, Guid systemUserId, CancellationToken cancellationToken);
+        Task<Result<bool>> DeleteAgentSystemUser(int partyId, Guid systemUserId, CancellationToken cancellationToken);
 
         /// <summary>
         /// Create a new system user

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/Interfaces/ISystemUserService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/Interfaces/ISystemUserService.cs
@@ -52,10 +52,9 @@ namespace Altinn.AccessManagement.UI.Core.Services.Interfaces
         /// </summary>
         /// <param name="partyId">The party Id of the party to retrieve</param>
         /// <param name="systemUserId">Id of system user to delete</param>
-        /// <param name="facilitatorId">Id of facilitator owning systemuser</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Boolean whether delete was successful or not</returns>
-        Task<bool> DeleteAgentSystemUser(int partyId, Guid systemUserId, Guid facilitatorId, CancellationToken cancellationToken);
+        Task<bool> DeleteAgentSystemUser(int partyId, Guid systemUserId, CancellationToken cancellationToken);
 
         /// <summary>
         /// Create a new system user

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/SystemUserAgentDelegationService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/SystemUserAgentDelegationService.cs
@@ -95,7 +95,7 @@ namespace Altinn.AccessManagement.UI.Core.Services
         }
 
         /// <inheritdoc />
-        public async Task<Result<AgentDelegationFE>> AddClient(int partyId, Guid systemUserGuid, Guid customerId, CancellationToken cancellationToken)
+        public async Task<Result<AgentDelegationFE>> AddClient(int partyId, Guid systemUserGuid, AgentDelegationRequestFE delegationRequestFe, CancellationToken cancellationToken)
         {
             Party party = await _registerClient.GetPartyByPartyId(partyId);
             if (party == null || party.PartyUuid == null)
@@ -105,7 +105,7 @@ namespace Altinn.AccessManagement.UI.Core.Services
 
             AgentDelegationRequest delegationRequest = new()
             {
-                CustomerId = customerId,
+                CustomerId = delegationRequestFe.CustomerId,
                 FacilitatorId = (Guid)party.PartyUuid
             };
 

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/SystemUserAgentDelegationService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/SystemUserAgentDelegationService.cs
@@ -6,6 +6,7 @@ using Altinn.AccessManagement.UI.Core.Models.SystemUser;
 using Altinn.AccessManagement.UI.Core.Models.SystemUser.Frontend;
 using Altinn.AccessManagement.UI.Core.Services.Interfaces;
 using Altinn.Authorization.ProblemDetails;
+using Altinn.Platform.Register.Models;
 
 namespace Altinn.AccessManagement.UI.Core.Services
 {
@@ -33,9 +34,15 @@ namespace Altinn.AccessManagement.UI.Core.Services
         }
         
         /// <inheritdoc /> 
-        public async Task<List<AgentDelegationPartyFE>> GetSystemUserCustomers(int partyId, Guid partyUuid, Guid systemUserGuid, CancellationToken cancellationToken)
+        public async Task<Result<List<CustomerPartyFE>>> GetSystemUserCustomers(int partyId, Guid systemUserGuid, CancellationToken cancellationToken)
         {
             // get access packages from systemuser
+            Party party = await _registerClient.GetPartyByPartyId(partyId);
+            if (party == null || party.PartyUuid == null)
+            {
+                return Problem.Reportee_Orgno_NotFound;
+            }
+
             SystemUser systemUser = await _systemUserClient.GetAgentSystemUser(partyId, systemUserGuid, cancellationToken);
             IEnumerable<string> accessPackageUrns = systemUser.AccessPackages.Select(x => x.Urn);
             CustomerRoleType customerType;
@@ -61,14 +68,20 @@ namespace Altinn.AccessManagement.UI.Core.Services
                 customerType = CustomerRoleType.None;
             }
 
-            CustomerList customers = await _registerClient.GetPartyCustomers(partyUuid, customerType, cancellationToken);
+            CustomerList customers = await _registerClient.GetPartyCustomers((Guid)party.PartyUuid, customerType, cancellationToken);
             return MapCustomerListToCustomerFE(customers);
         }
 
         /// <inheritdoc />
-        public async Task<List<AgentDelegationFE>> GetSystemUserAgentDelegations(int partyId, Guid facilitatorId, Guid systemUserGuid, CancellationToken cancellationToken)
+        public async Task<Result<List<AgentDelegationFE>>> GetSystemUserAgentDelegations(int partyId, Guid systemUserGuid, CancellationToken cancellationToken)
         {
-            List<AgentDelegation> delegations = await _systemUserAgentDelegationClient.GetSystemUserAgentDelegations(partyId, facilitatorId, systemUserGuid, cancellationToken);
+            Party party = await _registerClient.GetPartyByPartyId(partyId);
+            if (party == null || party.PartyUuid == null)
+            {
+                return Problem.Reportee_Orgno_NotFound;
+            }
+
+            List<AgentDelegation> delegations = await _systemUserAgentDelegationClient.GetSystemUserAgentDelegations(partyId, (Guid)party.PartyUuid, systemUserGuid, cancellationToken);
 
             return delegations.Select(delegation => 
             {
@@ -82,8 +95,20 @@ namespace Altinn.AccessManagement.UI.Core.Services
         }
 
         /// <inheritdoc />
-        public async Task<Result<AgentDelegationFE>> AddClient(int partyId, Guid systemUserGuid, AgentDelegationRequest delegationRequest, CancellationToken cancellationToken)
+        public async Task<Result<AgentDelegationFE>> AddClient(int partyId, Guid systemUserGuid, Guid customerId, CancellationToken cancellationToken)
         {
+            Party party = await _registerClient.GetPartyByPartyId(partyId);
+            if (party == null || party.PartyUuid == null)
+            {
+                return Problem.Reportee_Orgno_NotFound;
+            }
+
+            AgentDelegationRequest delegationRequest = new()
+            {
+                CustomerId = customerId,
+                FacilitatorId = (Guid)party.PartyUuid
+            };
+
             Result<List<AgentDelegation>> newAgentDelegations = await _systemUserAgentDelegationClient.AddClient(partyId, systemUserGuid, delegationRequest, cancellationToken);
             
             if (newAgentDelegations.IsProblem)
@@ -106,9 +131,15 @@ namespace Altinn.AccessManagement.UI.Core.Services
         }
 
         /// <inheritdoc />
-        public async Task<Result<bool>> RemoveClient(int partyId, Guid facilitatorId, Guid delegationId, CancellationToken cancellationToken)
+        public async Task<Result<bool>> RemoveClient(int partyId, Guid delegationId, CancellationToken cancellationToken)
         {
-            Result<bool> response = await _systemUserAgentDelegationClient.RemoveClient(partyId, facilitatorId, delegationId, cancellationToken);
+            Party party = await _registerClient.GetPartyByPartyId(partyId);
+            if (party == null || party.PartyUuid == null)
+            {
+                return Problem.Reportee_Orgno_NotFound;
+            }
+
+            Result<bool> response = await _systemUserAgentDelegationClient.RemoveClient(partyId, (Guid)party.PartyUuid, delegationId, cancellationToken);
             if (response.IsProblem)
             {
                 return new Result<bool>(response.Problem);
@@ -117,11 +148,11 @@ namespace Altinn.AccessManagement.UI.Core.Services
             return response.Value;
         }
 
-        private static List<AgentDelegationPartyFE> MapCustomerListToCustomerFE(CustomerList customers)
+        private static List<CustomerPartyFE> MapCustomerListToCustomerFE(CustomerList customers)
         {
             return customers.Data.Select(x => 
             {
-                return new AgentDelegationPartyFE()
+                return new CustomerPartyFE()
                 {
                     Id = x.PartyUuid,
                     Name = x.DisplayName,

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/SystemUserService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/SystemUserService.cs
@@ -102,9 +102,15 @@ namespace Altinn.AccessManagement.UI.Core.Services
         }
 
         /// <inheritdoc />
-        public async Task<bool> DeleteAgentSystemUser(int partyId, Guid systemUserId, Guid facilitatorId, CancellationToken cancellationToken)
+        public async Task<bool> DeleteAgentSystemUser(int partyId, Guid systemUserId, CancellationToken cancellationToken)
         {
-            return await _systemUserClient.DeleteAgentSystemUser(partyId, systemUserId, facilitatorId, cancellationToken);
+            Party party = await _registerClient.GetPartyByPartyId(partyId);
+            if (party == null || party.PartyUuid == null)
+            {
+                return false;
+            }
+
+            return await _systemUserClient.DeleteAgentSystemUser(partyId, systemUserId, (Guid)party.PartyUuid, cancellationToken);
         }
 
         /// <inheritdoc />

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/SystemUserService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/SystemUserService.cs
@@ -102,12 +102,12 @@ namespace Altinn.AccessManagement.UI.Core.Services
         }
 
         /// <inheritdoc />
-        public async Task<bool> DeleteAgentSystemUser(int partyId, Guid systemUserId, CancellationToken cancellationToken)
+        public async Task<Result<bool>> DeleteAgentSystemUser(int partyId, Guid systemUserId, CancellationToken cancellationToken)
         {
             Party party = await _registerClient.GetPartyByPartyId(partyId);
             if (party == null || party.PartyUuid == null)
             {
-                return false;
+                return Problem.Reportee_Orgno_NotFound;
             }
 
             return await _systemUserClient.DeleteAgentSystemUser(partyId, systemUserId, (Guid)party.PartyUuid, cancellationToken);

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/SystemUserService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/SystemUserService.cs
@@ -1,7 +1,6 @@
 using Altinn.AccessManagement.UI.Core.ClientInterfaces;
 using Altinn.AccessManagement.UI.Core.Constants;
 using Altinn.AccessManagement.UI.Core.Helpers;
-using Altinn.AccessManagement.UI.Core.Models.AccessManagement;
 using Altinn.AccessManagement.UI.Core.Models.SystemUser;
 using Altinn.AccessManagement.UI.Core.Models.SystemUser.Frontend;
 using Altinn.AccessManagement.UI.Core.Services.Interfaces;
@@ -14,7 +13,6 @@ namespace Altinn.AccessManagement.UI.Core.Services
     public class SystemUserService : ISystemUserService
     {
         private readonly ISystemUserClient _systemUserClient;
-        private readonly IAccessManagementClientV0 _accessManagementClientV0;
         private readonly ISystemRegisterClient _systemRegisterClient;
         private readonly IRegisterClient _registerClient;
         private readonly ResourceHelper _resourceHelper;
@@ -23,19 +21,16 @@ namespace Altinn.AccessManagement.UI.Core.Services
         /// Initializes a new instance of the <see cref="SystemUserService"/> class.
         /// </summary>
         /// <param name="systemUserClient">The system user client.</param>
-        /// <param name="accessManagementClient">The access management client.</param>
         /// <param name="systemRegisterClient">The system register client.</param>
         /// <param name="registerClient">The register client.</param>
         /// <param name="resourceHelper">Resources helper to enrich resources</param>
         public SystemUserService(
             ISystemUserClient systemUserClient,
-            IAccessManagementClientV0 accessManagementClient,
             ISystemRegisterClient systemRegisterClient,
             IRegisterClient registerClient,
             ResourceHelper resourceHelper)
         {
             _systemUserClient = systemUserClient;
-            _accessManagementClientV0 = accessManagementClient;
             _systemRegisterClient = systemRegisterClient;
             _registerClient = registerClient;
             _resourceHelper = resourceHelper;
@@ -50,12 +45,6 @@ namespace Altinn.AccessManagement.UI.Core.Services
         /// <inheritdoc />
         public async Task<Result<List<SystemUserFE>>> GetAllSystemUsersForParty(int partyId, string languageCode, CancellationToken cancellationToken)
         {
-            AuthorizedParty party = await _accessManagementClientV0.GetPartyFromReporteeListIfExists(partyId);
-            if (party is null)
-            {
-                return Problem.Reportee_Orgno_NotFound;
-            }
-            
             List<SystemUser> lista = await _systemUserClient.GetSystemUsersForParty(partyId, cancellationToken);
 
             return await MapToSystemUsersFE(lista, languageCode, false, cancellationToken);
@@ -77,12 +66,6 @@ namespace Altinn.AccessManagement.UI.Core.Services
         /// <inheritdoc />
         public async Task<Result<List<SystemUserFE>>> GetAgentSystemUsersForParty(int partyId, string languageCode, CancellationToken cancellationToken)
         {
-            AuthorizedParty party = await _accessManagementClientV0.GetPartyFromReporteeListIfExists(partyId);
-            if (party is null)
-            {
-                return Problem.Reportee_Orgno_NotFound;
-            }
-            
             List<SystemUser> lista = await _systemUserClient.GetAgentSystemUsersForParty(partyId, cancellationToken);
 
             return await MapToSystemUsersFE(lista, languageCode, false, cancellationToken);
@@ -116,12 +99,6 @@ namespace Altinn.AccessManagement.UI.Core.Services
         /// <inheritdoc />
         public async Task<Result<SystemUser>> CreateSystemUser(int partyId, NewSystemUserRequest newSystemUser, CancellationToken cancellationToken)
         {
-            AuthorizedParty party = await _accessManagementClientV0.GetPartyFromReporteeListIfExists(partyId);
-            if (party is null)
-            {
-                return Problem.Reportee_Orgno_NotFound;
-            }
-
             Result<SystemUser> createdSystemUser = await _systemUserClient.CreateNewSystemUser(partyId, newSystemUser, cancellationToken);
 
             return createdSystemUser;

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/RegisterClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/RegisterClient.cs
@@ -88,6 +88,33 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
         }
 
         /// <inheritdoc/>
+        public async Task<Party> GetPartyByPartyId(int partyId)
+        {
+            try
+            {
+                string endpointUrl = $"parties/{partyId}";
+                string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
+                var accessToken = await _accessTokenProvider.GetAccessToken();
+
+                HttpResponseMessage response = await _client.GetAsync(token, endpointUrl, accessToken);
+                string responseContent = await response.Content.ReadAsStringAsync();
+
+                if (response.StatusCode == HttpStatusCode.OK)
+                {
+                    return JsonSerializer.Deserialize<Party>(responseContent, _serializerOptions);
+                }
+
+                _logger.LogError("AccessManagement.UI // RegisterClient // GetPartyByPartyId // Unexpected HttpStatusCode: {StatusCode}\n {responseBody}", response.StatusCode, responseContent);
+                return null;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "AccessManagement.UI // RegisterClient // GetPartyByPartyId // Exception");
+                throw;
+            }
+        }
+
+        /// <inheritdoc/>
         public async Task<Party> GetPartyForPerson(string ssn)
         {
             string endpointUrl = $"parties/lookup";

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/SystemUserClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/SystemUserClient.cs
@@ -206,7 +206,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
         }
 
         /// <inheritdoc/>
-        public async Task<bool> DeleteAgentSystemUser(int partyId, Guid systemUserId, Guid facilitatorId, CancellationToken cancellationToken)
+        public async Task<Result<bool>> DeleteAgentSystemUser(int partyId, Guid systemUserId, Guid facilitatorId, CancellationToken cancellationToken)
         {
             try
             {
@@ -222,7 +222,8 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
                 }
 
                 _logger.LogError("AccessManagement.UI // SystemUserClient // DeleteAgentSystemUser // Unexpected HttpStatusCode: {StatusCode}\n {responseBody}", response.StatusCode, responseContent);
-                return false;
+                AltinnProblemDetails problemDetails = await response.Content.ReadFromJsonAsync<AltinnProblemDetails>(cancellationToken);
+                return ProblemMapper.MapToAuthUiError(problemDetails?.ErrorCode.ToString());
             }
             catch (Exception ex)
             {

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/RegisterClientMock.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/RegisterClientMock.cs
@@ -42,6 +42,21 @@ namespace Altinn.AccessManagement.UI.Mocks.Mocks
         }
 
         /// <inheritdoc/>
+        public Task<Party> GetPartyByPartyId(int partyId)
+        {
+            Party party = null;
+            string testDataPath = Path.Combine(Path.GetDirectoryName(new Uri(typeof(RegisterClientMock).Assembly.Location).LocalPath), "Data", "Register", "Parties", "parties.json");
+            if (File.Exists(testDataPath))
+            {
+                string content = File.ReadAllText(testDataPath);
+                List<Party> partyList = JsonSerializer.Deserialize<List<Party>>(content);
+                party = partyList?.FirstOrDefault(p => p.PartyId == partyId);
+            }
+
+            return Task.FromResult(party);
+        }
+
+        /// <inheritdoc/>
         public Task<List<Party>> GetPartyList(List<Guid> uuidList)
         {
             string testDataPath = Path.Combine(Path.GetDirectoryName(new Uri(typeof(RegisterClientMock).Assembly.Location).LocalPath), "Data", "Register", "Parties", "parties.json");

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/SystemUserClientMock.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/SystemUserClientMock.cs
@@ -84,15 +84,15 @@ namespace Altinn.AccessManagement.UI.Mocks.Mocks
         }
 
         /// <inheritdoc />
-        public Task<bool> DeleteAgentSystemUser(int partyId, Guid systemUserId, Guid facilitatorId, CancellationToken cancellationToken)
+        public Task<Result<bool>> DeleteAgentSystemUser(int partyId, Guid systemUserId, Guid facilitatorId, CancellationToken cancellationToken)
         {
             List<SystemUser> agentSystemUsers = Util.GetMockData<List<SystemUser>>($"{dataFolder}/SystemUser/agentSystemUsers.json");
             SystemUser systemUser = agentSystemUsers.Find(s => s.Id == systemUserId.ToString() && s.PartyId == partyId.ToString());
             if (systemUser is null)
             {
-                return Task.FromResult(false);
+                return Task.FromResult(new Result<bool>(TestErrors.SystemNotFound));
             }
-            return Task.FromResult(true);
+            return Task.FromResult(new Result<bool>(true));
         }
 
         internal static class TestErrors

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/SystemUserAgentDelegationControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/SystemUserAgentDelegationControllerTest.cs
@@ -47,11 +47,11 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             string partyId = "51329012";
             string systemUserId = _regnskapsforerSystemUserId;
             string path = Path.Combine(_expectedDataPath, "SystemUser", "regnskapsforerCustomers.json");
-            List<AgentDelegationPartyFE> expectedResponse = Util.GetMockData<List<AgentDelegationPartyFE>>(path);
+            List<CustomerPartyFE> expectedResponse = Util.GetMockData<List<CustomerPartyFE>>(path);
 
             // Act
             HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{partyUuid}/{systemUserId}/customers");
-            List<AgentDelegationPartyFE> actualResponse = await httpResponse.Content.ReadFromJsonAsync<List<AgentDelegationPartyFE>>();
+            List<CustomerPartyFE> actualResponse = await httpResponse.Content.ReadFromJsonAsync<List<CustomerPartyFE>>();
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, httpResponse.StatusCode);
@@ -70,11 +70,11 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             string partyId = "51329012";
             string systemUserId = _revisorSystemUserId;
             string path = Path.Combine(_expectedDataPath, "SystemUser", "revisorCustomers.json");
-            List<AgentDelegationPartyFE> expectedResponse = Util.GetMockData<List<AgentDelegationPartyFE>>(path);
+            List<CustomerPartyFE> expectedResponse = Util.GetMockData<List<CustomerPartyFE>>(path);
 
             // Act
             HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{partyUuid}/{systemUserId}/customers");
-            List<AgentDelegationPartyFE> actualResponse = await httpResponse.Content.ReadFromJsonAsync<List<AgentDelegationPartyFE>>();
+            List<CustomerPartyFE> actualResponse = await httpResponse.Content.ReadFromJsonAsync<List<CustomerPartyFE>>();
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, httpResponse.StatusCode);
@@ -93,11 +93,11 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             string partyId = "51329012";
             string systemUserId = _forretningsforerSystemUserId;
             string path = Path.Combine(_expectedDataPath, "SystemUser", "forretningsforerCustomers.json");
-            List<AgentDelegationPartyFE> expectedResponse = Util.GetMockData<List<AgentDelegationPartyFE>>(path);
+            List<CustomerPartyFE> expectedResponse = Util.GetMockData<List<CustomerPartyFE>>(path);
 
             // Act
             HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{partyUuid}/{systemUserId}/customers");
-            List<AgentDelegationPartyFE> actualResponse = await httpResponse.Content.ReadFromJsonAsync<List<AgentDelegationPartyFE>>();
+            List<CustomerPartyFE> actualResponse = await httpResponse.Content.ReadFromJsonAsync<List<CustomerPartyFE>>();
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, httpResponse.StatusCode);

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/SystemUserAgentDelegationControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/SystemUserAgentDelegationControllerTest.cs
@@ -102,6 +102,25 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         }
 
         /// <summary>
+        ///     Test case: GetForretningsforerCustomers checks that customers are returned
+        ///     Expected: GetForretningsforerCustomers returns customers
+        /// </summary>
+        [Fact]
+        public async Task GetForretningsforerCustomers_WrongPartyId_ReturnsCustomers()
+        {
+            // Arrange
+            string partyId = "411111111";
+            string systemUserId = _forretningsforerSystemUserId;
+            HttpStatusCode expectedResponse = HttpStatusCode.BadRequest;
+
+            // Act
+            HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/customers");
+
+            // Assert
+            Assert.Equal(expectedResponse, httpResponse.StatusCode);
+        }
+
+        /// <summary>
         ///     Test case: GetRegnskapsforerAgentDelegation checks that delegated regnskapsforer customers are returned
         ///     Expected: GetRegnskapsforerAgentDelegation returns delegations
         /// </summary>
@@ -165,6 +184,25 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             // Assert
             Assert.Equal(HttpStatusCode.OK, httpResponse.StatusCode);
             AssertionUtil.AssertCollections(expectedResponse, actualResponse, AssertionUtil.AssertEqual);
+        }
+
+        /// <summary>
+        ///     Test case: GetForretningsforerAgentDelegation checks that delegated forretningsforer customers are returned
+        ///     Expected: GetForretningsforerAgentDelegation returns delegations
+        /// </summary>
+        [Fact]
+        public async Task GetForretningsforerAgentDelegation_WrongPartyId_ReturnsBadRequest()
+        {
+            // Arrange
+            string partyId = "411111111";
+            string systemUserId = _forretningsforerSystemUserId;
+            HttpStatusCode expectedResponse = HttpStatusCode.BadRequest;
+
+            // Act
+            HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/delegation");
+
+            // Assert
+            Assert.Equal(expectedResponse, httpResponse.StatusCode);
         }
 
         /// <summary>
@@ -264,6 +302,34 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         }
 
         /// <summary>
+        ///     Test case: PostRegnskapsforerAgentDelegation checks error handling for invalid delegations
+        ///     Expected: PostRegnskapsforerAgentDelegation returns NotFound error
+        /// </summary>
+        [Fact]
+        public async Task PostRegnskapsforerAgentDelegation_WrongPartyId_ReturnBadRequest()
+        {
+            // Arrange
+            string partyId = "411111111";
+            string systemUserId = _regnskapsforerSystemUserId;
+            string customerId = "82cc64c5-60ff-4184-8c07-964c3a1e6fc7";
+            
+            AgentDelegationRequestFE dto = new AgentDelegationRequestFE
+            {
+                CustomerId = Guid.Parse(customerId),
+            };
+            string jsonDto = JsonSerializer.Serialize(dto);
+            HttpContent content = new StringContent(jsonDto, Encoding.UTF8, "application/json");
+
+            HttpStatusCode expectedResponse = HttpStatusCode.BadRequest;
+
+            // Act
+            HttpResponseMessage httpResponse = await _client.PostAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/delegation", content);
+
+            // Assert
+            Assert.Equal(expectedResponse, httpResponse.StatusCode);
+        }
+
+        /// <summary>
         ///     Test case: DeleteRegnskapsforerAgentDelegation checks that delegation is removed
         ///     Expected: DeleteRegnskapsforerAgentDelegation returns true
         /// </summary>
@@ -299,6 +365,27 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             string delegationId = "60f1ade9-ed48-4083-a369-178d45d6ffd1";
             
             HttpStatusCode expectedResponse = HttpStatusCode.NotFound;
+
+            // Act
+            HttpResponseMessage httpResponse = await _client.DeleteAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/delegation/{delegationId}");
+
+            // Assert
+            Assert.Equal(expectedResponse, httpResponse.StatusCode);
+        }
+
+        /// <summary>
+        ///     Test case: DeleteRegnskapsforerAgentDelegation checks error handling for non-existent delegations
+        ///     Expected: DeleteRegnskapsforerAgentDelegation returns NotFound error
+        /// </summary>
+        [Fact]
+        public async Task DeleteRegnskapsforerAgentDelegation_WrongPartyId_ReturnsBadRequest()
+        {
+            // Arrange
+            string partyId = "41111111";
+            string systemUserId = _regnskapsforerSystemUserId;
+            string delegationId = "7da509f3-cff5-4253-946e-0336ae0bc48f";
+            
+            HttpStatusCode expectedResponse = HttpStatusCode.BadRequest;
 
             // Act
             HttpResponseMessage httpResponse = await _client.DeleteAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/delegation/{delegationId}");

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/SystemUserAgentDelegationControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/SystemUserAgentDelegationControllerTest.cs
@@ -106,7 +106,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         ///     Expected: GetForretningsforerCustomers returns customers
         /// </summary>
         [Fact]
-        public async Task GetForretningsforerCustomers_WrongPartyId_ReturnsCustomers()
+        public async Task GetForretningsforerCustomers_WrongPartyId_ReturnsBadRequest()
         {
             // Arrange
             string partyId = "411111111";
@@ -303,7 +303,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
 
         /// <summary>
         ///     Test case: PostRegnskapsforerAgentDelegation checks error handling for invalid delegations
-        ///     Expected: PostRegnskapsforerAgentDelegation returns NotFound error
+        ///     Expected: PostRegnskapsforerAgentDelegation returns BadRequest error
         /// </summary>
         [Fact]
         public async Task PostRegnskapsforerAgentDelegation_WrongPartyId_ReturnBadRequest()
@@ -375,7 +375,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
 
         /// <summary>
         ///     Test case: DeleteRegnskapsforerAgentDelegation checks error handling for non-existent delegations
-        ///     Expected: DeleteRegnskapsforerAgentDelegation returns NotFound error
+        ///     Expected: DeleteRegnskapsforerAgentDelegation returns BadRequest error
         /// </summary>
         [Fact]
         public async Task DeleteRegnskapsforerAgentDelegation_WrongPartyId_ReturnsBadRequest()

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/SystemUserAgentDelegationControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/SystemUserAgentDelegationControllerTest.cs
@@ -43,14 +43,13 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         public async Task GetRegnskapsforerCustomers_ReturnsCustomers()
         {
             // Arrange
-            string partyUuid = "cd35779b-b174-4ecc-bbef-ece13611be7f";
             string partyId = "51329012";
             string systemUserId = _regnskapsforerSystemUserId;
             string path = Path.Combine(_expectedDataPath, "SystemUser", "regnskapsforerCustomers.json");
             List<CustomerPartyFE> expectedResponse = Util.GetMockData<List<CustomerPartyFE>>(path);
 
             // Act
-            HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{partyUuid}/{systemUserId}/customers");
+            HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/customers");
             List<CustomerPartyFE> actualResponse = await httpResponse.Content.ReadFromJsonAsync<List<CustomerPartyFE>>();
 
             // Assert
@@ -66,14 +65,13 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         public async Task GetRevisorCustomers_ReturnsCustomers()
         {
             // Arrange
-            string partyUuid = "cd35779b-b174-4ecc-bbef-ece13611be7f";
             string partyId = "51329012";
             string systemUserId = _revisorSystemUserId;
             string path = Path.Combine(_expectedDataPath, "SystemUser", "revisorCustomers.json");
             List<CustomerPartyFE> expectedResponse = Util.GetMockData<List<CustomerPartyFE>>(path);
 
             // Act
-            HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{partyUuid}/{systemUserId}/customers");
+            HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/customers");
             List<CustomerPartyFE> actualResponse = await httpResponse.Content.ReadFromJsonAsync<List<CustomerPartyFE>>();
 
             // Assert
@@ -89,14 +87,13 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         public async Task GetForretningsforerCustomers_ReturnsCustomers()
         {
             // Arrange
-            string partyUuid = "cd35779b-b174-4ecc-bbef-ece13611be7f";
             string partyId = "51329012";
             string systemUserId = _forretningsforerSystemUserId;
             string path = Path.Combine(_expectedDataPath, "SystemUser", "forretningsforerCustomers.json");
             List<CustomerPartyFE> expectedResponse = Util.GetMockData<List<CustomerPartyFE>>(path);
 
             // Act
-            HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{partyUuid}/{systemUserId}/customers");
+            HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/customers");
             List<CustomerPartyFE> actualResponse = await httpResponse.Content.ReadFromJsonAsync<List<CustomerPartyFE>>();
 
             // Assert
@@ -113,13 +110,12 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         {
             // Arrange
             string partyId = "51329012";
-            string partyUuid = "cd35779b-b174-4ecc-bbef-ece13611be7f";
             string systemUserId = _regnskapsforerSystemUserId;
             string path = Path.Combine(_expectedDataPath, "SystemUser", "regnskapsforerAgentDelegations.json");
             List<AgentDelegationFE> expectedResponse = Util.GetMockData<List<AgentDelegationFE>>(path);
 
             // Act
-            HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{partyUuid}/{systemUserId}/delegation");
+            HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/delegation");
             List<AgentDelegationFE> actualResponse = await httpResponse.Content.ReadFromJsonAsync<List<AgentDelegationFE>>();
 
             // Assert
@@ -136,13 +132,12 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         {
             // Arrange
             string partyId = "51329012";
-            string partyUuid = "cd35779b-b174-4ecc-bbef-ece13611be7f";
             string systemUserId = _revisorSystemUserId;
             string path = Path.Combine(_expectedDataPath, "SystemUser", "revisorAgentDelegations.json");
             List<AgentDelegationFE> expectedResponse = Util.GetMockData<List<AgentDelegationFE>>(path);
 
             // Act
-            HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{partyUuid}/{systemUserId}/delegation");
+            HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/delegation");
             List<AgentDelegationFE> actualResponse = await httpResponse.Content.ReadFromJsonAsync<List<AgentDelegationFE>>();
 
             // Assert
@@ -159,13 +154,12 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         {
             // Arrange
             string partyId = "51329012";
-            string partyUuid = "cd35779b-b174-4ecc-bbef-ece13611be7f";
             string systemUserId = _forretningsforerSystemUserId;
             string path = Path.Combine(_expectedDataPath, "SystemUser", "forretningsforerAgentDelegations.json");
             List<AgentDelegationFE> expectedResponse = Util.GetMockData<List<AgentDelegationFE>>(path);
 
             // Act
-            HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{partyUuid}/{systemUserId}/delegation");
+            HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/delegation");
             List<AgentDelegationFE> actualResponse = await httpResponse.Content.ReadFromJsonAsync<List<AgentDelegationFE>>();
 
             // Assert
@@ -182,14 +176,12 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         {
             // Arrange
             string partyId = "51329012";
-            string partyUuid = "cd35779b-b174-4ecc-bbef-ece13611be7f";
             string systemUserId = _regnskapsforerSystemUserId;
             string customerId = "6b0574ae-f569-4c0d-a8d4-8ad56f427890";
             
-            AgentDelegationRequest dto = new AgentDelegationRequest
+            AgentDelegationRequestFE dto = new AgentDelegationRequestFE
             {
-                CustomerId = Guid.Parse(customerId),
-                FacilitatorId = Guid.Parse(partyUuid)
+                CustomerId = Guid.Parse(customerId)
             };
             string jsonDto = JsonSerializer.Serialize(dto);
             HttpContent content = new StringContent(jsonDto, Encoding.UTF8, "application/json");
@@ -201,7 +193,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             };
 
             // Act
-            HttpResponseMessage httpResponse = await _client.PostAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{partyUuid}/{systemUserId}/delegation", content);
+            HttpResponseMessage httpResponse = await _client.PostAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/delegation", content);
             AgentDelegationFE actualResponse = await httpResponse.Content.ReadFromJsonAsync<AgentDelegationFE>();
 
             // Assert
@@ -218,14 +210,12 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         {
             // Arrange
             string partyId = "51329012";
-            string partyUuid = "cd35779b-b174-4ecc-bbef-ece13611be7f";
             string systemUserId = _revisorSystemUserId;
             string customerId = "cd35779b-b174-4ecc-bbef-ece13611be7f";
             
-            AgentDelegationRequest dto = new AgentDelegationRequest
+            AgentDelegationRequestFE dto = new AgentDelegationRequestFE
             {
-                CustomerId = Guid.Parse(customerId),
-                FacilitatorId = Guid.Parse(partyUuid)
+                CustomerId = Guid.Parse(customerId)
             };
             string jsonDto = JsonSerializer.Serialize(dto);
             HttpContent content = new StringContent(jsonDto, Encoding.UTF8, "application/json");
@@ -237,7 +227,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             };
 
             // Act
-            HttpResponseMessage httpResponse = await _client.PostAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{partyUuid}/{systemUserId}/delegation", content);
+            HttpResponseMessage httpResponse = await _client.PostAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/delegation", content);
             AgentDelegationFE actualResponse = await httpResponse.Content.ReadFromJsonAsync<AgentDelegationFE>();
 
             // Assert
@@ -254,14 +244,12 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         {
             // Arrange
             string partyId = "51329012";
-            string partyUuid = "cd35779b-b174-4ecc-bbef-ece13611be7f";
             string systemUserId = _regnskapsforerSystemUserId;
             string customerId = "82cc64c5-60ff-4184-8c07-964c3a1e6fc7";
             
-            AgentDelegationRequest dto = new AgentDelegationRequest
+            AgentDelegationRequestFE dto = new AgentDelegationRequestFE
             {
                 CustomerId = Guid.Parse(customerId),
-                FacilitatorId = Guid.Parse(partyUuid)
             };
             string jsonDto = JsonSerializer.Serialize(dto);
             HttpContent content = new StringContent(jsonDto, Encoding.UTF8, "application/json");
@@ -269,7 +257,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             HttpStatusCode expectedResponse = HttpStatusCode.NotFound;
 
             // Act
-            HttpResponseMessage httpResponse = await _client.PostAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{partyUuid}/{systemUserId}/delegation", content);
+            HttpResponseMessage httpResponse = await _client.PostAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/delegation", content);
 
             // Assert
             Assert.Equal(expectedResponse, httpResponse.StatusCode);
@@ -284,14 +272,13 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         {
             // Arrange
             string partyId = "51329012";
-            string partyUuid = "cd35779b-b174-4ecc-bbef-ece13611be7f";
             string systemUserId = _regnskapsforerSystemUserId;
             string delegationId = "7da509f3-cff5-4253-946e-0336ae0bc48f";
             
             bool expectedResponse = true;
 
             // Act
-            HttpResponseMessage httpResponse = await _client.DeleteAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{partyUuid}/{systemUserId}/delegation/{delegationId}");
+            HttpResponseMessage httpResponse = await _client.DeleteAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/delegation/{delegationId}");
             bool actualResponse = await httpResponse.Content.ReadFromJsonAsync<bool>();
 
             // Assert
@@ -308,14 +295,13 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         {
             // Arrange
             string partyId = "51329012";
-            string partyUuid = "cd35779b-b174-4ecc-bbef-ece13611be7f";
             string systemUserId = _regnskapsforerSystemUserId;
             string delegationId = "60f1ade9-ed48-4083-a369-178d45d6ffd1";
             
             HttpStatusCode expectedResponse = HttpStatusCode.NotFound;
 
             // Act
-            HttpResponseMessage httpResponse = await _client.DeleteAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{partyUuid}/{systemUserId}/delegation/{delegationId}");
+            HttpResponseMessage httpResponse = await _client.DeleteAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/delegation/{delegationId}");
 
             // Assert
             Assert.Equal(expectedResponse, httpResponse.StatusCode);

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/SystemUserControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/SystemUserControllerTest.cs
@@ -260,12 +260,11 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         {
             // Arrange
             int partyId = 51329012;
-            string facilitatorId = "cd35779b-b174-4ecc-bbef-ece13611be7f";
             string systemUserId = "61844188-3789-4b84-9314-2be1fdbc6633";
             HttpStatusCode expectedResponse = HttpStatusCode.Accepted;
 
             // Act
-            HttpResponseMessage httpResponse = await _client.DeleteAsync($"accessmanagement/api/v1/systemuser/agent/{partyId}/{systemUserId}?facilitatorId={facilitatorId}");
+            HttpResponseMessage httpResponse = await _client.DeleteAsync($"accessmanagement/api/v1/systemuser/agent/{partyId}/{systemUserId}");
 
             // Assert
             Assert.Equal(expectedResponse, httpResponse.StatusCode);
@@ -280,12 +279,30 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         {
             // Arrange
             int partyId = 51329012;
-            string facilitatorId = "cd35779b-b174-4ecc-bbef-ece13611be7f";
             string systemUserId = "e60073ad-c661-4ca0-b74c-40238ad333e9";
             HttpStatusCode expectedResponse = HttpStatusCode.NotFound;
 
             // Act
-            HttpResponseMessage httpResponse = await _client.DeleteAsync($"accessmanagement/api/v1/systemuser/agent/{partyId}/{systemUserId}?facilitatorId={facilitatorId}");
+            HttpResponseMessage httpResponse = await _client.DeleteAsync($"accessmanagement/api/v1/systemuser/agent/{partyId}/{systemUserId}");
+
+            // Assert
+            Assert.Equal(expectedResponse, httpResponse.StatusCode);
+        }
+
+        /// <summary>
+        ///     Test case: DeleteAgentSystemUser checks that agent system user with given id for given party is not deleted when it is not found
+        ///     Expected: DeleteAgentSystemUser returns not found
+        /// </summary>
+        [Fact]
+        public async Task DeleteAgentSystemUser_WrongPartyId_ReturnsNotFound()
+        {
+            // Arrange
+            int partyId = 411111111;
+            string systemUserId = "e60073ad-c661-4ca0-b74c-40238ad333e9";
+            HttpStatusCode expectedResponse = HttpStatusCode.NotFound;
+
+            // Act
+            HttpResponseMessage httpResponse = await _client.DeleteAsync($"accessmanagement/api/v1/systemuser/agent/{partyId}/{systemUserId}");
 
             // Assert
             Assert.Equal(expectedResponse, httpResponse.StatusCode);

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/SystemUserControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/SystemUserControllerTest.cs
@@ -291,15 +291,15 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
 
         /// <summary>
         ///     Test case: DeleteAgentSystemUser checks that agent system user with given id for given party is not deleted when it is not found
-        ///     Expected: DeleteAgentSystemUser returns not found
+        ///     Expected: DeleteAgentSystemUser returns bad requst
         /// </summary>
         [Fact]
-        public async Task DeleteAgentSystemUser_WrongPartyId_ReturnsNotFound()
+        public async Task DeleteAgentSystemUser_WrongPartyId_ReturnsBadRequest()
         {
             // Arrange
             int partyId = 411111111;
             string systemUserId = "e60073ad-c661-4ca0-b74c-40238ad333e9";
-            HttpStatusCode expectedResponse = HttpStatusCode.NotFound;
+            HttpStatusCode expectedResponse = HttpStatusCode.BadRequest;
 
             // Act
             HttpResponseMessage httpResponse = await _client.DeleteAsync($"accessmanagement/api/v1/systemuser/agent/{partyId}/{systemUserId}");

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Utils/AssertionUtil.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Utils/AssertionUtil.cs
@@ -536,7 +536,7 @@ namespace Altinn.AccessManagement.UI.Tests.Utils
             Assert.Equal(expected.PackageId, actual.PackageId);
         }
 
-        public static void AssertEqual(AgentDelegationPartyFE expected, AgentDelegationPartyFE actual)
+        public static void AssertEqual(CustomerPartyFE expected, CustomerPartyFE actual)
         {
             Assert.NotNull(actual);
             Assert.NotNull(expected);

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/SystemUserAgentDelegationController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/SystemUserAgentDelegationController.cs
@@ -1,5 +1,3 @@
-using Altinn.AccessManagement.UI.Core.Enums;
-using Altinn.AccessManagement.UI.Core.Models.SystemUser;
 using Altinn.AccessManagement.UI.Core.Models.SystemUser.Frontend;
 using Altinn.AccessManagement.UI.Core.Services.Interfaces;
 using Altinn.AccessManagement.UI.Filters;
@@ -31,48 +29,55 @@ namespace Altinn.AccessManagement.UI.Controllers
         /// Get all customers for the party
         /// </summary>
         /// <param name="partyId">Party user represents</param>
-        /// <param name="facilitatorId">Party uuid user represents</param>
         /// <param name="systemUserGuid">System user to get customers from</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>List of customer party</returns>
         [Authorize]
-        [HttpGet("{partyId}/{facilitatorId}/{systemUserGuid}/customers")]
-        public async Task<ActionResult> GetSystemUserCustomers([FromRoute] int partyId, [FromRoute] Guid facilitatorId, [FromRoute] Guid systemUserGuid, CancellationToken cancellationToken)
+        [HttpGet("{partyId}/{systemUserGuid}/customers")]
+        public async Task<ActionResult> GetSystemUserCustomers([FromRoute] int partyId,  [FromRoute] Guid systemUserGuid, CancellationToken cancellationToken)
         {
-            List<AgentDelegationPartyFE> customers = await _systemUserAgentDelegationService.GetSystemUserCustomers(partyId, facilitatorId, systemUserGuid, cancellationToken);
-            return Ok(customers);
+            Result<List<CustomerPartyFE>> result = await _systemUserAgentDelegationService.GetSystemUserCustomers(partyId, systemUserGuid, cancellationToken);
+            if (result.IsProblem)
+            {
+                return result.Problem.ToActionResult();
+            }
+            
+            return Ok(result.Value);
         }
 
         /// <summary>
         /// Get agent delegations for this system user
         /// </summary>
         /// <param name="partyId">Party user represents</param>
-        /// <param name="facilitatorId">Facilitator uuid, uuid of partyId</param>
         /// <param name="systemUserGuid">System user id to get</param> 
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns></returns>
         [Authorize]
-        [HttpGet("{partyId}/{facilitatorId}/{systemUserGuid}/delegation")]
-        public async Task<ActionResult> GetSystemUserAgentDelegations([FromRoute] int partyId, [FromRoute] Guid facilitatorId, [FromRoute] Guid systemUserGuid, CancellationToken cancellationToken)
+        [HttpGet("{partyId}/{systemUserGuid}/delegation")]
+        public async Task<ActionResult> GetSystemUserAgentDelegations([FromRoute] int partyId, [FromRoute] Guid systemUserGuid, CancellationToken cancellationToken)
         {
-            List<AgentDelegationFE> delegations = await _systemUserAgentDelegationService.GetSystemUserAgentDelegations(partyId, facilitatorId, systemUserGuid, cancellationToken);
-            return Ok(delegations);
+            Result<List<AgentDelegationFE>> result = await _systemUserAgentDelegationService.GetSystemUserAgentDelegations(partyId, systemUserGuid, cancellationToken);
+            if (result.IsProblem)
+            {
+                return result.Problem.ToActionResult();
+            }
+            
+            return Ok(result.Value);
         }
 
         /// <summary>
         /// Add a customer as a new agent delegation to this systemuser
         /// </summary>
         /// <param name="partyId">Party id user represents</param>
-        /// <param name="facilitatorId">Facilitator uuid, uuid of partyId</param>
         /// <param name="systemUserGuid">System user id to get</param>
-        /// <param name="delegationRequest">Delegation request which contains partyUuid of party owning systemuser + customerId to add </param>
+        /// <param name="customerId">CustomerId to add to systemuser</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns></returns>
         [Authorize]
-        [HttpPost("{partyId}/{facilitatorId}/{systemUserGuid}/delegation/")]
-        public async Task<ActionResult> AddClient([FromRoute] int partyId, [FromRoute] Guid facilitatorId, [FromRoute] Guid systemUserGuid, [FromBody] AgentDelegationRequest delegationRequest, CancellationToken cancellationToken)
+        [HttpPost("{partyId}/{systemUserGuid}/delegation/{customerId}")]
+        public async Task<ActionResult> AddClient([FromRoute] int partyId, [FromRoute] Guid systemUserGuid, [FromRoute] Guid customerId, CancellationToken cancellationToken)
         {
-            Result<AgentDelegationFE> result = await _systemUserAgentDelegationService.AddClient(partyId, systemUserGuid, delegationRequest, cancellationToken);
+            Result<AgentDelegationFE> result = await _systemUserAgentDelegationService.AddClient(partyId, systemUserGuid, customerId, cancellationToken);
 
             if (result.IsProblem)
             {
@@ -86,16 +91,15 @@ namespace Altinn.AccessManagement.UI.Controllers
         /// Remove an agent delegation from this systemuser
         /// </summary>
         /// <param name="partyId">Party user represents</param>
-        /// <param name="facilitatorId">Facilitator uuid, uuid of partyId</param>
         /// <param name="systemUserGuid">System user id to get</param>
         /// <param name="delegationId">Delegation id to remove from system user</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns></returns>
         [Authorize]
-        [HttpDelete("{partyId}/{facilitatorId}/{systemUserGuid}/delegation/{delegationId}")]
-        public async Task<ActionResult> RemoveClient([FromRoute] int partyId, [FromRoute] Guid facilitatorId, [FromRoute] Guid systemUserGuid, [FromRoute] Guid delegationId, CancellationToken cancellationToken)
+        [HttpDelete("{partyId}/{systemUserGuid}/delegation/{delegationId}")]
+        public async Task<ActionResult> RemoveClient([FromRoute] int partyId, [FromRoute] Guid systemUserGuid, [FromRoute] Guid delegationId, CancellationToken cancellationToken)
         {
-            Result<bool> result = await _systemUserAgentDelegationService.RemoveClient(partyId, facilitatorId, delegationId, cancellationToken);
+            Result<bool> result = await _systemUserAgentDelegationService.RemoveClient(partyId, delegationId, cancellationToken);
 
             if (result.IsProblem)
             {

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/SystemUserAgentDelegationController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/SystemUserAgentDelegationController.cs
@@ -1,3 +1,4 @@
+using Altinn.AccessManagement.UI.Core.Models.SystemUser;
 using Altinn.AccessManagement.UI.Core.Models.SystemUser.Frontend;
 using Altinn.AccessManagement.UI.Core.Services.Interfaces;
 using Altinn.AccessManagement.UI.Filters;
@@ -70,14 +71,14 @@ namespace Altinn.AccessManagement.UI.Controllers
         /// </summary>
         /// <param name="partyId">Party id user represents</param>
         /// <param name="systemUserGuid">System user id to get</param>
-        /// <param name="customerId">CustomerId to add to systemuser</param>
+        /// <param name="delegationRequest">Payload to send to add client</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns></returns>
         [Authorize]
-        [HttpPost("{partyId}/{systemUserGuid}/delegation/{customerId}")]
-        public async Task<ActionResult> AddClient([FromRoute] int partyId, [FromRoute] Guid systemUserGuid, [FromRoute] Guid customerId, CancellationToken cancellationToken)
+        [HttpPost("{partyId}/{systemUserGuid}/delegation")]
+        public async Task<ActionResult> AddClient([FromRoute] int partyId, [FromRoute] Guid systemUserGuid, [FromBody] AgentDelegationRequestFE delegationRequest, CancellationToken cancellationToken)
         {
-            Result<AgentDelegationFE> result = await _systemUserAgentDelegationService.AddClient(partyId, systemUserGuid, customerId, cancellationToken);
+            Result<AgentDelegationFE> result = await _systemUserAgentDelegationService.AddClient(partyId, systemUserGuid, delegationRequest, cancellationToken);
 
             if (result.IsProblem)
             {

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/SystemUserAgentDelegationController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/SystemUserAgentDelegationController.cs
@@ -71,14 +71,14 @@ namespace Altinn.AccessManagement.UI.Controllers
         /// </summary>
         /// <param name="partyId">Party id user represents</param>
         /// <param name="systemUserGuid">System user id to get</param>
-        /// <param name="delegationRequest">Payload to send to add client</param>
+        /// <param name="delegationRequestFe">Payload to send to add client</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns></returns>
         [Authorize]
         [HttpPost("{partyId}/{systemUserGuid}/delegation")]
-        public async Task<ActionResult> AddClient([FromRoute] int partyId, [FromRoute] Guid systemUserGuid, [FromBody] AgentDelegationRequestFE delegationRequest, CancellationToken cancellationToken)
+        public async Task<ActionResult> AddClient([FromRoute] int partyId, [FromRoute] Guid systemUserGuid, [FromBody] AgentDelegationRequestFE delegationRequestFe, CancellationToken cancellationToken)
         {
-            Result<AgentDelegationFE> result = await _systemUserAgentDelegationService.AddClient(partyId, systemUserGuid, delegationRequest, cancellationToken);
+            Result<AgentDelegationFE> result = await _systemUserAgentDelegationService.AddClient(partyId, systemUserGuid, delegationRequestFe, cancellationToken);
 
             if (result.IsProblem)
             {

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/SystemUserController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/SystemUserController.cs
@@ -138,13 +138,13 @@ namespace Altinn.AccessManagement.UI.Controllers
         [HttpDelete("agent/{partyId}/{systemUserGuid}")]
         public async Task<ActionResult> DeleteAgentSystemUser([FromRoute] int partyId, [FromRoute] Guid systemUserGuid, CancellationToken cancellationToken)
         {
-            bool result = await _systemUserService.DeleteAgentSystemUser(partyId, systemUserGuid, cancellationToken);
-            if (result)
+            Result<bool> result = await _systemUserService.DeleteAgentSystemUser(partyId, systemUserGuid, cancellationToken);
+            if (result.IsProblem)
             {
-                return Accepted();
+                return result.Problem.ToActionResult(); 
             }
 
-            return NotFound();
+            return Accepted();
         }
 
         /// <summary>

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/SystemUserController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/SystemUserController.cs
@@ -131,15 +131,14 @@ namespace Altinn.AccessManagement.UI.Controllers
         /// </summary>
         /// <param name="partyId">Party user represents</param>
         /// <param name="systemUserGuid">System user id to delete</param>
-        /// <param name="facilitatorId">Party owning the system user</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns></returns>
         [Authorize]
         [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
         [HttpDelete("agent/{partyId}/{systemUserGuid}")]
-        public async Task<ActionResult> DeleteAgentSystemUser([FromRoute] int partyId, [FromRoute] Guid systemUserGuid, [FromQuery] Guid facilitatorId, CancellationToken cancellationToken)
+        public async Task<ActionResult> DeleteAgentSystemUser([FromRoute] int partyId, [FromRoute] Guid systemUserGuid, CancellationToken cancellationToken)
         {
-            bool result = await _systemUserService.DeleteAgentSystemUser(partyId, systemUserGuid, facilitatorId, cancellationToken);
+            bool result = await _systemUserService.DeleteAgentSystemUser(partyId, systemUserGuid, cancellationToken);
             if (result)
             {
                 return Accepted();

--- a/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPage.tsx
@@ -19,7 +19,6 @@ export const SystemUserAgentDelegationPage = (): React.ReactNode => {
   const { id } = useParams();
   const { t } = useTranslation();
   const partyId = getCookie('AltinnPartyId');
-  const partyUuid = getCookie('AltinnPartyUuid');
 
   useDocumentTitle(t('systemuser_agent_delegation.page_title'));
 
@@ -33,7 +32,7 @@ export const SystemUserAgentDelegationPage = (): React.ReactNode => {
     data: customers,
     isError: isLoadCustomersError,
     isLoading: isLoadingCustomers,
-  } = useGetCustomersQuery({ partyId, partyUuid, systemUserId: id ?? '' });
+  } = useGetCustomersQuery({ partyId, systemUserId: id ?? '' });
 
   const {
     data: agentDelegations,
@@ -41,7 +40,6 @@ export const SystemUserAgentDelegationPage = (): React.ReactNode => {
     isLoading: isLoadingAssignedCustomers,
   } = useGetAssignedCustomersQuery({
     partyId: partyId,
-    facilitatorId: partyUuid,
     systemUserId: id || '',
   });
 

--- a/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPageContent.tsx
+++ b/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPageContent.tsx
@@ -41,7 +41,6 @@ export const SystemUserAgentDelegationPageContent = ({
   const navigate = useNavigate();
   const { t } = useTranslation();
   const partyId = getCookie('AltinnPartyId');
-  const partyUuid = getCookie('AltinnPartyUuid');
 
   const { id } = useParams();
   const modalRef = useRef<HTMLDialogElement>(null);
@@ -57,7 +56,7 @@ export const SystemUserAgentDelegationPageContent = ({
     useDeleteAgentSystemuserMutation();
 
   const handleDeleteSystemUser = (): void => {
-    deleteAgentSystemUser({ partyId, facilitatorId: partyUuid, systemUserId: id || '' })
+    deleteAgentSystemUser({ partyId, systemUserId: id || '' })
       .unwrap()
       .then(() => handleNavigateBack());
   };
@@ -82,7 +81,7 @@ export const SystemUserAgentDelegationPageContent = ({
     const onAddSuccess = (delegation: AgentDelegation) => {
       setDelegations((oldDelegations) => [...oldDelegations, delegation]);
     };
-    assignCustomer({ partyId, systemUserId: id ?? '', customerId: customerId, partyUuid })
+    assignCustomer({ partyId, systemUserId: id ?? '', customerId: customerId })
       .unwrap()
       .then(onAddSuccess)
       .catch(() => setErrorId(customerId))
@@ -98,7 +97,6 @@ export const SystemUserAgentDelegationPageContent = ({
     };
     removeCustomer({
       partyId,
-      partyUuid,
       systemUserId: id ?? '',
       delegationId: toRemove.delegationId,
     })

--- a/src/rtk/features/systemUserApi.ts
+++ b/src/rtk/features/systemUserApi.ts
@@ -83,50 +83,46 @@ export const systemUserApi = createApi({
     getAgentSystemUser: builder.query<SystemUser, { partyId: string; systemUserId: string }>({
       query: ({ partyId, systemUserId }) => `systemuser/agent/${partyId}/${systemUserId}`,
     }),
-    deleteAgentSystemuser: builder.mutation<
-      void,
-      { partyId: string; facilitatorId: string; systemUserId: string }
-    >({
-      query: ({ partyId, facilitatorId, systemUserId }) => ({
-        url: `systemuser/agent/${partyId}/${systemUserId}?facilitatorId=${facilitatorId}`,
+    deleteAgentSystemuser: builder.mutation<void, { partyId: string; systemUserId: string }>({
+      query: ({ partyId, systemUserId }) => ({
+        url: `systemuser/agent/${partyId}/${systemUserId}`,
         method: 'DELETE',
       }),
       invalidatesTags: [Tags.SystemUsers],
     }),
     getCustomers: builder.query<
       AgentDelegationCustomer[],
-      { partyId: string; partyUuid: string; systemUserId: string }
+      { partyId: string; systemUserId: string }
     >({
-      query: ({ partyId, partyUuid, systemUserId }) =>
-        `systemuser/agentdelegation/${partyId}/${partyUuid}/${systemUserId}/customers`,
+      query: ({ partyId, systemUserId }) =>
+        `systemuser/agentdelegation/${partyId}/${systemUserId}/customers`,
       keepUnusedDataFor: Infinity,
     }),
     getAssignedCustomers: builder.query<
       AgentDelegation[],
-      { partyId: string; facilitatorId: string; systemUserId: string }
+      { partyId: string; systemUserId: string }
     >({
-      query: ({ partyId, facilitatorId, systemUserId }) =>
-        `systemuser/agentdelegation/${partyId}/${facilitatorId}/${systemUserId}/delegation`,
+      query: ({ partyId, systemUserId }) =>
+        `systemuser/agentdelegation/${partyId}/${systemUserId}/delegation`,
     }),
     assignCustomer: builder.mutation<
       AgentDelegation,
-      { partyId: string; systemUserId: string; partyUuid: string; customerId: string }
+      { partyId: string; systemUserId: string; customerId: string }
     >({
-      query: ({ partyId, systemUserId, partyUuid, customerId }) => ({
-        url: `systemuser/agentdelegation/${partyId}/${partyUuid}/${systemUserId}/delegation`,
+      query: ({ partyId, systemUserId, customerId }) => ({
+        url: `systemuser/agentdelegation/${partyId}/${systemUserId}/delegation`,
         method: 'POST',
         body: {
           customerId: customerId,
-          facilitatorId: partyUuid,
         },
       }),
     }),
     removeCustomer: builder.mutation<
       void,
-      { partyId: string; systemUserId: string; partyUuid: string; delegationId: string }
+      { partyId: string; systemUserId: string; delegationId: string }
     >({
-      query: ({ partyId, systemUserId, partyUuid, delegationId }) => ({
-        url: `systemuser/agentdelegation/${partyId}/${partyUuid}/${systemUserId}/delegation/${delegationId}`,
+      query: ({ partyId, systemUserId, delegationId }) => ({
+        url: `systemuser/agentdelegation/${partyId}/${systemUserId}/delegation/${delegationId}`,
         method: 'DELETE',
       }),
     }),


### PR DESCRIPTION
## Description
- Instead of frontend sending both partyId and partyUuid in agent delegation request, send only partyId and use register to look up partyUuid from partyId in BFF.
- Return ProblemDetails from DELETE agent system user endpoint
- Rename class AgentDelegationPartyFE to CustomerPartyFE
- Remove extra validation

## Related Issue(s)
- this PR

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced a new capability to retrieve party information using a party ID.
  - Added an updated model for delegation requests that improves data handling.

- **Refactor**
  - Streamlined API endpoints by removing redundant parameters and renaming customer party representations for clarity.
  - Enhanced error handling in delegation processes for improved reliability.

- **Tests**
  - Updated test cases to reflect the new endpoint signatures and streamlined data models, ensuring consistent behavior.
  - Added new tests for handling incorrect party IDs in deletion operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->