### PR TITLE
Remove extra character caused by copy-paste

### DIFF
--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -526,7 +526,7 @@
     "assigned_customers_header": "Kunder tilknyttet systemtilgangen",
     "no_assigned_customers": "Denne systemtilgangen har ingen kunder",
     "access_package_single": "Fullmakt til 1 tilgangspakke",
-    "access_package_plural": "Fullmakt til {{accessPackageCount}} tilgangspakker`",
+    "access_package_plural": "Fullmakt til {{accessPackageCount}} tilgangspakker",
     "add_customers": "Legg til kunder",
     "edit_customers": "Legg til eller fjern kunder",
     "customer_search": "Søk etter kunde",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -525,7 +525,7 @@
     "assigned_customers_header": "Kunder tilknyttet systemtilgangen",
     "no_assigned_customers": "Denne systemtilgangen har ingen kunder",
     "access_package_single": "Fullmakt til 1 tilgangspakke",
-    "access_package_plural": "Fullmakt til {{accessPackageCount}} tilgangspakker`",
+    "access_package_plural": "Fullmakt til {{accessPackageCount}} tilgangspakker",
     "add_customers": "Legg til kunder",
     "edit_customers": "Legg til eller fjern kunder",
     "customer_search": "Søk etter kunde",


### PR DESCRIPTION
## Description
The character ` should not be in the translation files

## Related Issue(s)
- this PR

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected formatting issues in localized strings by removing unwanted characters, ensuring the proper display of plural labels for access packages in Norwegian.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->