### PR TITLE
Send partyUuid as query param instead of looking up partyuuid from partyid in registry

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/ClientInterfaces/IRegisterClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/ClientInterfaces/IRegisterClient.cs
@@ -19,15 +19,6 @@ namespace Altinn.AccessManagement.UI.Core.ClientInterfaces
                 Task<Party> GetPartyForOrganization(string organizationNumber);
 
                 /// <summary>
-                /// Looks up party information for an organization based on the partyId
-                /// </summary>
-                /// <param name="partyId">The partyId</param>
-                /// <returns>
-                /// Party information
-                /// </returns>
-                Task<Party> GetPartyByPartyId(int partyId);
-
-                /// <summary>
                 /// Looks up party information for a person based on the ssn
                 /// </summary>
                 /// <param name="ssn">The persons ssn</param>

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/Interfaces/ISystemUserAgentDelegationService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/Interfaces/ISystemUserAgentDelegationService.cs
@@ -1,4 +1,3 @@
-using Altinn.AccessManagement.UI.Core.Enums;
 using Altinn.AccessManagement.UI.Core.Models.SystemUser;
 using Altinn.AccessManagement.UI.Core.Models.SystemUser.Frontend;
 using Altinn.Authorization.ProblemDetails;
@@ -15,36 +14,40 @@ namespace Altinn.AccessManagement.UI.Core.Services.Interfaces
         /// </summary>
         /// <param name="partyId">The party id of the party owning system user</param>
         /// <param name="systemUserGuid">The system user UUID to get customers from</param>
+        /// <param name="partyUuid">The party uuid of the party owning system user</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>List of all systemuser customers</returns>
-        Task<Result<List<CustomerPartyFE>>> GetSystemUserCustomers(int partyId, Guid systemUserGuid, CancellationToken cancellationToken);
+        Task<Result<List<CustomerPartyFE>>> GetSystemUserCustomers(int partyId, Guid systemUserGuid, Guid partyUuid, CancellationToken cancellationToken);
 
         /// <summary>
         /// Return delegated customers for this system user
         /// </summary>
-        /// <param name="partyId">The party UUID of the party owning system user to retrieve delegated customers from</param>
+        /// <param name="partyId">The party id of the party owning system user to retrieve delegated customers from</param>
         /// <param name="systemUserGuid">The system user UUID to retrieve delegated customers from</param>
+        /// <param name="partyUuid">The party UUID of the party owning system user to retrieve delegated customers from</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>List of delegated customers for system user</returns>
-        Task<Result<List<AgentDelegationFE>>> GetSystemUserAgentDelegations(int partyId, Guid systemUserGuid, CancellationToken cancellationToken);
+        Task<Result<List<AgentDelegationFE>>> GetSystemUserAgentDelegations(int partyId, Guid systemUserGuid, Guid partyUuid, CancellationToken cancellationToken);
 
         /// <summary>
         /// Add client to system user
         /// </summary>
         /// <param name="partyId">The party id of the party owning system user to add customer to</param>
         /// <param name="systemUserGuid">The system user UUID to add customer to</param>
+        /// <param name="partyUuid">The party uuid of the party owning system user to add customer to</param>
         /// <param name="delegationRequestFe">Payload to send to add client</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>AgentDelegationFE with assignment id and customer id</returns>
-        Task<Result<AgentDelegationFE>> AddClient(int partyId, Guid systemUserGuid, AgentDelegationRequestFE delegationRequestFe, CancellationToken cancellationToken);
+        Task<Result<AgentDelegationFE>> AddClient(int partyId, Guid systemUserGuid, Guid partyUuid, AgentDelegationRequestFE delegationRequestFe, CancellationToken cancellationToken);
 
         /// <summary>
         /// Remove client from system user
         /// </summary>
         /// <param name="partyId">The party id of the party owning system user to remove customer from</param>
         /// <param name="delegationId">The delegation id to remove</param>
+        /// <param name="partyUuid">The party uuid of the party owning system user to remove customer from</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Boolean result of remove</returns>
-        Task<Result<bool>> RemoveClient(int partyId, Guid delegationId, CancellationToken cancellationToken);
+        Task<Result<bool>> RemoveClient(int partyId, Guid delegationId, Guid partyUuid, CancellationToken cancellationToken);
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/Interfaces/ISystemUserService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/Interfaces/ISystemUserService.cs
@@ -50,11 +50,12 @@ namespace Altinn.AccessManagement.UI.Core.Services.Interfaces
         /// <summary>
         /// Deletes agent system user
         /// </summary>
-        /// <param name="partyId">The party Id of the party to retrieve</param>
+        /// <param name="partyId">The party Id of the party</param>
         /// <param name="systemUserId">Id of system user to delete</param>
+        /// <param name="partyUuid">The party uuid of the party</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Boolean whether delete was successful or not</returns>
-        Task<Result<bool>> DeleteAgentSystemUser(int partyId, Guid systemUserId, CancellationToken cancellationToken);
+        Task<Result<bool>> DeleteAgentSystemUser(int partyId, Guid systemUserId, Guid partyUuid, CancellationToken cancellationToken);
 
         /// <summary>
         /// Create a new system user

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/SystemUserService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/SystemUserService.cs
@@ -85,15 +85,9 @@ namespace Altinn.AccessManagement.UI.Core.Services
         }
 
         /// <inheritdoc />
-        public async Task<Result<bool>> DeleteAgentSystemUser(int partyId, Guid systemUserId, CancellationToken cancellationToken)
+        public async Task<Result<bool>> DeleteAgentSystemUser(int partyId, Guid systemUserId, Guid partyUuid, CancellationToken cancellationToken)
         {
-            Party party = await _registerClient.GetPartyByPartyId(partyId);
-            if (party == null || party.PartyUuid == null)
-            {
-                return Problem.Reportee_Orgno_NotFound;
-            }
-
-            return await _systemUserClient.DeleteAgentSystemUser(partyId, systemUserId, (Guid)party.PartyUuid, cancellationToken);
+            return await _systemUserClient.DeleteAgentSystemUser(partyId, systemUserId, partyUuid, cancellationToken);
         }
 
         /// <inheritdoc />

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/RegisterClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/RegisterClient.cs
@@ -88,33 +88,6 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
         }
 
         /// <inheritdoc/>
-        public async Task<Party> GetPartyByPartyId(int partyId)
-        {
-            try
-            {
-                string endpointUrl = $"parties/{partyId}";
-                string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
-                var accessToken = await _accessTokenProvider.GetAccessToken();
-
-                HttpResponseMessage response = await _client.GetAsync(token, endpointUrl, accessToken);
-                string responseContent = await response.Content.ReadAsStringAsync();
-
-                if (response.StatusCode == HttpStatusCode.OK)
-                {
-                    return JsonSerializer.Deserialize<Party>(responseContent, _serializerOptions);
-                }
-
-                _logger.LogError("AccessManagement.UI // RegisterClient // GetPartyByPartyId // Unexpected HttpStatusCode: {StatusCode}\n {responseBody}", response.StatusCode, responseContent);
-                return null;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "AccessManagement.UI // RegisterClient // GetPartyByPartyId // Exception");
-                throw;
-            }
-        }
-
-        /// <inheritdoc/>
         public async Task<Party> GetPartyForPerson(string ssn)
         {
             string endpointUrl = $"parties/lookup";

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/RegisterClientMock.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/RegisterClientMock.cs
@@ -42,21 +42,6 @@ namespace Altinn.AccessManagement.UI.Mocks.Mocks
         }
 
         /// <inheritdoc/>
-        public Task<Party> GetPartyByPartyId(int partyId)
-        {
-            Party party = null;
-            string testDataPath = Path.Combine(Path.GetDirectoryName(new Uri(typeof(RegisterClientMock).Assembly.Location).LocalPath), "Data", "Register", "Parties", "parties.json");
-            if (File.Exists(testDataPath))
-            {
-                string content = File.ReadAllText(testDataPath);
-                List<Party> partyList = JsonSerializer.Deserialize<List<Party>>(content);
-                party = partyList?.FirstOrDefault(p => p.PartyId == partyId);
-            }
-
-            return Task.FromResult(party);
-        }
-
-        /// <inheritdoc/>
         public Task<List<Party>> GetPartyList(List<Guid> uuidList)
         {
             string testDataPath = Path.Combine(Path.GetDirectoryName(new Uri(typeof(RegisterClientMock).Assembly.Location).LocalPath), "Data", "Register", "Parties", "parties.json");

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/SystemUserAgentDelegationControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/SystemUserAgentDelegationControllerTest.cs
@@ -44,12 +44,13 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         {
             // Arrange
             string partyId = "51329012";
+            string partyUuid = "cd35779b-b174-4ecc-bbef-ece13611be7f";
             string systemUserId = _regnskapsforerSystemUserId;
             string path = Path.Combine(_expectedDataPath, "SystemUser", "regnskapsforerCustomers.json");
             List<CustomerPartyFE> expectedResponse = Util.GetMockData<List<CustomerPartyFE>>(path);
 
             // Act
-            HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/customers");
+            HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/customers?partyuuid={partyUuid}");
             List<CustomerPartyFE> actualResponse = await httpResponse.Content.ReadFromJsonAsync<List<CustomerPartyFE>>();
 
             // Assert
@@ -66,12 +67,13 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         {
             // Arrange
             string partyId = "51329012";
+            string partyUuid = "cd35779b-b174-4ecc-bbef-ece13611be7f";
             string systemUserId = _revisorSystemUserId;
             string path = Path.Combine(_expectedDataPath, "SystemUser", "revisorCustomers.json");
             List<CustomerPartyFE> expectedResponse = Util.GetMockData<List<CustomerPartyFE>>(path);
 
             // Act
-            HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/customers");
+            HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/customers?partyuuid={partyUuid}");
             List<CustomerPartyFE> actualResponse = await httpResponse.Content.ReadFromJsonAsync<List<CustomerPartyFE>>();
 
             // Assert
@@ -88,36 +90,18 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         {
             // Arrange
             string partyId = "51329012";
+            string partyUuid = "cd35779b-b174-4ecc-bbef-ece13611be7f";
             string systemUserId = _forretningsforerSystemUserId;
             string path = Path.Combine(_expectedDataPath, "SystemUser", "forretningsforerCustomers.json");
             List<CustomerPartyFE> expectedResponse = Util.GetMockData<List<CustomerPartyFE>>(path);
 
             // Act
-            HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/customers");
+            HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/customers?partyuuid={partyUuid}");
             List<CustomerPartyFE> actualResponse = await httpResponse.Content.ReadFromJsonAsync<List<CustomerPartyFE>>();
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, httpResponse.StatusCode);
             AssertionUtil.AssertCollections(expectedResponse, actualResponse, AssertionUtil.AssertEqual);
-        }
-
-        /// <summary>
-        ///     Test case: GetForretningsforerCustomers checks that customers are returned
-        ///     Expected: GetForretningsforerCustomers returns customers
-        /// </summary>
-        [Fact]
-        public async Task GetForretningsforerCustomers_WrongPartyId_ReturnsBadRequest()
-        {
-            // Arrange
-            string partyId = "411111111";
-            string systemUserId = _forretningsforerSystemUserId;
-            HttpStatusCode expectedResponse = HttpStatusCode.BadRequest;
-
-            // Act
-            HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/customers");
-
-            // Assert
-            Assert.Equal(expectedResponse, httpResponse.StatusCode);
         }
 
         /// <summary>
@@ -129,12 +113,13 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         {
             // Arrange
             string partyId = "51329012";
+            string partyUuid = "cd35779b-b174-4ecc-bbef-ece13611be7f";
             string systemUserId = _regnskapsforerSystemUserId;
             string path = Path.Combine(_expectedDataPath, "SystemUser", "regnskapsforerAgentDelegations.json");
             List<AgentDelegationFE> expectedResponse = Util.GetMockData<List<AgentDelegationFE>>(path);
 
             // Act
-            HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/delegation");
+            HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/delegation?partyuuid={partyUuid}");
             List<AgentDelegationFE> actualResponse = await httpResponse.Content.ReadFromJsonAsync<List<AgentDelegationFE>>();
 
             // Assert
@@ -151,12 +136,13 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         {
             // Arrange
             string partyId = "51329012";
+            string partyUuid = "cd35779b-b174-4ecc-bbef-ece13611be7f";
             string systemUserId = _revisorSystemUserId;
             string path = Path.Combine(_expectedDataPath, "SystemUser", "revisorAgentDelegations.json");
             List<AgentDelegationFE> expectedResponse = Util.GetMockData<List<AgentDelegationFE>>(path);
 
             // Act
-            HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/delegation");
+            HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/delegation?partyuuid={partyUuid}");
             List<AgentDelegationFE> actualResponse = await httpResponse.Content.ReadFromJsonAsync<List<AgentDelegationFE>>();
 
             // Assert
@@ -173,36 +159,18 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         {
             // Arrange
             string partyId = "51329012";
+            string partyUuid = "cd35779b-b174-4ecc-bbef-ece13611be7f";
             string systemUserId = _forretningsforerSystemUserId;
             string path = Path.Combine(_expectedDataPath, "SystemUser", "forretningsforerAgentDelegations.json");
             List<AgentDelegationFE> expectedResponse = Util.GetMockData<List<AgentDelegationFE>>(path);
 
             // Act
-            HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/delegation");
+            HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/delegation?partyuuid={partyUuid}");
             List<AgentDelegationFE> actualResponse = await httpResponse.Content.ReadFromJsonAsync<List<AgentDelegationFE>>();
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, httpResponse.StatusCode);
             AssertionUtil.AssertCollections(expectedResponse, actualResponse, AssertionUtil.AssertEqual);
-        }
-
-        /// <summary>
-        ///     Test case: GetForretningsforerAgentDelegation checks that delegated forretningsforer customers are returned
-        ///     Expected: GetForretningsforerAgentDelegation returns delegations
-        /// </summary>
-        [Fact]
-        public async Task GetForretningsforerAgentDelegation_WrongPartyId_ReturnsBadRequest()
-        {
-            // Arrange
-            string partyId = "411111111";
-            string systemUserId = _forretningsforerSystemUserId;
-            HttpStatusCode expectedResponse = HttpStatusCode.BadRequest;
-
-            // Act
-            HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/delegation");
-
-            // Assert
-            Assert.Equal(expectedResponse, httpResponse.StatusCode);
         }
 
         /// <summary>
@@ -214,6 +182,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         {
             // Arrange
             string partyId = "51329012";
+            string partyUuid = "cd35779b-b174-4ecc-bbef-ece13611be7f";
             string systemUserId = _regnskapsforerSystemUserId;
             string customerId = "6b0574ae-f569-4c0d-a8d4-8ad56f427890";
             
@@ -231,7 +200,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             };
 
             // Act
-            HttpResponseMessage httpResponse = await _client.PostAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/delegation", content);
+            HttpResponseMessage httpResponse = await _client.PostAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/delegation?partyuuid={partyUuid}", content);
             AgentDelegationFE actualResponse = await httpResponse.Content.ReadFromJsonAsync<AgentDelegationFE>();
 
             // Assert
@@ -248,6 +217,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         {
             // Arrange
             string partyId = "51329012";
+            string partyUuid = "cd35779b-b174-4ecc-bbef-ece13611be7f";
             string systemUserId = _revisorSystemUserId;
             string customerId = "cd35779b-b174-4ecc-bbef-ece13611be7f";
             
@@ -265,7 +235,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             };
 
             // Act
-            HttpResponseMessage httpResponse = await _client.PostAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/delegation", content);
+            HttpResponseMessage httpResponse = await _client.PostAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/delegation?partyuuid={partyUuid}", content);
             AgentDelegationFE actualResponse = await httpResponse.Content.ReadFromJsonAsync<AgentDelegationFE>();
 
             // Assert
@@ -282,6 +252,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         {
             // Arrange
             string partyId = "51329012";
+            string partyUuid = "cd35779b-b174-4ecc-bbef-ece13611be7f";
             string systemUserId = _regnskapsforerSystemUserId;
             string customerId = "82cc64c5-60ff-4184-8c07-964c3a1e6fc7";
             
@@ -295,35 +266,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             HttpStatusCode expectedResponse = HttpStatusCode.NotFound;
 
             // Act
-            HttpResponseMessage httpResponse = await _client.PostAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/delegation", content);
-
-            // Assert
-            Assert.Equal(expectedResponse, httpResponse.StatusCode);
-        }
-
-        /// <summary>
-        ///     Test case: PostRegnskapsforerAgentDelegation checks error handling for invalid delegations
-        ///     Expected: PostRegnskapsforerAgentDelegation returns BadRequest error
-        /// </summary>
-        [Fact]
-        public async Task PostRegnskapsforerAgentDelegation_WrongPartyId_ReturnBadRequest()
-        {
-            // Arrange
-            string partyId = "411111111";
-            string systemUserId = _regnskapsforerSystemUserId;
-            string customerId = "82cc64c5-60ff-4184-8c07-964c3a1e6fc7";
-            
-            AgentDelegationRequestFE dto = new AgentDelegationRequestFE
-            {
-                CustomerId = Guid.Parse(customerId),
-            };
-            string jsonDto = JsonSerializer.Serialize(dto);
-            HttpContent content = new StringContent(jsonDto, Encoding.UTF8, "application/json");
-
-            HttpStatusCode expectedResponse = HttpStatusCode.BadRequest;
-
-            // Act
-            HttpResponseMessage httpResponse = await _client.PostAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/delegation", content);
+            HttpResponseMessage httpResponse = await _client.PostAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/delegation?partyuuid={partyUuid}", content);
 
             // Assert
             Assert.Equal(expectedResponse, httpResponse.StatusCode);
@@ -338,13 +281,14 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         {
             // Arrange
             string partyId = "51329012";
+            string partyUuid = "cd35779b-b174-4ecc-bbef-ece13611be7f";
             string systemUserId = _regnskapsforerSystemUserId;
             string delegationId = "7da509f3-cff5-4253-946e-0336ae0bc48f";
             
             bool expectedResponse = true;
 
             // Act
-            HttpResponseMessage httpResponse = await _client.DeleteAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/delegation/{delegationId}");
+            HttpResponseMessage httpResponse = await _client.DeleteAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/delegation/{delegationId}?partyuuid={partyUuid}");
             bool actualResponse = await httpResponse.Content.ReadFromJsonAsync<bool>();
 
             // Assert
@@ -361,34 +305,14 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         {
             // Arrange
             string partyId = "51329012";
+            string partyUuid = "cd35779b-b174-4ecc-bbef-ece13611be7f";
             string systemUserId = _regnskapsforerSystemUserId;
             string delegationId = "60f1ade9-ed48-4083-a369-178d45d6ffd1";
             
             HttpStatusCode expectedResponse = HttpStatusCode.NotFound;
 
             // Act
-            HttpResponseMessage httpResponse = await _client.DeleteAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/delegation/{delegationId}");
-
-            // Assert
-            Assert.Equal(expectedResponse, httpResponse.StatusCode);
-        }
-
-        /// <summary>
-        ///     Test case: DeleteRegnskapsforerAgentDelegation checks error handling for non-existent delegations
-        ///     Expected: DeleteRegnskapsforerAgentDelegation returns BadRequest error
-        /// </summary>
-        [Fact]
-        public async Task DeleteRegnskapsforerAgentDelegation_WrongPartyId_ReturnsBadRequest()
-        {
-            // Arrange
-            string partyId = "41111111";
-            string systemUserId = _regnskapsforerSystemUserId;
-            string delegationId = "7da509f3-cff5-4253-946e-0336ae0bc48f";
-            
-            HttpStatusCode expectedResponse = HttpStatusCode.BadRequest;
-
-            // Act
-            HttpResponseMessage httpResponse = await _client.DeleteAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/delegation/{delegationId}");
+            HttpResponseMessage httpResponse = await _client.DeleteAsync($"accessmanagement/api/v1/systemuser/agentdelegation/{partyId}/{systemUserId}/delegation/{delegationId}?partyuuid={partyUuid}");
 
             // Assert
             Assert.Equal(expectedResponse, httpResponse.StatusCode);

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/SystemUserControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/SystemUserControllerTest.cs
@@ -261,10 +261,11 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             // Arrange
             int partyId = 51329012;
             string systemUserId = "61844188-3789-4b84-9314-2be1fdbc6633";
+            string partyUuid = "cd35779b-b174-4ecc-bbef-ece13611be7f";
             HttpStatusCode expectedResponse = HttpStatusCode.Accepted;
 
             // Act
-            HttpResponseMessage httpResponse = await _client.DeleteAsync($"accessmanagement/api/v1/systemuser/agent/{partyId}/{systemUserId}");
+            HttpResponseMessage httpResponse = await _client.DeleteAsync($"accessmanagement/api/v1/systemuser/agent/{partyId}/{systemUserId}?partyuuid={partyUuid}");
 
             // Assert
             Assert.Equal(expectedResponse, httpResponse.StatusCode);
@@ -280,29 +281,11 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             // Arrange
             int partyId = 51329012;
             string systemUserId = "e60073ad-c661-4ca0-b74c-40238ad333e9";
+            string partyUuid = "cd35779b-b174-4ecc-bbef-ece13611be7f";
             HttpStatusCode expectedResponse = HttpStatusCode.NotFound;
 
             // Act
-            HttpResponseMessage httpResponse = await _client.DeleteAsync($"accessmanagement/api/v1/systemuser/agent/{partyId}/{systemUserId}");
-
-            // Assert
-            Assert.Equal(expectedResponse, httpResponse.StatusCode);
-        }
-
-        /// <summary>
-        ///     Test case: DeleteAgentSystemUser checks that agent system user with given id for given party is not deleted when it is not found
-        ///     Expected: DeleteAgentSystemUser returns bad requst
-        /// </summary>
-        [Fact]
-        public async Task DeleteAgentSystemUser_WrongPartyId_ReturnsBadRequest()
-        {
-            // Arrange
-            int partyId = 411111111;
-            string systemUserId = "e60073ad-c661-4ca0-b74c-40238ad333e9";
-            HttpStatusCode expectedResponse = HttpStatusCode.BadRequest;
-
-            // Act
-            HttpResponseMessage httpResponse = await _client.DeleteAsync($"accessmanagement/api/v1/systemuser/agent/{partyId}/{systemUserId}");
+            HttpResponseMessage httpResponse = await _client.DeleteAsync($"accessmanagement/api/v1/systemuser/agent/{partyId}/{systemUserId}?partyuuid={partyUuid}");
 
             // Assert
             Assert.Equal(expectedResponse, httpResponse.StatusCode);

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/SystemUserAgentDelegationController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/SystemUserAgentDelegationController.cs
@@ -31,13 +31,14 @@ namespace Altinn.AccessManagement.UI.Controllers
         /// </summary>
         /// <param name="partyId">Party user represents</param>
         /// <param name="systemUserGuid">System user to get customers from</param>
+        /// <param name="partyUuid">Party uuid of party user represents</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>List of customer party</returns>
         [Authorize]
         [HttpGet("{partyId}/{systemUserGuid}/customers")]
-        public async Task<ActionResult> GetSystemUserCustomers([FromRoute] int partyId,  [FromRoute] Guid systemUserGuid, CancellationToken cancellationToken)
+        public async Task<ActionResult> GetSystemUserCustomers([FromRoute] int partyId, [FromRoute] Guid systemUserGuid, [FromQuery] Guid partyUuid, CancellationToken cancellationToken)
         {
-            Result<List<CustomerPartyFE>> result = await _systemUserAgentDelegationService.GetSystemUserCustomers(partyId, systemUserGuid, cancellationToken);
+            Result<List<CustomerPartyFE>> result = await _systemUserAgentDelegationService.GetSystemUserCustomers(partyId, systemUserGuid, partyUuid, cancellationToken);
             if (result.IsProblem)
             {
                 return result.Problem.ToActionResult();
@@ -51,13 +52,14 @@ namespace Altinn.AccessManagement.UI.Controllers
         /// </summary>
         /// <param name="partyId">Party user represents</param>
         /// <param name="systemUserGuid">System user id to get</param> 
+        /// <param name="partyUuid">Party uuid of party user represents</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns></returns>
         [Authorize]
         [HttpGet("{partyId}/{systemUserGuid}/delegation")]
-        public async Task<ActionResult> GetSystemUserAgentDelegations([FromRoute] int partyId, [FromRoute] Guid systemUserGuid, CancellationToken cancellationToken)
+        public async Task<ActionResult> GetSystemUserAgentDelegations([FromRoute] int partyId, [FromRoute] Guid systemUserGuid, [FromQuery] Guid partyUuid, CancellationToken cancellationToken)
         {
-            Result<List<AgentDelegationFE>> result = await _systemUserAgentDelegationService.GetSystemUserAgentDelegations(partyId, systemUserGuid, cancellationToken);
+            Result<List<AgentDelegationFE>> result = await _systemUserAgentDelegationService.GetSystemUserAgentDelegations(partyId, systemUserGuid, partyUuid, cancellationToken);
             if (result.IsProblem)
             {
                 return result.Problem.ToActionResult();
@@ -71,14 +73,15 @@ namespace Altinn.AccessManagement.UI.Controllers
         /// </summary>
         /// <param name="partyId">Party id user represents</param>
         /// <param name="systemUserGuid">System user id to get</param>
+        /// <param name="partyUuid">Party uuid of party user represents</param>
         /// <param name="delegationRequestFe">Payload to send to add client</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns></returns>
         [Authorize]
         [HttpPost("{partyId}/{systemUserGuid}/delegation")]
-        public async Task<ActionResult> AddClient([FromRoute] int partyId, [FromRoute] Guid systemUserGuid, [FromBody] AgentDelegationRequestFE delegationRequestFe, CancellationToken cancellationToken)
+        public async Task<ActionResult> AddClient([FromRoute] int partyId, [FromRoute] Guid systemUserGuid, [FromQuery] Guid partyUuid, [FromBody] AgentDelegationRequestFE delegationRequestFe, CancellationToken cancellationToken)
         {
-            Result<AgentDelegationFE> result = await _systemUserAgentDelegationService.AddClient(partyId, systemUserGuid, delegationRequestFe, cancellationToken);
+            Result<AgentDelegationFE> result = await _systemUserAgentDelegationService.AddClient(partyId, systemUserGuid, partyUuid, delegationRequestFe, cancellationToken);
 
             if (result.IsProblem)
             {
@@ -94,13 +97,14 @@ namespace Altinn.AccessManagement.UI.Controllers
         /// <param name="partyId">Party user represents</param>
         /// <param name="systemUserGuid">System user id to get</param>
         /// <param name="delegationId">Delegation id to remove from system user</param>
+        /// <param name="partyUuid">Party uuid of party user represents</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns></returns>
         [Authorize]
         [HttpDelete("{partyId}/{systemUserGuid}/delegation/{delegationId}")]
-        public async Task<ActionResult> RemoveClient([FromRoute] int partyId, [FromRoute] Guid systemUserGuid, [FromRoute] Guid delegationId, CancellationToken cancellationToken)
+        public async Task<ActionResult> RemoveClient([FromRoute] int partyId, [FromRoute] Guid systemUserGuid, [FromRoute] Guid delegationId, [FromQuery] Guid partyUuid, CancellationToken cancellationToken)
         {
-            Result<bool> result = await _systemUserAgentDelegationService.RemoveClient(partyId, delegationId, cancellationToken);
+            Result<bool> result = await _systemUserAgentDelegationService.RemoveClient(partyId, delegationId, partyUuid, cancellationToken);
 
             if (result.IsProblem)
             {

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/SystemUserController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/SystemUserController.cs
@@ -131,14 +131,15 @@ namespace Altinn.AccessManagement.UI.Controllers
         /// </summary>
         /// <param name="partyId">Party user represents</param>
         /// <param name="systemUserGuid">System user id to delete</param>
+        /// <param name="partyUuid">Party uuid of party user represents</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns></returns>
         [Authorize]
         [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
         [HttpDelete("agent/{partyId}/{systemUserGuid}")]
-        public async Task<ActionResult> DeleteAgentSystemUser([FromRoute] int partyId, [FromRoute] Guid systemUserGuid, CancellationToken cancellationToken)
+        public async Task<ActionResult> DeleteAgentSystemUser([FromRoute] int partyId, [FromRoute] Guid systemUserGuid, [FromQuery] Guid partyUuid, CancellationToken cancellationToken)
         {
-            Result<bool> result = await _systemUserService.DeleteAgentSystemUser(partyId, systemUserGuid, cancellationToken);
+            Result<bool> result = await _systemUserService.DeleteAgentSystemUser(partyId, systemUserGuid, partyUuid, cancellationToken);
             if (result.IsProblem)
             {
                 return result.Problem.ToActionResult(); 

--- a/src/features/amUI/systemUser/SystemUserAgentDelegationPage/CustomerList.tsx
+++ b/src/features/amUI/systemUser/SystemUserAgentDelegationPage/CustomerList.tsx
@@ -21,7 +21,7 @@ const filterCustomerList = (
   });
 };
 
-const itemsPerPage = 10;
+const itemsPerPage = 5;
 const showPages = 7;
 
 interface CustomerListProps {

--- a/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPage.tsx
@@ -19,6 +19,7 @@ export const SystemUserAgentDelegationPage = (): React.ReactNode => {
   const { id } = useParams();
   const { t } = useTranslation();
   const partyId = getCookie('AltinnPartyId');
+  const partyUuid = getCookie('AltinnPartyUuid');
 
   useDocumentTitle(t('systemuser_agent_delegation.page_title'));
 
@@ -32,7 +33,7 @@ export const SystemUserAgentDelegationPage = (): React.ReactNode => {
     data: customers,
     isError: isLoadCustomersError,
     isLoading: isLoadingCustomers,
-  } = useGetCustomersQuery({ partyId, systemUserId: id ?? '' });
+  } = useGetCustomersQuery({ partyId, systemUserId: id ?? '', partyUuid });
 
   const {
     data: agentDelegations,
@@ -41,6 +42,7 @@ export const SystemUserAgentDelegationPage = (): React.ReactNode => {
   } = useGetAssignedCustomersQuery({
     partyId: partyId,
     systemUserId: id || '',
+    partyUuid,
   });
 
   return (

--- a/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPageContent.tsx
+++ b/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPageContent.tsx
@@ -43,6 +43,7 @@ export const SystemUserAgentDelegationPageContent = ({
   const navigate = useNavigate();
   const { t } = useTranslation();
   const partyId = getCookie('AltinnPartyId');
+  const partyUuid = getCookie('AltinnPartyUuid');
 
   const { id } = useParams();
   const modalRef = useRef<HTMLDialogElement>(null);
@@ -60,7 +61,7 @@ export const SystemUserAgentDelegationPageContent = ({
     useDeleteAgentSystemuserMutation();
 
   const handleDeleteSystemUser = (): void => {
-    deleteAgentSystemUser({ partyId, systemUserId: id || '' })
+    deleteAgentSystemUser({ partyId, systemUserId: id || '', partyUuid })
       .unwrap()
       .then(() => handleNavigateBack());
   };
@@ -85,7 +86,7 @@ export const SystemUserAgentDelegationPageContent = ({
     const onAddSuccess = (delegation: AgentDelegation) => {
       setDelegations((oldDelegations) => [...oldDelegations, delegation]);
     };
-    assignCustomer({ partyId, systemUserId: id ?? '', customerId: customerId })
+    assignCustomer({ partyId, systemUserId: id ?? '', customerId: customerId, partyUuid })
       .unwrap()
       .then(onAddSuccess)
       .catch(() => setErrorId(customerId))
@@ -103,6 +104,7 @@ export const SystemUserAgentDelegationPageContent = ({
       partyId,
       systemUserId: id ?? '',
       delegationId: toRemove.delegationId,
+      partyUuid,
     })
       .unwrap()
       .then(onRemoveSuccess)

--- a/src/rtk/features/systemUserApi.ts
+++ b/src/rtk/features/systemUserApi.ts
@@ -83,34 +83,37 @@ export const systemUserApi = createApi({
     getAgentSystemUser: builder.query<SystemUser, { partyId: string; systemUserId: string }>({
       query: ({ partyId, systemUserId }) => `systemuser/agent/${partyId}/${systemUserId}`,
     }),
-    deleteAgentSystemuser: builder.mutation<void, { partyId: string; systemUserId: string }>({
-      query: ({ partyId, systemUserId }) => ({
-        url: `systemuser/agent/${partyId}/${systemUserId}`,
+    deleteAgentSystemuser: builder.mutation<
+      void,
+      { partyId: string; systemUserId: string; partyUuid: string }
+    >({
+      query: ({ partyId, systemUserId, partyUuid }) => ({
+        url: `systemuser/agent/${partyId}/${systemUserId}?partyuuid=${partyUuid}`,
         method: 'DELETE',
       }),
       invalidatesTags: [Tags.SystemUsers],
     }),
     getCustomers: builder.query<
       AgentDelegationCustomer[],
-      { partyId: string; systemUserId: string }
+      { partyId: string; systemUserId: string; partyUuid: string }
     >({
-      query: ({ partyId, systemUserId }) =>
-        `systemuser/agentdelegation/${partyId}/${systemUserId}/customers`,
+      query: ({ partyId, systemUserId, partyUuid }) =>
+        `systemuser/agentdelegation/${partyId}/${systemUserId}/customers?partyuuid=${partyUuid}`,
       keepUnusedDataFor: Infinity,
     }),
     getAssignedCustomers: builder.query<
       AgentDelegation[],
-      { partyId: string; systemUserId: string }
+      { partyId: string; systemUserId: string; partyUuid: string }
     >({
-      query: ({ partyId, systemUserId }) =>
-        `systemuser/agentdelegation/${partyId}/${systemUserId}/delegation`,
+      query: ({ partyId, systemUserId, partyUuid }) =>
+        `systemuser/agentdelegation/${partyId}/${systemUserId}/delegation?partyuuid=${partyUuid}`,
     }),
     assignCustomer: builder.mutation<
       AgentDelegation,
-      { partyId: string; systemUserId: string; customerId: string }
+      { partyId: string; systemUserId: string; customerId: string; partyUuid: string }
     >({
-      query: ({ partyId, systemUserId, customerId }) => ({
-        url: `systemuser/agentdelegation/${partyId}/${systemUserId}/delegation`,
+      query: ({ partyId, systemUserId, customerId, partyUuid }) => ({
+        url: `systemuser/agentdelegation/${partyId}/${systemUserId}/delegation?partyuuid=${partyUuid}`,
         method: 'POST',
         body: {
           customerId: customerId,
@@ -119,10 +122,10 @@ export const systemUserApi = createApi({
     }),
     removeCustomer: builder.mutation<
       void,
-      { partyId: string; systemUserId: string; delegationId: string }
+      { partyId: string; systemUserId: string; delegationId: string; partyUuid: string }
     >({
-      query: ({ partyId, systemUserId, delegationId }) => ({
-        url: `systemuser/agentdelegation/${partyId}/${systemUserId}/delegation/${delegationId}`,
+      query: ({ partyId, systemUserId, delegationId, partyUuid }) => ({
+        url: `systemuser/agentdelegation/${partyId}/${systemUserId}/delegation/${delegationId}?partyuuid=${partyUuid}`,
         method: 'DELETE',
       }),
     }),


### PR DESCRIPTION
## Description
- Send partyUuid from frontend instead of looking up partyUuid through register. When looking up partyUuid in register, due to the token we use (with userId), will check that this user can get the party information. For a party with 20K customers, this call is really slow so we should avoid it (and instead consider how we can move from partyId to partyUuid for systemuser)

## Related Issue(s)
- this PR

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Agent delegation workflows have been streamlined by incorporating a unique party identifier, enhancing the precision and reliability of management operations.
  - The customer list display now shows 5 items per page instead of 10, resulting in a cleaner, more organized browsing experience for end users.

- **Bug Fixes**
  - Removed deprecated methods for retrieving party information, improving overall system clarity and reducing potential confusion for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->