### PR TITLE
Chore/amui/1364 delgation check warning icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "vitest:ci": "vitest --coverage"
   },
   "dependencies": {
-    "@altinn/altinn-components": "0.22.8",
+    "@altinn/altinn-components": "0.23.3",
     "@digdir/designsystemet-css": "1.0.2",
     "@digdir/designsystemet-react": "1.0.2",
     "@digdir/designsystemet-theme": "1.0.2",

--- a/src/features/amUI/common/AccessPackageList/AreaItemContent.tsx
+++ b/src/features/amUI/common/AccessPackageList/AreaItemContent.tsx
@@ -1,12 +1,10 @@
-import { Alert, Heading, Paragraph } from '@digdir/designsystemet-react';
-import { Button, ListBase } from '@altinn/altinn-components';
-import { MinusCircleIcon, PlusCircleIcon } from '@navikt/aksel-icons';
+import { Alert, Heading, Paragraph, Spinner } from '@digdir/designsystemet-react';
+import { ListBase } from '@altinn/altinn-components';
 import { useTranslation } from 'react-i18next';
-import { useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 
 import type { AccessPackage } from '@/rtk/features/accessPackageApi';
 
-import { ButtonWithConfirmPopup } from '../ButtonWithConfirmPopup/ButtonWithConfirmPopup';
 import { DelegationAction } from '../DelegationModal/EditModal';
 
 import classes from './AccessPackageList.module.css';
@@ -17,6 +15,8 @@ import { ActionError } from '@/resources/hooks/useActionError';
 import { TechnicalErrorParagraphs } from '../TechnicalErrorParagraphs';
 import cn from 'classnames';
 import { useIsMobileOrSmaller } from '@/resources/utils/screensizeUtils';
+import { RevokeAccessPackageActionControl } from './RevokeAccessPackageActionControl';
+import { DelegateAccessPackageActionControl } from './DelegateAccessPackageActionControl';
 
 interface AreaItemContentProps {
   area: ExtendedAccessArea;
@@ -80,36 +80,14 @@ export const AreaItemContent = ({
               onSelect={onSelect}
               hasAccess
               controls={
-                !isSm &&
-                (availableActions?.includes(DelegationAction.REVOKE) && useDeleteConfirm ? (
-                  <ButtonWithConfirmPopup
-                    triggerButtonContent={t('common.delete_poa')}
-                    triggerButtonProps={{
-                      icon: MinusCircleIcon,
-                      variant: 'text',
-                      size: 'sm',
-                      disabled: pkg.inherited,
-                    }}
-                    popoverProps={{
-                      color: 'neutral',
-                    }}
-                    message={t('user_rights_page.delete_confirm_message', {
-                      name: pkg.name,
-                    })}
-                    data-size='sm'
-                    onConfirm={() => onRevoke(pkg)}
+                !isSm && (
+                  <RevokeAccessPackageActionControl
+                    availableActions={availableActions}
+                    onRevoke={() => onRevoke(pkg)}
+                    pkg={pkg}
+                    useDeleteConfirm={useDeleteConfirm}
                   />
-                ) : (
-                  <Button
-                    icon={MinusCircleIcon}
-                    variant='text'
-                    size='sm'
-                    disabled={pkg.inherited}
-                    onClick={() => onRevoke(pkg)}
-                  >
-                    {t('common.delete_poa')}
-                  </Button>
-                ))
+                )
               }
             />
           ))}
@@ -124,30 +102,14 @@ export const AreaItemContent = ({
               onSelect={onSelect}
               controls={
                 !isSm && (
-                  <>
-                    {availableActions?.includes(DelegationAction.DELEGATE) && (
-                      <Button
-                        icon={PlusCircleIcon}
-                        variant='text'
-                        size='sm'
-                        disabled={!canDelegate(pkg.id) || isLoading}
-                        onClick={() => onDelegate(pkg)}
-                      >
-                        {t('common.give_poa')}
-                      </Button>
-                    )}
-                    {availableActions?.includes(DelegationAction.REQUEST) && (
-                      <Button
-                        icon={PlusCircleIcon}
-                        variant='text'
-                        size='sm'
-                        disabled
-                        onClick={() => onRequest(pkg)}
-                      >
-                        {t('common.request_poa')}
-                      </Button>
-                    )}
-                  </>
+                  <DelegateAccessPackageActionControl
+                    isLoading={isLoading}
+                    availableActions={availableActions}
+                    canDelegate={!!canDelegate(pkg.id)}
+                    onDelegate={() => onDelegate(pkg)}
+                    onRequest={() => onRequest(pkg)}
+                    onSelect={() => onSelect?.(pkg)}
+                  />
                 )
               }
             />

--- a/src/features/amUI/common/AccessPackageList/AreaItemContent.tsx
+++ b/src/features/amUI/common/AccessPackageList/AreaItemContent.tsx
@@ -103,7 +103,7 @@ export const AreaItemContent = ({
               controls={
                 !isSm && (
                   <DelegateAccessPackageActionControl
-                    isLoading={isLoading || isUninitialized}
+                    isLoading={(isLoading || isUninitialized) && shouldShowDelegationCheck}
                     availableActions={availableActions}
                     canDelegate={!!canDelegate(pkg.id)}
                     onDelegate={() => onDelegate(pkg)}

--- a/src/features/amUI/common/AccessPackageList/AreaItemContent.tsx
+++ b/src/features/amUI/common/AccessPackageList/AreaItemContent.tsx
@@ -48,7 +48,7 @@ export const AreaItemContent = ({
     setDelegationCheckError(error);
   };
   const shouldShowDelegationCheck = !!availableActions?.includes(DelegationAction.DELEGATE);
-  const { canDelegate, isLoading } = useAccessPackageDelegationCheck(
+  const { canDelegate, isLoading, isUninitialized } = useAccessPackageDelegationCheck(
     availablePackageIds,
     shouldShowDelegationCheck,
     handleDelegationCheckFailure,
@@ -103,7 +103,7 @@ export const AreaItemContent = ({
               controls={
                 !isSm && (
                   <DelegateAccessPackageActionControl
-                    isLoading={isLoading}
+                    isLoading={isLoading || isUninitialized}
                     availableActions={availableActions}
                     canDelegate={!!canDelegate(pkg.id)}
                     onDelegate={() => onDelegate(pkg)}

--- a/src/features/amUI/common/AccessPackageList/DelegateAccessPackageActionControl.tsx
+++ b/src/features/amUI/common/AccessPackageList/DelegateAccessPackageActionControl.tsx
@@ -1,0 +1,76 @@
+import { Paragraph, Spinner } from '@digdir/designsystemet-react';
+import { Button } from '@altinn/altinn-components';
+import { ExclamationmarkTriangleIcon, PlusCircleIcon } from '@navikt/aksel-icons';
+import { useTranslation } from 'react-i18next';
+import { DelegationAction } from '../DelegationModal/EditModal';
+
+interface DelegateAccessPackageActionControlsProps {
+  isLoading: boolean;
+  availableActions?: DelegationAction[];
+  onDelegate: () => void;
+  onSelect: () => void;
+  onRequest: () => void;
+  canDelegate: boolean;
+}
+
+export const DelegateAccessPackageActionControl = ({
+  isLoading,
+  availableActions,
+  canDelegate,
+  onRequest,
+  onSelect,
+  onDelegate,
+}: DelegateAccessPackageActionControlsProps) => {
+  const { t } = useTranslation();
+
+  if (isLoading) {
+    return (
+      <Spinner
+        data-size='sm'
+        aria-hidden='true'
+      />
+    );
+  }
+
+  if (availableActions?.includes(DelegationAction.DELEGATE)) {
+    if (!isLoading && canDelegate === false) {
+      return (
+        <Button
+          data-size='xs'
+          onClick={onSelect}
+          variant='text'
+          aria-label={t('delegation_modal.delegation_check_not_delegable')}
+          size='sm'
+        >
+          <ExclamationmarkTriangleIcon
+            aria-hidden='true'
+            fontSize={'1.2rem'}
+          />
+        </Button>
+      );
+    }
+    return (
+      <Button
+        icon={PlusCircleIcon}
+        variant='text'
+        size='sm'
+        onClick={onDelegate}
+      >
+        {t('common.give_poa')}
+      </Button>
+    );
+  }
+  if (availableActions?.includes(DelegationAction.REQUEST)) {
+    return (
+      <Button
+        icon={PlusCircleIcon}
+        variant='text'
+        size='sm'
+        disabled
+        onClick={onRequest}
+      >
+        {t('common.request_poa')}
+      </Button>
+    );
+  }
+};

--- a/src/features/amUI/common/AccessPackageList/DelegateAccessPackageActionControl.tsx
+++ b/src/features/amUI/common/AccessPackageList/DelegateAccessPackageActionControl.tsx
@@ -33,7 +33,7 @@ export const DelegateAccessPackageActionControl = ({
   }
 
   if (availableActions?.includes(DelegationAction.DELEGATE)) {
-    if (!isLoading && canDelegate === false) {
+    if (canDelegate === false) {
       return (
         <Button
           data-size='xs'
@@ -73,4 +73,5 @@ export const DelegateAccessPackageActionControl = ({
       </Button>
     );
   }
+  return null;
 };

--- a/src/features/amUI/common/AccessPackageList/DelegateAccessPackageActionControl.tsx
+++ b/src/features/amUI/common/AccessPackageList/DelegateAccessPackageActionControl.tsx
@@ -26,7 +26,7 @@ export const DelegateAccessPackageActionControl = ({
   if (isLoading) {
     return (
       <Spinner
-        data-size='sm'
+        data-size='xs'
         aria-hidden='true'
       />
     );

--- a/src/features/amUI/common/AccessPackageList/RevokeAccessPackageActionControl.tsx
+++ b/src/features/amUI/common/AccessPackageList/RevokeAccessPackageActionControl.tsx
@@ -1,0 +1,60 @@
+import { Button } from '@altinn/altinn-components';
+import { MinusCircleIcon } from '@navikt/aksel-icons';
+import { useTranslation } from 'react-i18next';
+import React from 'react';
+
+import type { AccessPackage } from '@/rtk/features/accessPackageApi';
+
+import { ButtonWithConfirmPopup } from '../ButtonWithConfirmPopup/ButtonWithConfirmPopup';
+import { DelegationAction } from '../DelegationModal/EditModal';
+
+interface RevokeAccessPackageActionControlsProps {
+  availableActions?: DelegationAction[];
+  onRevoke: () => void;
+  pkg: AccessPackage;
+  useDeleteConfirm?: boolean;
+}
+
+export const RevokeAccessPackageActionControl = ({
+  availableActions,
+  onRevoke,
+  pkg,
+  useDeleteConfirm = false,
+}: RevokeAccessPackageActionControlsProps) => {
+  const { t } = useTranslation();
+
+  if (availableActions?.includes(DelegationAction.REVOKE)) {
+    if (useDeleteConfirm) {
+      return (
+        <ButtonWithConfirmPopup
+          triggerButtonContent={t('common.delete_poa')}
+          triggerButtonProps={{
+            icon: MinusCircleIcon,
+            variant: 'text',
+            size: 'sm',
+            disabled: pkg.inherited,
+          }}
+          popoverProps={{
+            color: 'neutral',
+          }}
+          message={t('user_rights_page.delete_confirm_message', {
+            name: pkg.name,
+          })}
+          data-size='sm'
+          onConfirm={onRevoke}
+        />
+      );
+    }
+    return (
+      <Button
+        icon={MinusCircleIcon}
+        variant='text'
+        size='sm'
+        disabled={pkg.inherited}
+        onClick={onRevoke}
+      >
+        {t('common.delete_poa')}
+      </Button>
+    );
+  }
+};

--- a/src/features/amUI/common/AccessPackageList/RevokeAccessPackageActionControl.tsx
+++ b/src/features/amUI/common/AccessPackageList/RevokeAccessPackageActionControl.tsx
@@ -57,4 +57,5 @@ export const RevokeAccessPackageActionControl = ({
       </Button>
     );
   }
+  return null;
 };

--- a/src/features/amUI/common/DelegationModal/AccessPackages/AccessPackageInfo.tsx
+++ b/src/features/amUI/common/DelegationModal/AccessPackages/AccessPackageInfo.tsx
@@ -72,7 +72,7 @@ export const AccessPackageInfo = ({ accessPackage, availableActions = [] }: Pack
     return accessPackage ? [accessPackage.id] : [];
   }, [accessPackage]);
 
-  const { canDelegate, isLoading } = useAccessPackageDelegationCheck(
+  const { canDelegate, isLoading, isUninitialized } = useAccessPackageDelegationCheck(
     accessPackageIds,
     shouldShowDelegationCheck,
     handleDelegationCheckFailure,
@@ -82,7 +82,8 @@ export const AccessPackageInfo = ({ accessPackage, availableActions = [] }: Pack
     shouldShowDelegationCheck &&
     !delegationCheckError &&
     !canDelegate(accessPackage.id) &&
-    !isLoading;
+    !isLoading &&
+    !isUninitialized;
 
   const { listItems } = useMinimizableResourceList(accessPackage.resources);
 

--- a/src/features/amUI/common/DelegationModal/AccessPackages/AccessPackageInfo.tsx
+++ b/src/features/amUI/common/DelegationModal/AccessPackages/AccessPackageInfo.tsx
@@ -77,11 +77,14 @@ export const AccessPackageInfo = ({ accessPackage, availableActions = [] }: Pack
     shouldShowDelegationCheck,
     handleDelegationCheckFailure,
   );
+
+  const delegationCheckResult = React.useMemo(() => {
+    setDelegationCheckError(null);
+    return canDelegate(accessPackage.id);
+  }, [accessPackageIds]);
+
   const showMissingRightsMessage =
-    shouldShowDelegationCheck &&
-    !delegationCheckError &&
-    !canDelegate(accessPackage.id) &&
-    !isLoading;
+    shouldShowDelegationCheck && !delegationCheckError && !delegationCheckResult && !isLoading;
 
   const { listItems } = useMinimizableResourceList(accessPackage.resources);
 

--- a/src/features/amUI/common/DelegationModal/AccessPackages/AccessPackageInfo.tsx
+++ b/src/features/amUI/common/DelegationModal/AccessPackages/AccessPackageInfo.tsx
@@ -68,8 +68,11 @@ export const AccessPackageInfo = ({ accessPackage, availableActions = [] }: Pack
 
   // memorize this to prevent unnecessary re-renders
   const accessPackageIds = React.useMemo(() => {
-    setDelegationCheckError(null);
     return accessPackage ? [accessPackage.id] : [];
+  }, [accessPackage]);
+
+  React.useEffect(() => {
+    setDelegationCheckError(null);
   }, [accessPackage]);
 
   const { canDelegate, isLoading, isUninitialized } = useAccessPackageDelegationCheck(

--- a/src/features/amUI/common/DelegationModal/AccessPackages/AccessPackageInfo.tsx
+++ b/src/features/amUI/common/DelegationModal/AccessPackages/AccessPackageInfo.tsx
@@ -67,10 +67,10 @@ export const AccessPackageInfo = ({ accessPackage, availableActions = [] }: Pack
   const shouldShowDelegationCheck = availableActions.includes(DelegationAction.DELEGATE);
 
   // memorize this to prevent unnecessary re-renders
-  const accessPackageIds = React.useMemo(
-    () => (accessPackage ? [accessPackage.id] : []),
-    [accessPackage],
-  );
+  const accessPackageIds = React.useMemo(() => {
+    setDelegationCheckError(null);
+    return accessPackage ? [accessPackage.id] : [];
+  }, [accessPackage]);
 
   const { canDelegate, isLoading } = useAccessPackageDelegationCheck(
     accessPackageIds,
@@ -78,13 +78,11 @@ export const AccessPackageInfo = ({ accessPackage, availableActions = [] }: Pack
     handleDelegationCheckFailure,
   );
 
-  const delegationCheckResult = React.useMemo(() => {
-    setDelegationCheckError(null);
-    return canDelegate(accessPackage.id);
-  }, [accessPackageIds]);
-
   const showMissingRightsMessage =
-    shouldShowDelegationCheck && !delegationCheckError && !delegationCheckResult && !isLoading;
+    shouldShowDelegationCheck &&
+    !delegationCheckError &&
+    !canDelegate(accessPackage.id) &&
+    !isLoading;
 
   const { listItems } = useMinimizableResourceList(accessPackage.resources);
 

--- a/src/features/amUI/common/DelegationModal/AccessPackages/AccessPackageInfo.tsx
+++ b/src/features/amUI/common/DelegationModal/AccessPackages/AccessPackageInfo.tsx
@@ -68,7 +68,6 @@ export const AccessPackageInfo = ({ accessPackage, availableActions = [] }: Pack
 
   // memorize this to prevent unnecessary re-renders
   const accessPackageIds = React.useMemo(() => {
-    setDelegationCheckError(null);
     return accessPackage ? [accessPackage.id] : [];
   }, [accessPackage]);
 

--- a/src/features/amUI/common/DelegationModal/AccessPackages/AccessPackageInfo.tsx
+++ b/src/features/amUI/common/DelegationModal/AccessPackages/AccessPackageInfo.tsx
@@ -68,6 +68,7 @@ export const AccessPackageInfo = ({ accessPackage, availableActions = [] }: Pack
 
   // memorize this to prevent unnecessary re-renders
   const accessPackageIds = React.useMemo(() => {
+    setDelegationCheckError(null);
     return accessPackage ? [accessPackage.id] : [];
   }, [accessPackage]);
 

--- a/src/features/amUI/common/RoleList/RoleList.tsx
+++ b/src/features/amUI/common/RoleList/RoleList.tsx
@@ -7,7 +7,6 @@ import {
   useGetRolesForUserQuery,
   useGetRolesQuery,
 } from '@/rtk/features/roleApi';
-import { useGetPartyByUUIDQuery } from '@/rtk/features/lookupApi';
 
 import { DelegationAction } from '../DelegationModal/EditModal';
 
@@ -117,6 +116,11 @@ export const RoleList = ({
                         fullText={false}
                         size='sm'
                         onDelegateError={onActionError}
+                        onSelect={() => {
+                          onSelect(role);
+                        }}
+                        showSpinner={true}
+                        showWarning={true}
                       />
                     )}
                     {availableActions?.includes(DelegationAction.REQUEST) && <RequestRoleButton />}

--- a/src/features/amUI/reporteeRightsPage/ReporteeRoleSection.tsx
+++ b/src/features/amUI/reporteeRightsPage/ReporteeRoleSection.tsx
@@ -1,4 +1,4 @@
-import { Heading } from '@digdir/designsystemet-react';
+import { Heading, Paragraph } from '@digdir/designsystemet-react';
 import { useTranslation } from 'react-i18next';
 import { useRef, useState } from 'react';
 
@@ -28,6 +28,7 @@ export const ReporteeRoleSection = ({ numberOfAccesses }: ReporteeRoleSectionPro
       >
         {t('role.current_roles_title', { count: numberOfAccesses })}
       </Heading>
+      <Paragraph data-size='sm'>{t('role.roles_description')}</Paragraph>
       <RoleList
         onSelect={(role) => {
           setModalItem(role);

--- a/src/features/amUI/userRightsPage/RoleSection/RoleSection.tsx
+++ b/src/features/amUI/userRightsPage/RoleSection/RoleSection.tsx
@@ -1,6 +1,6 @@
 import { useParams } from 'react-router';
 import { useRef, useState } from 'react';
-import { Heading } from '@digdir/designsystemet-react';
+import { Heading, Paragraph } from '@digdir/designsystemet-react';
 import { useTranslation } from 'react-i18next';
 
 import type { Role } from '@/rtk/features/roleApi';
@@ -36,7 +36,7 @@ export const RoleSection = ({ numberOfAccesses }: RoleSectionProps) => {
       >
         {t('role.current_roles_title', { count: numberOfAccesses })}
       </Heading>
-
+      <Paragraph data-size='sm'>{t('role.roles_description')}</Paragraph>
       <RoleList
         availableActions={[
           isCurrentUser ? DelegationAction.REQUEST : DelegationAction.DELEGATE,

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -263,6 +263,7 @@
   },
   "role": {
     "current_roles_title": "{{count}} administrator accesses",
+    "roles_description": "This access area includes the powers to manage access for the business. No resources or services are linked to this access.",
     "role_delegation_success": "{{name}} has been successfully granted power of attorney over {{role}}.",
     "role_delegation_error": "Failed to grant power of attorney over {{role}} to {{name}}.",
     "role_deletion_success": "Power of attorney over {{role}} has been successfully revoked for {{name}}.",

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -307,7 +307,7 @@
     "edit_success": "The power of attorney was updated",
     "package_services": "Grants access to {{count}} services",
     "inherited_role_org_message": "<b>{{user_name}}</b> has access to this through their role in <b>{{org_name}}</b>. Therefore, it cannot be deleted.",
-    "delegation_check_not_delegable": "You cannot grant this access package because you  lack access yourself.",
+    "delegation_check_not_delegable": "You cannot grant this access package because you lack access yourself.",
     "specific_rights": {
       "missing_role_message": "You cannot delegate the entire service because you lack some of the rights yourself. The general manager or chief administrator can grant you access.",
       "missing_srr_right_message": "{{reportee}} is not given permission from {{resourceOwner}} to delegate the whole service. Contact them if you want to change this."

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -263,7 +263,7 @@
   },
   "role": {
     "current_roles_title": "{{count}} administrator accesses",
-    "roles_description": "This access area includes the powers to manage access for the business. No resources or services are linked to this access.",
+    "roles_description": "This access area includes the powers to manage access for your business. No resources or services are linked to this access.",
     "role_delegation_success": "{{name}} has been successfully granted power of attorney over {{role}}.",
     "role_delegation_error": "Failed to grant power of attorney over {{role}} to {{name}}.",
     "role_deletion_success": "Power of attorney over {{role}} has been successfully revoked for {{name}}.",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -262,6 +262,7 @@
   },
   "role": {
     "current_roles_title": "{{count}} administratortilganger",
+    "roles_description": "Dette fullmaktsområdet omfatter fullmakter til å administrere tilganger for virksomheten. Det er ikke knyttet noen ressurser eller tjenester til disse tilgangene.",
     "role_delegation_success": "{{name}} har nå fått fullmakt til {{role}}.",
     "role_delegation_error": "Det var ikke mulig å gi {{name}} fullmakt til {{role}}.",
     "role_deletion_success": "Fullmakten til {{role}} er fjernet fra {{name}}.",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -259,6 +259,7 @@
   },
   "role": {
     "current_roles_title": "{{count}} administratortilganger",
+    "roles_description": "Dette fullmaktsområdet omfattar fullmakter til å administrere tilgangar for verksemda. Det er ikkje knytt nokre ressursar eller tenester til desse tilgangane.",
     "role_delegation_success": "{{name}} har nå fått fullmakt til {{role}}.",
     "role_delegation_error": "Det var ikke mulig å gi {{name}} fullmakt til {{role}}.",
     "role_deletion_success": "Fullmakten til {{role}} er fjernet fra {{name}}.",

--- a/src/resources/hooks/useAccessPackageDelegationCheck.ts
+++ b/src/resources/hooks/useAccessPackageDelegationCheck.ts
@@ -15,7 +15,7 @@ export const useAccessPackageDelegationCheck = (
   shouldShowDelegationCheck: boolean,
   handleDelegationCheckFailure: (error: ActionError) => void,
 ) => {
-  const [delegationCheck, { isLoading, data }] = useDelegationCheckMutation();
+  const [delegationCheck, { isLoading, data, isUninitialized }] = useDelegationCheckMutation();
 
   useEffect(() => {
     if (accessPackageIds.length > 0 && shouldShowDelegationCheck) {
@@ -39,5 +39,5 @@ export const useAccessPackageDelegationCheck = (
   const canDelegate = (id: string) =>
     !isLoading && data?.find((d) => d.packageId === id)?.canDelegate;
 
-  return { canDelegate, isLoading };
+  return { canDelegate, isLoading: isLoading || isUninitialized };
 };

--- a/src/resources/hooks/useAccessPackageDelegationCheck.ts
+++ b/src/resources/hooks/useAccessPackageDelegationCheck.ts
@@ -39,5 +39,5 @@ export const useAccessPackageDelegationCheck = (
   const canDelegate = (id: string) =>
     !isLoading && data?.find((d) => d.packageId === id)?.canDelegate;
 
-  return { canDelegate, isLoading: isLoading || isUninitialized };
+  return { canDelegate, isLoading, isUninitialized };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,18 +19,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@altinn/altinn-components@npm:0.22.8":
-  version: 0.22.8
-  resolution: "@altinn/altinn-components@npm:0.22.8"
+"@altinn/altinn-components@npm:0.23.3":
+  version: 0.23.3
+  resolution: "@altinn/altinn-components@npm:0.23.3"
   dependencies:
     "@navikt/aksel-icons": "npm:^7.9.2"
+    "@tanstack/react-virtual": "npm:^3.13.4"
     classnames: "npm:^2.5.1"
     react: "npm:^19.0.0"
     react-dom: "npm:^19.0.0"
   peerDependencies:
     react: ">=18.3.1 || ^19.0.0"
     react-dom: ">=18.3.1 || ^19.0.0"
-  checksum: 10/a7f37ffa909b8d9a69dfb8b9caa9debad59c11574517aeb347552d4411f9a7c97ab5f1359d3bd6596f6069db93251ffaca2b648d3e071fde89aa71e11f252a34
+  checksum: 10/93b8706c6a2afa3d1271af68f1d77a7c06346ffb52db92a0c16ba69c86b6e0ffb043634518a5d7e2c8f34de07ebb303f407b80594eaccd6a13a43ee0e0770118
   languageName: node
   linkType: hard
 
@@ -2206,10 +2207,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tanstack/react-virtual@npm:^3.13.4":
+  version: 3.13.6
+  resolution: "@tanstack/react-virtual@npm:3.13.6"
+  dependencies:
+    "@tanstack/virtual-core": "npm:3.13.6"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10/4500088f7719a5a6241f4fcf24074a2fa8cb54d9c5c50786e909e87aee98af2ac0c1513139984c388e97e8ddb65d108390d39083b0b793fbfd343976f13447c4
+  languageName: node
+  linkType: hard
+
 "@tanstack/virtual-core@npm:3.13.2":
   version: 3.13.2
   resolution: "@tanstack/virtual-core@npm:3.13.2"
   checksum: 10/b051409c613530514be5d841a2c0d10cb31326c728a90fd79b0bb489d61e2114234fcb6452ac331d5d1b624b0663693fd7c5d9b6fa3bf5035aadf66007f0c1e5
+  languageName: node
+  linkType: hard
+
+"@tanstack/virtual-core@npm:3.13.6":
+  version: 3.13.6
+  resolution: "@tanstack/virtual-core@npm:3.13.6"
+  checksum: 10/f6fc9e902077e68fcfc2fe936fcd90c89b128b1fca206d7e1d71bea0cf351994c11685a2aedeb9c9305596a1bc77ac9ef27eb889a2b348fcfbfa80dd608bb73c
   languageName: node
   linkType: hard
 
@@ -3065,7 +3085,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "access-management@workspace:."
   dependencies:
-    "@altinn/altinn-components": "npm:0.22.8"
+    "@altinn/altinn-components": "npm:0.23.3"
     "@axe-core/playwright": "npm:^4.10.1"
     "@digdir/designsystemet-css": "npm:1.0.2"
     "@digdir/designsystemet-react": "npm:1.0.2"


### PR DESCRIPTION
- Add warning icon to access-package list if delegation-check returns "not-allowed
- fix bug where error-message was not reset when modal was closed.  

## Related Issue(s)
- #[1364](https://github.com/Altinn/altinn-access-management-frontend/issues/1364) 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Streamlined access package management with enhanced controls for delegating and revoking access, featuring responsive feedback during action processing.
  - Added new descriptions for roles in localization files to provide clearer context for users.

- **Bug Fixes**
  - Improved the clarity of delegation notification messages through minor text corrections.

- **Chores**
  - Updated a key third-party dependency to incorporate the latest improvements and bug fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->