### PR TITLE
Chore/amui/493 ux fixes

### DIFF
--- a/src/features/amUI/common/AccessPackageList/AccessPackageExpandedContext.tsx
+++ b/src/features/amUI/common/AccessPackageList/AccessPackageExpandedContext.tsx
@@ -1,0 +1,92 @@
+import { createContext, ReactNode, useContext, useState } from 'react';
+
+/**
+ * AccessPackageExpandedContext.tsx
+ *
+ * This file provides a context and utility hooks for managing the expanded state of areas
+ * in the Access Package List. It allows components to share the expanded state via context
+ * or fall back to a local state if the context is not available.
+ */
+
+interface AccessPackageContextValue {
+  /**
+   * Toggles the expanded state of a specific area by its ID.
+   * @param areaId - The ID of the area to toggle.
+   */
+  toggleExpandedArea: (areaId: string) => void;
+
+  /**
+   * Checks if a specific area is expanded.
+   * @param areaId - The ID of the area to check.
+   * @returns `true` if the area is expanded, otherwise `false`.
+   */
+  isExpanded: (areaId: string) => boolean;
+
+  /**
+   * Closes all areas by resetting the expanded state.
+   */
+  closeAllAreas: () => void;
+}
+
+/**
+ * React Context for managing the expanded state of areas.
+ * Components can use this context to share the expanded state across the component tree.
+ */
+export const AccessPackageContext = createContext<AccessPackageContextValue | null>(null);
+
+/**
+ * Hook to manage the expanded state of areas.
+ *
+ * @returns An object with `toggleExpandedArea` and `isExpanded` functions.
+ */
+const useAreaExpandedState = () => {
+  const [expandedAreas, setExpandedAreas] = useState<string[]>([]);
+
+  const toggleExpandedArea = (areaId: string) => {
+    if (expandedAreas.some((id) => id === areaId)) {
+      const newExpandedState = expandedAreas.filter((id) => id !== areaId);
+      setExpandedAreas(newExpandedState);
+    } else {
+      setExpandedAreas([...expandedAreas, areaId]);
+    }
+  };
+
+  const closeAllAreas = () => {
+    setExpandedAreas([]);
+  };
+
+  const isExpanded = (areaId: string) => expandedAreas.some((id) => id === areaId);
+
+  return { toggleExpandedArea, isExpanded, closeAllAreas };
+};
+
+/**
+ * Hook to use the expanded state from the context if available.
+ * Falls back to local state if the context is not provided.
+ *
+ * @returns An object with `toggleExpandedArea` and `isExpanded` functions.
+ */
+export const useAreaExpandedContextOrLocal = () => {
+  const context = useContext(AccessPackageContext);
+  if (!context) {
+    return useAreaExpandedState();
+  }
+  return context;
+};
+
+/**
+ * Context Provider for the expanded state of areas.
+ * Wrap your component tree with this provider to share the expanded state via context.
+ *
+ * @param children - The child components that will have access to the context.
+ * @returns A React component that provides the context to its children.
+ */
+export const AreaExpandedStateProvider = ({ children }: { children: ReactNode }) => {
+  const { toggleExpandedArea, isExpanded, closeAllAreas } = useAreaExpandedState();
+
+  return (
+    <AccessPackageContext.Provider value={{ toggleExpandedArea, isExpanded, closeAllAreas }}>
+      {children}
+    </AccessPackageContext.Provider>
+  );
+};

--- a/src/features/amUI/common/AccessPackageList/AccessPackageList.tsx
+++ b/src/features/amUI/common/AccessPackageList/AccessPackageList.tsx
@@ -15,6 +15,7 @@ import { AreaItem } from './AreaItem';
 import { useAccessPackageActions } from './useAccessPackageActions';
 import { SkeletonAccessPackageList } from './SkeletonAccessPackageList';
 import { AreaItemContent } from './AreaItemContent';
+import { useAreaExpandedContextOrLocal } from './AccessPackageExpandedContext';
 
 interface AccessPackageListProps {
   showAllPackages?: boolean;
@@ -52,16 +53,7 @@ export const AccessPackageList = ({
     to: toParty?.partyUuid ?? '',
   });
 
-  const [expandedAreas, setExpandedAreas] = useState<string[]>([]);
-
-  const toggleExpandedArea = (areaId: string) => {
-    if (expandedAreas.some((id) => id === areaId)) {
-      const newExpandedState = expandedAreas.filter((id) => id !== areaId);
-      setExpandedAreas(newExpandedState);
-    } else {
-      setExpandedAreas([...expandedAreas, areaId]);
-    }
-  };
+  const { toggleExpandedArea, isExpanded } = useAreaExpandedContextOrLocal();
 
   const { assignedAreas, availableAreas } = useAreaPackageList({
     allPackageAreas,
@@ -91,9 +83,7 @@ export const AccessPackageList = ({
       ) : (
         <ListBase>
           {displayAreas.map((area) => {
-            const expanded =
-              (searchString && searchString.length > 2) ||
-              expandedAreas.some((areaId) => areaId === area.id);
+            const expanded = (searchString && searchString.length > 2) || isExpanded(area.id);
 
             return (
               <AreaItem

--- a/src/features/amUI/common/DelegationModal/AccessPackages/AccessPackageInfo.tsx
+++ b/src/features/amUI/common/DelegationModal/AccessPackages/AccessPackageInfo.tsx
@@ -35,7 +35,7 @@ export interface PackageInfoProps {
 
 export const AccessPackageInfo = ({ accessPackage, availableActions = [] }: PackageInfoProps) => {
   const { t } = useTranslation();
-  const { fromParty, toParty, selfParty } = usePartyRepresentation();
+  const { fromParty, toParty } = usePartyRepresentation();
 
   const { onDelegate, onRevoke } = useAccessPackageActions({
     toUuid: toParty?.partyUuid || '',

--- a/src/features/amUI/common/DelegationModal/DelegationModal.tsx
+++ b/src/features/amUI/common/DelegationModal/DelegationModal.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import { DelegationModalContent } from './DelegationModalContent';
 import type { DelegationAction } from './EditModal';
+import { AreaExpandedStateProvider } from '../AccessPackageList/AccessPackageExpandedContext';
 
 export enum DelegationType {
   SingleRights = 'SingleRights',
@@ -15,9 +16,11 @@ export interface DelegationModalProps {
 
 export const DelegationModal = ({ delegationType, availableActions }: DelegationModalProps) => {
   return (
-    <DelegationModalContent
-      delegationType={delegationType}
-      availableActions={availableActions}
-    />
+    <AreaExpandedStateProvider>
+      <DelegationModalContent
+        delegationType={delegationType}
+        availableActions={availableActions}
+      />
+    </AreaExpandedStateProvider>
   );
 };

--- a/src/features/amUI/common/DelegationModal/DelegationModalContent.tsx
+++ b/src/features/amUI/common/DelegationModal/DelegationModalContent.tsx
@@ -18,6 +18,7 @@ import { PackageSearch } from './AccessPackages/PackageSearch';
 import { AccessPackageInfo } from './AccessPackages/AccessPackageInfo';
 import type { DelegationAction } from './EditModal';
 import { usePartyRepresentation } from '../PartyRepresentationContext/PartyRepresentationContext';
+import { useAreaExpandedContextOrLocal } from '../AccessPackageList/AccessPackageExpandedContext';
 
 export interface DelegationModalProps {
   delegationType: DelegationType;
@@ -40,7 +41,7 @@ export const DelegationModalContent = ({
     setActionError,
   } = useDelegationModalContext();
   const { toParty } = usePartyRepresentation();
-
+  const { closeAllAreas } = useAreaExpandedContextOrLocal();
   const onResourceSelection = (resource?: ServiceResource) => {
     setInfoView(true);
     setResourceToView(resource);
@@ -58,6 +59,7 @@ export const DelegationModalContent = ({
 
   const onClosing = () => {
     reset();
+    closeAllAreas();
   };
 
   useEffect(() => {

--- a/src/features/amUI/common/RoleList/DelegateRoleButton.tsx
+++ b/src/features/amUI/common/RoleList/DelegateRoleButton.tsx
@@ -10,10 +10,10 @@ import { Role, useDelegateMutation, useDelegationCheckQuery } from '@/rtk/featur
 import { SnackbarDuration, SnackbarMessageVariant } from '../Snackbar/SnackbarProvider';
 import { useSnackbar } from '../Snackbar';
 import { ActionError } from '@/resources/hooks/useActionError';
+import { usePartyRepresentation } from '../PartyRepresentationContext/PartyRepresentationContext';
 
 interface DelegateRoleButtonProps extends Omit<ButtonProps, 'icon'> {
   accessRole: Role;
-  toParty?: Party;
   fullText?: boolean;
   icon?: boolean;
   onDelegateError?: (role: Role, error: ActionError) => void;
@@ -21,7 +21,6 @@ interface DelegateRoleButtonProps extends Omit<ButtonProps, 'icon'> {
 
 export const DelegateRoleButton = ({
   accessRole,
-  toParty,
   fullText = false,
   variant = 'text',
   icon = true,
@@ -30,12 +29,12 @@ export const DelegateRoleButton = ({
 }: DelegateRoleButtonProps) => {
   const { t } = useTranslation();
   const { openSnackbar } = useSnackbar();
-  const { data: representingParty } = useGetReporteePartyQuery();
+  const { fromParty, toParty } = usePartyRepresentation();
   const [delegateRole, { isLoading: delegateRoleLoading }] = useDelegateMutation();
 
   const { data: delegationCheckResult, isLoading: delegationCheckLoading } =
     useDelegationCheckQuery({
-      rightownerUuid: representingParty?.partyUuid || '',
+      rightownerUuid: fromParty?.partyUuid || '',
       roleUuid: accessRole.id,
     });
 
@@ -55,7 +54,7 @@ export const DelegateRoleButton = ({
       openSnackbar(snackbarData);
     };
 
-    if (representingParty) {
+    if (fromParty) {
       delegateRole({
         to: toParty?.partyUuid || '',
         roleId: accessRole.id,

--- a/src/features/amUI/common/RoleList/RevokeRoleButton.tsx
+++ b/src/features/amUI/common/RoleList/RevokeRoleButton.tsx
@@ -10,11 +10,11 @@ import { useRevokeMutation } from '@/rtk/features/roleApi';
 import type { ActionError } from '@/resources/hooks/useActionError';
 
 import { useSnackbar } from '../Snackbar';
+import { usePartyRepresentation } from '../PartyRepresentationContext/PartyRepresentationContext';
 
 interface RevokeRoleButtonProps extends Omit<ButtonProps, 'icon'> {
   accessRole: Role;
   assignmentId: string;
-  toParty?: Party;
   fullText?: boolean;
   icon?: boolean;
   onRevokeSuccess?: (role: Role, toParty: Party) => void;
@@ -24,7 +24,6 @@ interface RevokeRoleButtonProps extends Omit<ButtonProps, 'icon'> {
 export const RevokeRoleButton = ({
   assignmentId,
   accessRole,
-  toParty,
   fullText = false,
   disabled,
   variant = 'text',
@@ -37,7 +36,7 @@ export const RevokeRoleButton = ({
   const { openSnackbar } = useSnackbar();
   const { data: representingParty } = useGetReporteePartyQuery();
   const [revoke, { isLoading }] = useRevokeMutation();
-
+  const { toParty } = usePartyRepresentation();
   const handleRevokeSuccess = (role: Role, toParty?: Party) => {
     if (onRevokeSuccess && toParty) onRevokeSuccess(role, toParty);
     else {

--- a/src/features/amUI/reporteeRightsPage/ReporteeAccessPackageSection.tsx
+++ b/src/features/amUI/reporteeRightsPage/ReporteeAccessPackageSection.tsx
@@ -11,6 +11,7 @@ import { AccessPackageList } from '../common/AccessPackageList/AccessPackageList
 import { DelegationAction } from '../common/DelegationModal/EditModal';
 import { AccessPackageInfoModal } from '../userRightsPage/AccessPackageSection/AccessPackageInfoModal';
 import { useDelegationModalContext } from '../common/DelegationModal/DelegationModalContext';
+import classes from './ReporteeRightsPage.module.css';
 
 interface ReporteeAccessPackageSectionProps {
   reporteeUuid?: string;
@@ -34,7 +35,7 @@ export const ReporteeAccessPackageSection = ({
   }, []);
 
   return (
-    <>
+    <div className={classes.tabContentContainer}>
       <Heading
         level={2}
         data-size='xs'
@@ -68,6 +69,6 @@ export const ReporteeAccessPackageSection = ({
           modalActions={[DelegationAction.REVOKE, DelegationAction.REQUEST]}
         />
       )}
-    </>
+    </div>
   );
 };

--- a/src/features/amUI/reporteeRightsPage/ReporteeRightsPage.module.css
+++ b/src/features/amUI/reporteeRightsPage/ReporteeRightsPage.module.css
@@ -1,0 +1,6 @@
+.tabContentContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 1rem 0 0.5rem 0;
+}

--- a/src/features/amUI/reporteeRightsPage/ReporteeRoleSection.tsx
+++ b/src/features/amUI/reporteeRightsPage/ReporteeRoleSection.tsx
@@ -9,7 +9,7 @@ import { RoleInfoModal } from '../common/RoleList/RoleInfoModal';
 import { RoleList } from '../common/RoleList/RoleList';
 import { DelegationAction } from '../common/DelegationModal/EditModal';
 import { useDelegationModalContext } from '../common/DelegationModal/DelegationModalContext';
-import { ActionError } from '@/resources/hooks/useActionError';
+import classes from './ReporteeRightsPage.module.css';
 
 interface ReporteeRoleSectionProps {
   reporteeUuid?: string;
@@ -27,7 +27,7 @@ export const ReporteeRoleSection = ({
   const toUuid = getCookie('AltinnPartyUuid');
 
   return (
-    <>
+    <div className={classes.tabContentContainer}>
       <Heading
         level={2}
         data-size='xs'
@@ -35,28 +35,26 @@ export const ReporteeRoleSection = ({
       >
         {t('role.current_roles_title', { count: numberOfAccesses })}
       </Heading>
-      <div>
-        <RoleList
-          to={toUuid}
-          from={reporteeUuid ?? ''}
-          onSelect={(role) => {
-            setModalItem(role);
-            modalRef.current?.showModal();
-          }}
-          availableActions={[DelegationAction.REVOKE, DelegationAction.REQUEST]}
-          onActionError={(role, error) => {
-            setModalItem(role);
-            modalRef.current?.showModal();
-            setActionError(error);
-          }}
-        />
-      </div>
+      <RoleList
+        to={toUuid}
+        from={reporteeUuid ?? ''}
+        onSelect={(role) => {
+          setModalItem(role);
+          modalRef.current?.showModal();
+        }}
+        availableActions={[DelegationAction.REVOKE, DelegationAction.REQUEST]}
+        onActionError={(role, error) => {
+          setModalItem(role);
+          modalRef.current?.showModal();
+          setActionError(error);
+        }}
+      />
       <RoleInfoModal
         modalRef={modalRef}
         role={modalItem}
         onClose={() => setModalItem(undefined)}
         availableActions={[DelegationAction.REVOKE, DelegationAction.REQUEST]}
       />
-    </>
+    </div>
   );
 };

--- a/src/features/amUI/userRightsPage/RoleSection/RoleSection.tsx
+++ b/src/features/amUI/userRightsPage/RoleSection/RoleSection.tsx
@@ -30,7 +30,7 @@ export const RoleSection = ({ numberOfAccesses }: RoleSectionProps) => {
   const isCurrentUser = currentUser?.uuid === rightHolderUuid;
 
   return (
-    <>
+    <div className={classes.roleSection}>
       <Heading
         level={2}
         data-size='xs'
@@ -38,37 +38,36 @@ export const RoleSection = ({ numberOfAccesses }: RoleSectionProps) => {
       >
         {t('role.current_roles_title', { count: numberOfAccesses })}
       </Heading>
-      <div className={classes.roleSection}>
-        <RoleList
-          from={reportee?.partyUuid ?? ''}
-          to={rightHolderUuid ?? ''}
+
+      <RoleList
+        from={reportee?.partyUuid ?? ''}
+        to={rightHolderUuid ?? ''}
+        availableActions={[
+          isCurrentUser ? DelegationAction.REQUEST : DelegationAction.DELEGATE,
+          DelegationAction.REVOKE,
+        ]}
+        onActionError={(role, error) => {
+          setModalItem(role);
+          setActionError(error);
+          modalRef.current?.showModal();
+        }}
+        onSelect={(role) => {
+          setModalItem(role);
+          modalRef.current?.showModal();
+        }}
+        isLoading={currentUserIsLoading}
+      />
+      {party && (
+        <RoleInfoModal
+          modalRef={modalRef}
+          role={modalItem}
+          onClose={() => setModalItem(undefined)}
           availableActions={[
             isCurrentUser ? DelegationAction.REQUEST : DelegationAction.DELEGATE,
             DelegationAction.REVOKE,
           ]}
-          onActionError={(role, error) => {
-            setModalItem(role);
-            setActionError(error);
-            modalRef.current?.showModal();
-          }}
-          onSelect={(role) => {
-            setModalItem(role);
-            modalRef.current?.showModal();
-          }}
-          isLoading={currentUserIsLoading}
         />
-        {party && (
-          <RoleInfoModal
-            modalRef={modalRef}
-            role={modalItem}
-            onClose={() => setModalItem(undefined)}
-            availableActions={[
-              isCurrentUser ? DelegationAction.REQUEST : DelegationAction.DELEGATE,
-              DelegationAction.REVOKE,
-            ]}
-          />
-        )}
-      </div>
-    </>
+      )}
+    </div>
   );
 };

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -262,7 +262,7 @@
     }
   },
   "role": {
-    "current_roles_title": "Power of attorney to {{count}} roles(s)",
+    "current_roles_title": "{{count}} administrator accesses",
     "role_delegation_success": "{{name}} has been successfully granted power of attorney over {{role}}.",
     "role_delegation_error": "Failed to grant power of attorney over {{role}} to {{name}}.",
     "role_deletion_success": "Power of attorney over {{role}} has been successfully revoked for {{name}}.",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -261,7 +261,7 @@
     }
   },
   "role": {
-    "current_roles_title": "Fullmakt til {{count}} rolle(r)",
+    "current_roles_title": "{{count}} administratortilganger",
     "role_delegation_success": "{{name}} har nå fått fullmakt til {{role}}.",
     "role_delegation_error": "Det var ikke mulig å gi {{name}} fullmakt til {{role}}.",
     "role_deletion_success": "Fullmakten til {{role}} er fjernet fra {{name}}.",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -258,7 +258,7 @@
     }
   },
   "role": {
-    "current_roles_title": "Fullmakt til {{count}} rolle(r)",
+    "current_roles_title": "{{count}} administratortilganger",
     "role_delegation_success": "{{name}} har nå fått fullmakt til {{role}}.",
     "role_delegation_error": "Det var ikke mulig å gi {{name}} fullmakt til {{role}}.",
     "role_deletion_success": "Fullmakten til {{role}} er fjernet fra {{name}}.",


### PR DESCRIPTION


## Description

- [ x ]  Mer mellomrom mellom elementer i pakke-fanen på tilganger hos andre (overskrift)
- [ x ] Overskrift på rolle-fanen skal være Administrator-tilganger (eller noe sånt)
  - 
<img width="749" alt="Screenshot 2025-03-28 at 09 44 36" src="https://github.com/user-attachments/assets/76723045-6e88-47b0-9fc6-194417c8f3e3" />


- [ x ] Ta bort parentes i overskrift "Fullmakt til 2 tilgangspakker"

- [ x ] Søkesiden skal huske hvilke områder som var åpne når man kommer tilbake til den
  - Legger til en valgfri kontekst som husker hvilke opråder som er åpne. Faller tilbake på lokal state hvis det ikke finnes noe context  

## Related Issue(s)
- #[493](https://github.com/Altinn/altinn-authorization-tmp/issues/493)

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
