### PR TITLE
Fix: double snackbar in customer agent delegation

### DIFF
--- a/src/features/amUI/systemUser/SystemUserAgentDelegationPage/CustomerList.module.css
+++ b/src/features/amUI/systemUser/SystemUserAgentDelegationPage/CustomerList.module.css
@@ -8,11 +8,6 @@
   margin-bottom: var(--ds-size-2);
 }
 
-/* TODO: bug in altinn-components, non-interactive listItem should not show outline on hover */
-.customerList li {
-  outline: none !important;
-}
-
 .searchBar {
   max-width: 20rem;
 }

--- a/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPage.module.css
+++ b/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPage.module.css
@@ -18,11 +18,7 @@
   margin-top: var(--ds-size-12);
 }
 
-.customerListSnackbarWrapper .customerListSnackbar {
-  display: flex;
+.customerListSnackbar {
   align-self: flex-end;
   max-width: 20rem;
-}
-.customerListSnackbar {
-  display: none;
 }

--- a/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPage.module.css
+++ b/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPage.module.css
@@ -18,7 +18,11 @@
   margin-top: var(--ds-size-12);
 }
 
-.customerListSnackbar {
+.customerListSnackbarWrapper .customerListSnackbar {
+  display: flex;
   align-self: flex-end;
   max-width: 20rem;
+}
+.customerListSnackbar {
+  display: none;
 }

--- a/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPage.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Alert, Spinner } from '@digdir/designsystemet-react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
+import { SnackbarProvider } from '@altinn/altinn-components';
 
 import {
   useGetAssignedCustomersQuery,
@@ -63,11 +64,13 @@ export const SystemUserAgentDelegationPage = (): React.ReactNode => {
           </Alert>
         )}
         {systemUser && customers && agentDelegations && (
-          <SystemUserAgentDelegationPageContent
-            systemUser={systemUser}
-            customers={customers}
-            existingAgentDelegations={agentDelegations}
-          />
+          <SnackbarProvider>
+            <SystemUserAgentDelegationPageContent
+              systemUser={systemUser}
+              customers={customers}
+              existingAgentDelegations={agentDelegations}
+            />
+          </SnackbarProvider>
         )}
       </PageLayoutWrapper>
     </PageWrapper>

--- a/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPageContent.tsx
+++ b/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPageContent.tsx
@@ -184,7 +184,7 @@ export const SystemUserAgentDelegationPageContent = ({
             onAddCustomer={onAddCustomer}
             onRemoveCustomer={onRemoveCustomer}
           />
-          <div className={classes.customerListSnackbarWrapper}>
+          <div>
             <Button onClick={onCloseModal}>{t('systemuser_agent_delegation.confirm_close')}</Button>
             <Snackbar className={classes.customerListSnackbar} />
           </div>

--- a/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPageContent.tsx
+++ b/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPageContent.tsx
@@ -5,14 +5,6 @@ import { useNavigate, useParams } from 'react-router';
 import { PencilIcon, PlusIcon } from '@navikt/aksel-icons';
 import { Snackbar, useSnackbar } from '@altinn/altinn-components';
 
-import { SystemUserHeader } from '../components/SystemUserHeader/SystemUserHeader';
-import type { AgentDelegation, AgentDelegationCustomer, SystemUser } from '../types';
-import { DeleteSystemUserPopover } from '../components/DeleteSystemUserPopover/DeleteSystemUserPopover';
-import { RightsList } from '../components/RightsList/RightsList';
-
-import classes from './SystemUserAgentDelegationPage.module.css';
-import { CustomerList } from './CustomerList';
-
 import { useGetReporteeQuery } from '@/rtk/features/userInfoApi';
 import { SystemUserPath } from '@/routes/paths';
 import { PageContainer } from '@/features/amUI/common/PageContainer/PageContainer';
@@ -22,6 +14,14 @@ import {
   useRemoveCustomerMutation,
 } from '@/rtk/features/systemUserApi';
 import { getCookie } from '@/resources/Cookie/CookieMethods';
+
+import { SystemUserHeader } from '../components/SystemUserHeader/SystemUserHeader';
+import type { AgentDelegation, AgentDelegationCustomer, SystemUser } from '../types';
+import { DeleteSystemUserPopover } from '../components/DeleteSystemUserPopover/DeleteSystemUserPopover';
+import { RightsList } from '../components/RightsList/RightsList';
+
+import classes from './SystemUserAgentDelegationPage.module.css';
+import { CustomerList } from './CustomerList';
 
 const getAssignedCustomers = (
   customers: AgentDelegationCustomer[],
@@ -184,7 +184,7 @@ export const SystemUserAgentDelegationPageContent = ({
             onAddCustomer={onAddCustomer}
             onRemoveCustomer={onRemoveCustomer}
           />
-          <div>
+          <div className={classes.customerListSnackbarWrapper}>
             <Button onClick={onCloseModal}>{t('systemuser_agent_delegation.confirm_close')}</Button>
             <Snackbar className={classes.customerListSnackbar} />
           </div>


### PR DESCRIPTION
## Description
- Wrap agent delegation in SnackbarProvider to only show snackbar in dialog

## Related Issue(s)
- this PR

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for displaying snackbars within the System User Agent Delegation page for improved user notifications.

- **Style**
  - Updated list item styles in the customer list to restore default outline behavior on hover.

- **Refactor**
  - Reorganized import statements for improved code structure (no impact on user experience).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->