### PR TITLE
Minimize other available packages in area

### DIFF
--- a/src/features/amUI/common/AccessPackageList/AccessPackageList.module.css
+++ b/src/features/amUI/common/AccessPackageList/AccessPackageList.module.css
@@ -12,3 +12,7 @@
   width: 100%;
   height: 90%;
 }
+
+.showAvailablePackagesButton {
+  width: fit-content;
+}

--- a/src/features/amUI/common/AccessPackageList/AccessPackageList.tsx
+++ b/src/features/amUI/common/AccessPackageList/AccessPackageList.tsx
@@ -19,6 +19,7 @@ import { useAreaExpandedContextOrLocal } from './AccessPackageExpandedContext';
 interface AccessPackageListProps {
   showAllPackages?: boolean;
   showAllAreas?: boolean;
+  minimizeAvailablePackages?: boolean;
   isLoading?: boolean;
   availableActions?: DelegationAction[];
   searchString?: string;
@@ -33,6 +34,7 @@ interface AccessPackageListProps {
 export const AccessPackageList = ({
   showAllAreas,
   showAllPackages,
+  minimizeAvailablePackages,
   isLoading,
   availableActions,
   onSelect,
@@ -100,6 +102,7 @@ export const AccessPackageList = ({
                   onRevoke={onRevoke}
                   onRequest={onRequest}
                   useDeleteConfirm={useDeleteConfirm}
+                  showAvailablePackages={!minimizeAvailablePackages}
                 />
               </AreaItem>
             );

--- a/src/features/amUI/common/AccessPackageList/AreaItemContent.tsx
+++ b/src/features/amUI/common/AccessPackageList/AreaItemContent.tsx
@@ -1,20 +1,21 @@
-import { Alert, Heading, Paragraph, Spinner } from '@digdir/designsystemet-react';
+import { Alert, Button, Heading, Paragraph } from '@digdir/designsystemet-react';
 import { ListBase } from '@altinn/altinn-components';
 import { useTranslation } from 'react-i18next';
 import React, { useMemo, useState } from 'react';
+import cn from 'classnames';
+import { ChevronDownIcon, ChevronUpIcon } from '@navikt/aksel-icons';
 
 import type { AccessPackage } from '@/rtk/features/accessPackageApi';
+import { useAccessPackageDelegationCheck } from '@/resources/hooks/useAccessPackageDelegationCheck';
+import type { ActionError } from '@/resources/hooks/useActionError';
+import { useIsMobileOrSmaller } from '@/resources/utils/screensizeUtils';
 
 import { DelegationAction } from '../DelegationModal/EditModal';
+import { TechnicalErrorParagraphs } from '../TechnicalErrorParagraphs';
 
 import classes from './AccessPackageList.module.css';
 import type { ExtendedAccessArea } from './useAreaPackageList';
 import { PackageItem } from './PackageItem';
-import { useAccessPackageDelegationCheck } from '@/resources/hooks/useAccessPackageDelegationCheck';
-import { ActionError } from '@/resources/hooks/useActionError';
-import { TechnicalErrorParagraphs } from '../TechnicalErrorParagraphs';
-import cn from 'classnames';
-import { useIsMobileOrSmaller } from '@/resources/utils/screensizeUtils';
 import { RevokeAccessPackageActionControl } from './RevokeAccessPackageActionControl';
 import { DelegateAccessPackageActionControl } from './DelegateAccessPackageActionControl';
 
@@ -25,6 +26,7 @@ interface AreaItemContentProps {
   onDelegate: (accessPackage: AccessPackage) => void;
   onRevoke: (accessPackage: AccessPackage) => void;
   onRequest: (accessPackage: AccessPackage) => void;
+  showAvailablePackages?: boolean;
   useDeleteConfirm?: boolean;
 }
 
@@ -35,10 +37,14 @@ export const AreaItemContent = ({
   onDelegate,
   onRevoke,
   onRequest,
+  showAvailablePackages: showAvailablePackagesExternal = false,
   useDeleteConfirm,
 }: AreaItemContentProps) => {
   const { packages } = area;
   const { t } = useTranslation();
+  const [showAvailablePackages, setShowAvailablePackages] = useState(
+    showAvailablePackagesExternal ?? false,
+  );
   const [delegationCheckError, setDelegationCheckError] = useState<ActionError | null>(null);
   const availablePackageIds = useMemo(
     () => packages.available.map((pkg) => pkg.id),
@@ -50,29 +56,15 @@ export const AreaItemContent = ({
   const shouldShowDelegationCheck = !!availableActions?.includes(DelegationAction.DELEGATE);
   const { canDelegate, isLoading, isUninitialized } = useAccessPackageDelegationCheck(
     availablePackageIds,
-    shouldShowDelegationCheck,
+    shouldShowDelegationCheck && showAvailablePackages,
     handleDelegationCheckFailure,
   );
   const isSm = useIsMobileOrSmaller();
   return (
     <div className={cn(classes.accessAreaContent, !isSm && classes.accessAreaContentMargin)}>
       <Paragraph>{area.description}</Paragraph>
-      {delegationCheckError && (
-        <Alert data-color='danger'>
-          <Heading level={3}>
-            {t('access_packages.delegation_check.delegation_check_error_heading')}
-          </Heading>
-          <TechnicalErrorParagraphs
-            message={t('access_packages.delegation_check.delegation_check_error_message_plural', {
-              count: 2,
-            })}
-            status={delegationCheckError.httpStatus}
-            time={delegationCheckError.timestamp}
-          />
-        </Alert>
-      )}
       {packages.assigned.length > 0 && (
-        <ListBase>
+        <ListBase aria-label={t('access_packages.given_packages_title')}>
           {packages.assigned.map((pkg) => (
             <PackageItem
               key={pkg.id}
@@ -93,8 +85,38 @@ export const AreaItemContent = ({
           ))}
         </ListBase>
       )}
-      {packages.available.length > 0 && (
-        <ListBase>
+
+      {!showAvailablePackagesExternal && (
+        <Button
+          variant='tertiary'
+          onClick={() => setShowAvailablePackages((prev) => !prev)}
+          className={classes.showAvailablePackagesButton}
+          data-size='sm'
+        >
+          {t('access_packages.other_available')} {`(${packages.available.length})`}{' '}
+          {showAvailablePackages ? (
+            <ChevronUpIcon aria-label={t('common.close')} />
+          ) : (
+            <ChevronDownIcon aria-label={t('common.open')} />
+          )}
+        </Button>
+      )}
+      {showAvailablePackages && delegationCheckError && (
+        <Alert data-color='danger'>
+          <Heading level={3}>
+            {t('access_packages.delegation_check.delegation_check_error_heading')}
+          </Heading>
+          <TechnicalErrorParagraphs
+            message={t('access_packages.delegation_check.delegation_check_error_message_plural', {
+              count: 2,
+            })}
+            status={delegationCheckError.httpStatus}
+            time={delegationCheckError.timestamp}
+          />
+        </Alert>
+      )}
+      {packages.available.length > 0 && showAvailablePackages && (
+        <ListBase aria-label={t('access_packages.available_packages_title')}>
           {packages.available.map((pkg) => (
             <PackageItem
               key={pkg.id}

--- a/src/features/amUI/common/DelegationModal/AccessPackages/PackageSearch.tsx
+++ b/src/features/amUI/common/DelegationModal/AccessPackages/PackageSearch.tsx
@@ -6,7 +6,6 @@ import { debounce } from '@/resources/utils';
 import type { AccessPackage } from '@/rtk/features/accessPackageApi';
 import type { Party } from '@/rtk/features/lookupApi';
 import { AccessPackageList } from '@/features/amUI/common/AccessPackageList/AccessPackageList';
-import { getCookie } from '@/resources/Cookie/CookieMethods';
 
 import type { DelegationAction } from '../EditModal';
 import { useDelegationModalContext } from '../DelegationModalContext';

--- a/src/features/amUI/userRightsPage/AccessPackageSection/ActiveDelegations.tsx
+++ b/src/features/amUI/userRightsPage/AccessPackageSection/ActiveDelegations.tsx
@@ -1,15 +1,13 @@
 import React, { useRef, useState } from 'react';
 
 import type { AccessPackage } from '@/rtk/features/accessPackageApi';
-import { getCookie } from '@/resources/Cookie/CookieMethods';
-import { useActionError } from '@/resources/hooks/useActionError';
 
 import { AccessPackageList } from '../../common/AccessPackageList/AccessPackageList';
 import { DelegationAction } from '../../common/DelegationModal/EditModal';
-
-import { AccessPackageInfoModal } from './AccessPackageInfoModal';
 import { usePartyRepresentation } from '../../common/PartyRepresentationContext/PartyRepresentationContext';
 import { useDelegationModalContext } from '../../common/DelegationModal/DelegationModalContext';
+
+import { AccessPackageInfoModal } from './AccessPackageInfoModal';
 
 export const ActiveDelegations = () => {
   const modalRef = useRef<HTMLDialogElement>(null);
@@ -23,6 +21,7 @@ export const ActiveDelegations = () => {
       <AccessPackageList
         isLoading={isLoading}
         showAllPackages
+        minimizeAvailablePackages
         onSelect={(accessPackage) => {
           setModalItem(accessPackage);
           modalRef.current?.showModal();

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -3,6 +3,7 @@
     "error": "Error",
     "restart": "Restart",
     "close": "Close",
+    "open": "Open",
     "back": "Back",
     "changes_made_msg": "Changes made. Click the save button to apply",
     "status_code": "Status code",
@@ -248,6 +249,9 @@
     "delete_singleRight_error_message": "Failed to delete access to "
   },
   "access_packages": {
+    "given_packages_title": "Currently held access packages",
+    "available_packages_title": "Available access packages",
+    "other_available": "Other available",
     "current_access_packages_title": "{{count}} access packages",
     "give_new_button": "Give power of attorney to new access package",
     "other_packages_in_area_title": "Other available packages in this area:",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -3,6 +3,7 @@
     "error": "Feil",
     "restart": "Start på nytt",
     "close": "Lukk",
+    "open": "Åpne",
     "back": "Tilbake",
     "changes_made_msg": "Endringer gjort. Klikk på lagre for å gjøre dem gjeldende",
     "status_code": "Statuskode",
@@ -247,6 +248,9 @@
     "delete_singleRight_error_message": "Kunne ikke slette tilgang til "
   },
   "access_packages": {
+    "given_packages_title": "Mottatte tilgangspakker",
+    "available_packages_title": "Tilgjengelige tilgangspakker",
+    "other_available": "Andre tilgjengelige",
     "current_access_packages_title": "{{count}} tilgangspakker",
     "give_new_button": "Gi fullmakt til ny tilgangspakke",
     "other_packages_in_area_title": "Andre tilgjengelige pakker i området:",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -3,6 +3,7 @@
     "error": "Feil",
     "restart": "Start på nytt",
     "close": "Lukk",
+    "open": "Åpne",
     "back": "Tilbake",
     "changes_made_msg": "Endringar gjort. Klikk på lagre-knappen for å gjere dei gjeldande",
     "status_code": "Statuskode",
@@ -244,6 +245,9 @@
     "delete_singleRight_error_message": "Kunne ikke slette tilgang til "
   },
   "access_packages": {
+    "given_packages_title": "Mottatte tilgangspakker",
+    "available_packages_title": "Tilgjengelege tilgangspakker",
+    "other_available": "Andre tilgjengelege",
     "current_access_packages_title": "{{count}} tilgangspakker",
     "give_new_button": "Gi fullmakt til ny tilgangspakke",
     "other_packages_in_area_title": "Andre tilgjengelige pakker i området:",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

![image](https://github.com/user-attachments/assets/46872785-79e5-4991-bc36-50727bfccd41)

## Description
<!--- Describe your changes in detail -->

I went to the Designsystem channel and asked for advice about expandables inside expandables, and they suggested using a simple button to show and hide the extended list instead, which is something that Brønnøysundregistrene uses on their page. This PR is a test for this case.
The argument from BR was that as long as the button itself explains what it should do and the content being shown is close to the trigger, there is no need for the use of expanded and aria-controls, since the user will be able to figure it out from the context.

A button is thus added to toggle the display of the available packages in the area.
An aria-label is added to the chevron in the button, indicating whether the button will open or close the display of these other packages. Aria-labels are also added to the lists themselves to indicate the difference between them.

The number of available packages is displayed in the button for clarity

## Related Issue(s)
-  https://github.com/Altinn/altinn-authorization-tmp/issues/501

## Note
The packages are not minimized inside the delegation modal
![image](https://github.com/user-attachments/assets/c384604c-462b-4ed7-bb0f-252537582085)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new options to control the display of available access packages, allowing users to toggle or minimize package listings.
  
- **Style**
  - Introduced a new button style to improve the presentation of the package display option.
  
- **Documentation**
  - Enhanced user interface text by adding new labels and titles for access package sections in multiple languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->