### PR TITLE
Add OldRolesAlert component

### DIFF
--- a/src/features/amUI/common/OldRolesAlert/OldRolesAlert.module.css
+++ b/src/features/amUI/common/OldRolesAlert/OldRolesAlert.module.css
@@ -1,0 +1,5 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}

--- a/src/features/amUI/common/OldRolesAlert/OldRolesAlert.module.css
+++ b/src/features/amUI/common/OldRolesAlert/OldRolesAlert.module.css
@@ -1,7 +1,7 @@
 .container {
   display: flex;
   flex-direction: column;
-  gap: 0.6rem;
+  gap: 0.4rem;
 }
 
 .link {
@@ -9,4 +9,8 @@
   flex-direction: row;
   align-items: center;
   gap: 0.2rem;
+}
+
+.heading {
+  margin-bottom: var(--ds-size-2);
 }

--- a/src/features/amUI/common/OldRolesAlert/OldRolesAlert.module.css
+++ b/src/features/amUI/common/OldRolesAlert/OldRolesAlert.module.css
@@ -3,3 +3,10 @@
   flex-direction: column;
   gap: 0.6rem;
 }
+
+.link {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.2rem;
+}

--- a/src/features/amUI/common/OldRolesAlert/OldRolesAlert.stories.tsx
+++ b/src/features/amUI/common/OldRolesAlert/OldRolesAlert.stories.tsx
@@ -1,0 +1,11 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { OldRolesAlert } from './OldRolesAlert';
+
+export default {
+  title: 'Features/AMUI/OldRolesAlert',
+  component: OldRolesAlert,
+} as Meta;
+
+export const Default: StoryObj<{}> = {
+  args: {},
+};

--- a/src/features/amUI/common/OldRolesAlert/OldRolesAlert.stories.tsx
+++ b/src/features/amUI/common/OldRolesAlert/OldRolesAlert.stories.tsx
@@ -6,6 +6,6 @@ export default {
   component: OldRolesAlert,
 } as Meta;
 
-export const Default: StoryObj<{}> = {
+export const Default: StoryObj = {
   args: {},
 };

--- a/src/features/amUI/common/OldRolesAlert/OldRolesAlert.tsx
+++ b/src/features/amUI/common/OldRolesAlert/OldRolesAlert.tsx
@@ -1,13 +1,20 @@
-import { getHostUrl } from '@/resources/utils/pathUtils';
 import { useTranslation } from 'react-i18next';
 
 import { ExternalLinkIcon } from '@navikt/aksel-icons';
 import { Link } from 'react-router';
 import { Alert, Heading, Paragraph, Link as DsLink } from '@digdir/designsystemet-react';
 import styles from './OldRolesAlert.module.css';
+import { usePartyRepresentation } from '../PartyRepresentationContext/PartyRepresentationContext';
+import { getRedirectToSevicesAvailableForUserUrl } from '@/resources/utils';
+import { useFetchRecipientInfo } from '@/resources/hooks/useFetchRecipientInfo';
 
 export const OldRolesAlert = () => {
   const { t } = useTranslation();
+  const { toParty, fromParty, selfParty } = usePartyRepresentation();
+
+  const { userID, partyID } = useFetchRecipientInfo(toParty?.partyUuid ?? '', null);
+
+  const url = getRedirectToSevicesAvailableForUserUrl(userID, partyID);
   return (
     <Alert data-color='info'>
       <div className={styles.container}>
@@ -24,7 +31,7 @@ export const OldRolesAlert = () => {
         <Paragraph>{t('a2Alerts.launchAlertContent')}</Paragraph>
         <DsLink asChild>
           <Link
-            to={`${getHostUrl()}ui/profile/`}
+            to={url}
             className={styles.link}
           >
             {t('a2Alerts.launchAlertLinkText')}

--- a/src/features/amUI/common/OldRolesAlert/OldRolesAlert.tsx
+++ b/src/features/amUI/common/OldRolesAlert/OldRolesAlert.tsx
@@ -13,7 +13,7 @@ export const OldRolesAlert = () => {
       <div className={styles.container}>
         <Heading
           data-size='xs'
-          level={2}
+          level={3}
           style={{
             marginBottom: 'var(--ds-size-2)',
           }}

--- a/src/features/amUI/common/OldRolesAlert/OldRolesAlert.tsx
+++ b/src/features/amUI/common/OldRolesAlert/OldRolesAlert.tsx
@@ -36,6 +36,8 @@ export const OldRolesAlert = () => {
           <Link
             to={url}
             className={styles.link}
+            target='_blank'
+            rel='noopener noreferrer'
           >
             {t('a2Alerts.launchAlertLinkText')}
             <ExternalLinkIcon aria-hidden />

--- a/src/features/amUI/common/OldRolesAlert/OldRolesAlert.tsx
+++ b/src/features/amUI/common/OldRolesAlert/OldRolesAlert.tsx
@@ -5,14 +5,18 @@ import { Link } from 'react-router';
 import { Alert, Heading, Paragraph, Link as DsLink } from '@digdir/designsystemet-react';
 import styles from './OldRolesAlert.module.css';
 import { usePartyRepresentation } from '../PartyRepresentationContext/PartyRepresentationContext';
-import { getRedirectToSevicesAvailableForUserUrl } from '@/resources/utils';
+import { getRedirectToServicesAvailableForUserUrl } from '@/resources/utils';
 import { useFetchRecipientInfo } from '@/resources/hooks/useFetchRecipientInfo';
+import { getHostUrl } from '@/resources/utils/pathUtils';
 
 export const OldRolesAlert = () => {
   const { t } = useTranslation();
   const { toParty } = usePartyRepresentation();
   const { userID, partyID } = useFetchRecipientInfo(toParty?.partyUuid ?? '', null);
-  const url = getRedirectToSevicesAvailableForUserUrl(userID, partyID);
+  const url =
+    userID && partyID
+      ? getRedirectToServicesAvailableForUserUrl(userID, partyID)
+      : `${getHostUrl()}ui/profile/`;
 
   return (
     <Alert data-color='info'>

--- a/src/features/amUI/common/OldRolesAlert/OldRolesAlert.tsx
+++ b/src/features/amUI/common/OldRolesAlert/OldRolesAlert.tsx
@@ -1,0 +1,34 @@
+import { getHostUrl } from '@/resources/utils/pathUtils';
+import { useTranslation } from 'react-i18next';
+
+import { ExternalLinkIcon } from '@navikt/aksel-icons';
+import { Link } from 'react-router';
+import { Alert, Heading, Paragraph, Link as DsLink } from '@digdir/designsystemet-react';
+import styles from './OldRolesAlert.module.css';
+
+export const OldRolesAlert = () => {
+  const { t } = useTranslation();
+  return (
+    <Alert data-color='info'>
+      <div className={styles.container}>
+        <Heading
+          data-size='xs'
+          level={2}
+          style={{
+            marginBottom: 'var(--ds-size-2)',
+          }}
+        >
+          {t('a2Alerts.launchAlertHeading')}
+        </Heading>
+
+        <Paragraph>{t('a2Alerts.launchAlertContent')}</Paragraph>
+        <DsLink asChild>
+          <Link to={`${getHostUrl()}ui/profile/`}>
+            {t('a2Alerts.launchAlertLinkText')}
+            {/* <ExternalLinkIcon title='external link' /> */}
+          </Link>
+        </DsLink>
+      </div>
+    </Alert>
+  );
+};

--- a/src/features/amUI/common/OldRolesAlert/OldRolesAlert.tsx
+++ b/src/features/amUI/common/OldRolesAlert/OldRolesAlert.tsx
@@ -24,9 +24,7 @@ export const OldRolesAlert = () => {
         <Heading
           data-size='xs'
           level={2}
-          style={{
-            marginBottom: 'var(--ds-size-2)',
-          }}
+          className={styles.heading}
         >
           {t('a2Alerts.launchAlertHeading')}
         </Heading>

--- a/src/features/amUI/common/OldRolesAlert/OldRolesAlert.tsx
+++ b/src/features/amUI/common/OldRolesAlert/OldRolesAlert.tsx
@@ -10,17 +10,16 @@ import { useFetchRecipientInfo } from '@/resources/hooks/useFetchRecipientInfo';
 
 export const OldRolesAlert = () => {
   const { t } = useTranslation();
-  const { toParty, fromParty, selfParty } = usePartyRepresentation();
-
+  const { toParty } = usePartyRepresentation();
   const { userID, partyID } = useFetchRecipientInfo(toParty?.partyUuid ?? '', null);
-
   const url = getRedirectToSevicesAvailableForUserUrl(userID, partyID);
+
   return (
     <Alert data-color='info'>
       <div className={styles.container}>
         <Heading
           data-size='xs'
-          level={3}
+          level={2}
           style={{
             marginBottom: 'var(--ds-size-2)',
           }}

--- a/src/features/amUI/common/OldRolesAlert/OldRolesAlert.tsx
+++ b/src/features/amUI/common/OldRolesAlert/OldRolesAlert.tsx
@@ -23,9 +23,12 @@ export const OldRolesAlert = () => {
 
         <Paragraph>{t('a2Alerts.launchAlertContent')}</Paragraph>
         <DsLink asChild>
-          <Link to={`${getHostUrl()}ui/profile/`}>
+          <Link
+            to={`${getHostUrl()}ui/profile/`}
+            className={styles.link}
+          >
             {t('a2Alerts.launchAlertLinkText')}
-            {/* <ExternalLinkIcon title='external link' /> */}
+            <ExternalLinkIcon aria-hidden />
           </Link>
         </DsLink>
       </div>

--- a/src/features/amUI/common/OldRolesAlert/OldRolesAlert.tsx
+++ b/src/features/amUI/common/OldRolesAlert/OldRolesAlert.tsx
@@ -36,8 +36,6 @@ export const OldRolesAlert = () => {
           <Link
             to={url}
             className={styles.link}
-            target='_blank'
-            rel='noopener noreferrer'
           >
             {t('a2Alerts.launchAlertLinkText')}
             <ExternalLinkIcon aria-hidden />

--- a/src/features/amUI/common/RoleList/RoleList.stories.tsx
+++ b/src/features/amUI/common/RoleList/RoleList.stories.tsx
@@ -3,15 +3,15 @@ import { Provider } from 'react-redux';
 
 import store from '@/rtk/app/store';
 
-import { AccessPackageList } from './AccessPackageList';
+import { RoleList } from './RoleList';
 import { PartyRepresentationProvider } from '../PartyRepresentationContext/PartyRepresentationContext';
 import { SnackbarProvider } from '../Snackbar/SnackbarProvider';
 
-type AreaListPropsAndCustomArgs = React.ComponentProps<typeof AccessPackageList>;
+type RoleListPropsAndCustomArgs = React.ComponentProps<typeof RoleList>;
 
 export default {
-  title: 'Features/AMUI/AreaList',
-  component: AccessPackageList,
+  title: 'Features/AMUI/RoleList',
+  component: RoleList,
   render: (args) => (
     <Provider store={store}>
       <SnackbarProvider>
@@ -19,13 +19,17 @@ export default {
           fromPartyUuid='123'
           toPartyUuid='456'
         >
-          <AccessPackageList {...args} />
+          <RoleList
+            {...args}
+            onActionError={(error) => console.log(`onActionError`, error)}
+            onSelect={(id) => console.log(`onselect: ${id}`)}
+          />
         </PartyRepresentationProvider>
       </SnackbarProvider>
     </Provider>
   ),
 } as Meta;
 
-export const Default: StoryObj<AreaListPropsAndCustomArgs> = {
+export const Default: StoryObj<RoleListPropsAndCustomArgs> = {
   args: {},
 };

--- a/src/features/amUI/reporteeRightsPage/ReporteeAccessPackageSection.tsx
+++ b/src/features/amUI/reporteeRightsPage/ReporteeAccessPackageSection.tsx
@@ -9,6 +9,7 @@ import { AccessPackageList } from '../common/AccessPackageList/AccessPackageList
 import { DelegationAction } from '../common/DelegationModal/EditModal';
 import { AccessPackageInfoModal } from '../userRightsPage/AccessPackageSection/AccessPackageInfoModal';
 import { useDelegationModalContext } from '../common/DelegationModal/DelegationModalContext';
+import { OldRolesAlert } from '../common/OldRolesAlert/OldRolesAlert';
 
 interface ReporteeAccessPackageSectionProps {
   numberOfAccesses?: number;
@@ -37,6 +38,7 @@ export const ReporteeAccessPackageSection = ({
       >
         {t('access_packages.current_access_packages_title', { count: numberOfAccesses })}
       </Heading>
+      <OldRolesAlert />
       <AccessPackageList
         availableActions={[DelegationAction.REVOKE, DelegationAction.REQUEST]}
         useDeleteConfirm

--- a/src/features/amUI/reporteeRightsPage/ReporteeAccessPackageSection.tsx
+++ b/src/features/amUI/reporteeRightsPage/ReporteeAccessPackageSection.tsx
@@ -31,6 +31,7 @@ export const ReporteeAccessPackageSection = ({
 
   return (
     <>
+      <OldRolesAlert />
       <Heading
         level={2}
         data-size='2xs'
@@ -38,7 +39,6 @@ export const ReporteeAccessPackageSection = ({
       >
         {t('access_packages.current_access_packages_title', { count: numberOfAccesses })}
       </Heading>
-      <OldRolesAlert />
       <AccessPackageList
         availableActions={[DelegationAction.REVOKE, DelegationAction.REQUEST]}
         useDeleteConfirm

--- a/src/features/amUI/reporteeRightsPage/ReporteeRoleSection.tsx
+++ b/src/features/amUI/reporteeRightsPage/ReporteeRoleSection.tsx
@@ -8,6 +8,7 @@ import { RoleInfoModal } from '../common/RoleList/RoleInfoModal';
 import { RoleList } from '../common/RoleList/RoleList';
 import { DelegationAction } from '../common/DelegationModal/EditModal';
 import { useDelegationModalContext } from '../common/DelegationModal/DelegationModalContext';
+import { OldRolesAlert } from '../common/OldRolesAlert/OldRolesAlert';
 
 interface ReporteeRoleSectionProps {
   numberOfAccesses?: number;
@@ -28,6 +29,7 @@ export const ReporteeRoleSection = ({ numberOfAccesses }: ReporteeRoleSectionPro
       >
         {t('role.current_roles_title', { count: numberOfAccesses })}
       </Heading>
+      <OldRolesAlert />
       <Paragraph data-size='sm'>{t('role.roles_description')}</Paragraph>
       <RoleList
         onSelect={(role) => {

--- a/src/features/amUI/reporteeRightsPage/ReporteeRoleSection.tsx
+++ b/src/features/amUI/reporteeRightsPage/ReporteeRoleSection.tsx
@@ -22,6 +22,7 @@ export const ReporteeRoleSection = ({ numberOfAccesses }: ReporteeRoleSectionPro
 
   return (
     <>
+      <OldRolesAlert />
       <Heading
         level={2}
         data-size='2xs'
@@ -29,7 +30,6 @@ export const ReporteeRoleSection = ({ numberOfAccesses }: ReporteeRoleSectionPro
       >
         {t('role.current_roles_title', { count: numberOfAccesses })}
       </Heading>
-      <OldRolesAlert />
       <Paragraph data-size='sm'>{t('role.roles_description')}</Paragraph>
       <RoleList
         onSelect={(role) => {

--- a/src/features/amUI/userRightsPage/AccessPackageSection/AccessPackageSection.tsx
+++ b/src/features/amUI/userRightsPage/AccessPackageSection/AccessPackageSection.tsx
@@ -22,6 +22,7 @@ export const AccessPackageSection = ({ numberOfAccesses }: { numberOfAccesses: n
   return (
     party && (
       <>
+        <OldRolesAlert />
         <Heading
           level={2}
           data-size='2xs'
@@ -29,7 +30,6 @@ export const AccessPackageSection = ({ numberOfAccesses }: { numberOfAccesses: n
         >
           {t('access_packages.current_access_packages_title', { count: numberOfAccesses })}
         </Heading>
-        <OldRolesAlert />
         <DelegationModal
           delegationType={DelegationType.AccessPackage}
           availableActions={[

--- a/src/features/amUI/userRightsPage/AccessPackageSection/AccessPackageSection.tsx
+++ b/src/features/amUI/userRightsPage/AccessPackageSection/AccessPackageSection.tsx
@@ -10,6 +10,7 @@ import { DelegationAction } from '../../common/DelegationModal/EditModal';
 
 import { ActiveDelegations } from './ActiveDelegations';
 import { usePartyRepresentation } from '../../common/PartyRepresentationContext/PartyRepresentationContext';
+import { OldRolesAlert } from '../../common/OldRolesAlert/OldRolesAlert';
 
 export const AccessPackageSection = ({ numberOfAccesses }: { numberOfAccesses: number }) => {
   const { t } = useTranslation();
@@ -28,6 +29,7 @@ export const AccessPackageSection = ({ numberOfAccesses }: { numberOfAccesses: n
         >
           {t('access_packages.current_access_packages_title', { count: numberOfAccesses })}
         </Heading>
+        <OldRolesAlert />
         <DelegationModal
           delegationType={DelegationType.AccessPackage}
           availableActions={[

--- a/src/features/amUI/userRightsPage/RoleSection/RoleSection.tsx
+++ b/src/features/amUI/userRightsPage/RoleSection/RoleSection.tsx
@@ -1,5 +1,5 @@
 import { useParams } from 'react-router';
-import { useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { Heading, Paragraph } from '@digdir/designsystemet-react';
 import { useTranslation } from 'react-i18next';
 
@@ -12,6 +12,7 @@ import { RoleInfoModal } from '../../common/RoleList/RoleInfoModal';
 import { DelegationAction } from '../../common/DelegationModal/EditModal';
 
 import { useDelegationModalContext } from '../../common/DelegationModal/DelegationModalContext';
+import { OldRolesAlert } from '../../common/OldRolesAlert/OldRolesAlert';
 
 interface RoleSectionProps {
   numberOfAccesses?: number;
@@ -36,6 +37,7 @@ export const RoleSection = ({ numberOfAccesses }: RoleSectionProps) => {
       >
         {t('role.current_roles_title', { count: numberOfAccesses })}
       </Heading>
+      <OldRolesAlert />
       <Paragraph data-size='sm'>{t('role.roles_description')}</Paragraph>
       <RoleList
         availableActions={[

--- a/src/features/amUI/userRightsPage/RoleSection/RoleSection.tsx
+++ b/src/features/amUI/userRightsPage/RoleSection/RoleSection.tsx
@@ -30,6 +30,7 @@ export const RoleSection = ({ numberOfAccesses }: RoleSectionProps) => {
 
   return (
     <>
+      <OldRolesAlert />
       <Heading
         level={2}
         data-size='2xs'
@@ -37,7 +38,6 @@ export const RoleSection = ({ numberOfAccesses }: RoleSectionProps) => {
       >
         {t('role.current_roles_title', { count: numberOfAccesses })}
       </Heading>
-      <OldRolesAlert />
       <Paragraph data-size='sm'>{t('role.roles_description')}</Paragraph>
       <RoleList
         availableActions={[

--- a/src/features/amUI/userRightsPage/UserRightsPage.tsx
+++ b/src/features/amUI/userRightsPage/UserRightsPage.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Spinner } from '@digdir/designsystemet-react';
-import { useNavigate, useParams } from 'react-router';
+import { useParams } from 'react-router';
 
 import { useDocumentTitle } from '@/resources/hooks/useDocumentTitle';
 import { PageWrapper } from '@/components';
@@ -28,8 +28,6 @@ import { PartyRepresentationProvider } from '../common/PartyRepresentationContex
 export const UserRightsPage = () => {
   const { t } = useTranslation();
   const { id } = useParams();
-
-  const navigate = useNavigate();
 
   const { data: reportee } = useGetReporteeQuery();
   const { data: party } = useGetPartyByUUIDQuery(id ?? '');
@@ -69,7 +67,6 @@ export const UserRightsPage = () => {
                         )
                       }
                     />
-
                     <RightsTabs
                       tabBadge={{
                         accessPackages: allAccesses.accessPackages?.length ?? 0,

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -347,8 +347,8 @@
   },
   "a2Alerts": {
     "launchAlertHeading": "We are renewing Altinn",
-    "launchAlertContent": "This user may also have authorizations from the old Altinn.",
-    "launchAlertLinkText": "View authorizations from the old Altinn"
+    "launchAlertContent": "This user may also have authorizations from the previous Altinn.",
+    "launchAlertLinkText": "View authorizations from the previous Altinn"
   },
   "user_role": {
     "SREVA": "Auditor registered in the registry of auditors",

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -265,7 +265,7 @@
   },
   "role": {
     "current_roles_title": "{{count}} administrator accesses",
-    "roles_description": "This access area includes the powers to manage access for your business. No resources or services are linked to this access.",
+    "roles_description": "Here you will find authorizations to manage access for the organization. No resources or services are associated with these accesses.",
     "role_delegation_success": "{{name}} has been successfully granted power of attorney over {{role}}.",
     "role_delegation_error": "Failed to grant power of attorney over {{role}} to {{name}}.",
     "role_deletion_success": "Power of attorney over {{role}} has been successfully revoked for {{name}}.",
@@ -291,7 +291,6 @@
     "access_packages_title": "Access packages",
     "single_rights_title": "Services",
     "roles_title": "Administrative accesses",
-    "roles_description": "Administrator access grants the ability to delegate permissions to other users. No specific services are associated with these permissions.",
     "resource_type_text": "Single right",
     "delete_confirm_message": "Are you sure you want to delete this?"
   },
@@ -345,6 +344,11 @@
     "modal_title": "Add new person or organization",
     "trigger_button": "Add user",
     "add_button": "Add user"
+  },
+  "a2Alerts": {
+    "launchAlertHeading": "We are renewing Altinn",
+    "launchAlertContent": "This user may also have authorizations from the old Altinn.",
+    "launchAlertLinkText": "View authorizations from the old Altinn"
   },
   "user_role": {
     "SREVA": "Auditor registered in the registry of auditors",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -346,9 +346,9 @@
   },
   "a2Alerts": {
     "launchAlertHeading": "Vi fornyer Altinn",
-    "launchAlertContent": "Denne brukeren kan også ha fullmakter fra gamle Altinn.",
-    "launchAlertLinkText": "Se fullmakter fra gamle Altinn"
-  }, 
+    "launchAlertContent": "Denne brukaren kan også ha fullmakter frå tidlegare Altinn.",
+    "launchAlertLinkText": "Sjå fullmakter frå tidlegare Altinn"
+  },
   "user_role": {
     "SREVA": "Revisor registrert i revisorregisteret",
     "FGRP": "Inngår i foretaksgruppe med",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -346,8 +346,8 @@
   },
   "a2Alerts": {
     "launchAlertHeading": "Vi fornyer Altinn",
-    "launchAlertContent": "Denne brukaren kan også ha fullmakter frå tidlegare Altinn.",
-    "launchAlertLinkText": "Sjå fullmakter frå tidlegare Altinn"
+    "launchAlertContent": "Denne brukeren kan også ha fullmakter fra tidligere Altinn.",
+    "launchAlertLinkText": "Se fullmakter fra tidligere Altinn"
   },
   "user_role": {
     "SREVA": "Revisor registrert i revisorregisteret",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -264,7 +264,7 @@
   },
   "role": {
     "current_roles_title": "{{count}} administratortilganger",
-    "roles_description": "Dette fullmaktsområdet omfatter fullmakter til å administrere tilganger for virksomheten. Det er ikke knyttet noen ressurser eller tjenester til disse tilgangene.",
+    "roles_description": "Her finner du fullmakter for å administrere tilganger for virksomheten. Det er ikke knyttet noen ressurser eller tjenester til disse tilgangene.",
     "role_delegation_success": "{{name}} har nå fått fullmakt til {{role}}.",
     "role_delegation_error": "Det var ikke mulig å gi {{name}} fullmakt til {{role}}.",
     "role_deletion_success": "Fullmakten til {{role}} er fjernet fra {{name}}.",
@@ -290,7 +290,6 @@
     "access_packages_title": "Tilgangspakker",
     "single_rights_title": "Tjenester",
     "roles_title": "Administratortilganger",
-    "roles_description": "Administratortilganger gir tilgang til å gi fullmakter til andre brukere. Det er ikke knyttet noen spesifikke tjenester til disse fullmaktene.",
     "resource_type_text": "Enkelttjeneste",
     "delete_confirm_message": "Er du sikker på at du vil slette denne?"
   },
@@ -345,6 +344,11 @@
     "trigger_button": "Legg til bruker",
     "add_button": "Legg til bruker"
   },
+  "a2Alerts": {
+    "launchAlertHeading": "Vi fornyer Altinn",
+    "launchAlertContent": "Denne brukeren kan også ha fullmakter fra gamle Altinn.",
+    "launchAlertLinkText": "Se fullmakter fra gamle Altinn"
+  }, 
   "user_role": {
     "SREVA": "Revisor registrert i revisorregisteret",
     "FGRP": "Inngår i foretaksgruppe med",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -261,7 +261,7 @@
   },
   "role": {
     "current_roles_title": "{{count}} administratortilganger",
-    "roles_description": "Dette fullmaktsområdet omfattar fullmakter til å administrere tilgangar for verksemda. Det er ikkje knytt nokre ressursar eller tenester til desse tilgangane.",
+    "roles_description": "Her finner du fullmakter for å administrere tilganger for virksomheten. Det er ikke knyttet noen ressurser eller tjenester til disse tilgangene.",
     "role_delegation_success": "{{name}} har nå fått fullmakt til {{role}}.",
     "role_delegation_error": "Det var ikke mulig å gi {{name}} fullmakt til {{role}}.",
     "role_deletion_success": "Fullmakten til {{role}} er fjernet fra {{name}}.",
@@ -287,7 +287,6 @@
     "access_packages_title": "Tilgangspakker",
     "single_rights_title": "Tjenester",
     "roles_title": "Administratortilganger",
-    "roles_description": "Administratortilganger gir tilgang til å gi fullmakter til andre brukarar. Det er ikkje knytt nokon spesifikke tenester til desse fullmaktene.",
     "resource_type_text": "Enkelttjeneste",
     "delete_confirm_message": "Er du sikker på at du vil slette denne?"
   },
@@ -341,6 +340,11 @@
     "modal_title": "Legg til ny person eller virksemnd",
     "trigger_button": "Legg til brukar",
     "add_button": "Legg til brukar"
+  },
+  "a2Alerts": {
+    "launchAlertHeading": "Vi fornyer Altinn",
+    "launchAlertContent": "Denne brukeren kan også ha fullmakter fra gamle Altinn.",
+    "launchAlertLinkText": "Se fullmakter fra gamle Altinn"
   },
   "user_role": {
     "SREVA": "Revisor registrert i revisorregisteret",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -343,8 +343,8 @@
   },
   "a2Alerts": {
     "launchAlertHeading": "Vi fornyer Altinn",
-    "launchAlertContent": "Denne brukeren kan også ha fullmakter fra tidligere Altinn.",
-    "launchAlertLinkText": "Se fullmakter fra tidligere Altinn"
+    "launchAlertContent": "Denne brukaren kan også ha fullmakter frå tidlegare Altinn.",
+    "launchAlertLinkText": "Sjå fullmakter frå tidlegare Altinn"
   },
   "user_role": {
     "SREVA": "Revisor registrert i revisorregisteret",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -343,8 +343,8 @@
   },
   "a2Alerts": {
     "launchAlertHeading": "Vi fornyer Altinn",
-    "launchAlertContent": "Denne brukeren kan også ha fullmakter fra gamle Altinn.",
-    "launchAlertLinkText": "Se fullmakter fra gamle Altinn"
+    "launchAlertContent": "Denne brukeren kan også ha fullmakter fra tidligere Altinn.",
+    "launchAlertLinkText": "Se fullmakter fra tidligere Altinn"
   },
   "user_role": {
     "SREVA": "Revisor registrert i revisorregisteret",

--- a/src/resources/utils/redirectUtils.ts
+++ b/src/resources/utils/redirectUtils.ts
@@ -2,9 +2,13 @@ import { GeneralPath } from '@/routes/paths';
 
 import { getCookie } from '../Cookie/CookieMethods';
 
-export const redirectToSevicesAvailableForUser = (userID: string, partyID: string) => {
+export const getRedirectToSevicesAvailableForUserUrl = (userID: string, partyID: string) => {
   const cleanHostname = window.location.hostname.replace('am.ui.', '');
-  window.location.href = `https://${cleanHostname}/${GeneralPath.Profile}?R=${getCookie('AltinnPartyId')}&lm=${encodeURIComponent(`/ui/AccessManagement/ServicesAvailableForActor/?userID=${userID ? userID : 0}&partyID=${partyID}`)}`;
+  return `https://${cleanHostname}/${GeneralPath.Profile}?R=${getCookie('AltinnPartyId')}&lm=${encodeURIComponent(`/ui/AccessManagement/ServicesAvailableForActor/?userID=${userID ? userID : 0}&partyID=${partyID}`)}`;
+};
+
+export const redirectToSevicesAvailableForUser = (userID: string, partyID: string) => {
+  window.location.href = getRedirectToSevicesAvailableForUserUrl(userID, partyID);
 };
 
 export const getRedirectToProfileUrl = () => {

--- a/src/resources/utils/redirectUtils.ts
+++ b/src/resources/utils/redirectUtils.ts
@@ -2,13 +2,13 @@ import { GeneralPath } from '@/routes/paths';
 
 import { getCookie } from '../Cookie/CookieMethods';
 
-export const getRedirectToSevicesAvailableForUserUrl = (userID: string, partyID: string) => {
+export const getRedirectToServicesAvailableForUserUrl = (userID: string, partyID: string) => {
   const cleanHostname = window.location.hostname.replace('am.ui.', '');
   return `https://${cleanHostname}/${GeneralPath.Profile}?R=${getCookie('AltinnPartyId')}&lm=${encodeURIComponent(`/ui/AccessManagement/ServicesAvailableForActor/?userID=${userID ? userID : 0}&partyID=${partyID}`)}`;
 };
 
 export const redirectToSevicesAvailableForUser = (userID: string, partyID: string) => {
-  window.location.href = getRedirectToSevicesAvailableForUserUrl(userID, partyID);
+  window.location.href = getRedirectToServicesAvailableForUserUrl(userID, partyID);
 };
 
 export const getRedirectToProfileUrl = () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adding alert to inform users that we are updating Altinn with a link to the old altinn solution

I followed the design sketches, but I’m not sure if I agree with the location and the text. I’d love to hear your thoughts.

I also changed the link text to make it a bit more self-explanatory outside of the previous paragraph. 
 
 
## Related Issue(s)
- #[208](https://github.com/Altinn/altinn-authorization-tmp/issues/208)

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced an "Old Roles Alert" notification that now appears across several access and rights pages to inform users about legacy role authorizations.
  - Updated on-screen text for role descriptions and alerts, including new messaging about the Altinn renewal, to provide clearer and more inclusive guidance.
  - Added a new `SnackbarProvider` context for improved notifications in the `AccessPackageList` component.
  - Created new Storybook stories for the `OldRolesAlert` and `RoleList` components to enhance development documentation.

- **Bug Fixes**
  - Removed outdated role description from the user rights page to simplify user information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->