### PR TITLE
Add account search functionality & virtualization to PageLayoutWrapper

### DIFF
--- a/src/features/amUI/common/PageLayoutWrapper/PageLayoutWrapper.tsx
+++ b/src/features/amUI/common/PageLayoutWrapper/PageLayoutWrapper.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ChangeEvent, useState } from 'react';
 import type { AccountMenuItem, MenuGroupProps, MenuItemProps } from '@altinn/altinn-components';
 import { Layout, RootProvider } from '@altinn/altinn-components';
 import { useTranslation } from 'react-i18next';
@@ -29,7 +29,7 @@ export const PageLayoutWrapper = ({ children }: PageLayoutWrapperProps): React.R
   const { data: reportee } = useGetReporteeQuery();
   const { data: userinfo } = useGetUserInfoQuery();
   const { pathname } = useLocation();
-
+  const [searchString, setSearchString] = useState<string>('');
   const isSm = useIsTabletOrSmaller();
 
   const headerLinks: MenuItemProps[] = [
@@ -136,13 +136,18 @@ export const PageLayoutWrapper = ({ children }: PageLayoutWrapperProps): React.R
             accountGroups,
             accounts,
             accountSearch: {
+              name: 'account-search',
+              value: searchString,
+              onChange: (event: ChangeEvent<HTMLInputElement>) => {
+                setSearchString(event.target.value);
+              },
               placeholder: t('header.search-label'),
-              name: 'search-account',
               hidden: false,
               getResultsLabel: (hits: number) => {
                 return `${hits} ${t('header.search-hits')}`;
               },
             },
+            isVirtualized: accounts.length > 20,
             onSelectAccount: (accountId) => {
               const redirectUrl = window.location.pathname.includes('systemuser')
                 ? `${window.location.origin}/accessmanagement/ui/systemuser/overview`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The accounts-list in the header now has scrolling, search and virtualization like the implementation in inbox. 
This can be tested by logging in with a user that has many accounts. For example, this one: 13886499404

## Related Issue(s)
- #[1385](https://github.com/Altinn/altinn-access-management-frontend/issues/1385)

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an interactive account search that updates in real-time as you type.
  - Enhanced performance by optimizing the display when handling a large number of accounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->