### PR TITLE
Add language selection functionality

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/HomeController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/HomeController.cs
@@ -93,29 +93,32 @@ namespace Altinn.AccessManagement.UI.Controllers
 
             string goToUrl = HttpUtility.UrlEncode($"{_generalSettings.FrontendBaseUrl}{Request.Path}{Request.QueryString}");
             string redirectUrl = $"{_platformSettings.ApiAuthenticationEndpoint}authentication?goto={goToUrl}";
-            
+
             return Redirect(redirectUrl);
         }
 
         private async Task SetLanguageCookie()
         {
-            // Get the language code from the Altinn persistence cookie
-            string languageCode = LanguageHelper.GetAltinnPersistenceCookieValueFrontendStandard(_httpContextAccessor.HttpContext);
-            
-            // If the language code is not found in the Altinn persistence cookie, get the language code from user profile.
-            if (string.IsNullOrEmpty(languageCode))
+            if (HttpContext.Request.Cookies.ContainsKey("selectedLanguage") == false)
             {
-                int userId = AuthenticationHelper.GetUserId(_httpContextAccessor.HttpContext);
-                UserProfileFE user = await _userService.GetUserProfile(userId);
-                languageCode = LanguageHelper.GetFrontendStandardLanguage(user?.ProfileSettingPreference?.Language);
-            }
+                // Get the language code from the Altinn persistence cookie
+                string languageCode = LanguageHelper.GetAltinnPersistenceCookieValueFrontendStandard(_httpContextAccessor.HttpContext);
 
-            HttpContext.Response.Cookies.Append("selectedLanguage", languageCode ?? "no_nb", new CookieOptions
-            {
-                // Make this cookie readable by Javascript.
-                HttpOnly = false,
-                SameSite = SameSiteMode.Strict
-            });
+                // If the language code is not found in the Altinn persistence cookie, get the language code from user profile.
+                if (string.IsNullOrEmpty(languageCode))
+                {
+                    int userId = AuthenticationHelper.GetUserId(_httpContextAccessor.HttpContext);
+                    UserProfileFE user = await _userService.GetUserProfile(userId);
+                    languageCode = LanguageHelper.GetFrontendStandardLanguage(user?.ProfileSettingPreference?.Language);
+                }
+
+                HttpContext.Response.Cookies.Append("selectedLanguage", languageCode ?? "no_nb", new CookieOptions
+                {
+                    // Make this cookie readable by Javascript.
+                    HttpOnly = false,
+                    SameSite = SameSiteMode.Strict
+                });
+            }
         }
 
         private async Task<bool> ShouldShowAppView()

--- a/src/features/amUI/common/PageLayoutWrapper/PageLayoutWrapper.tsx
+++ b/src/features/amUI/common/PageLayoutWrapper/PageLayoutWrapper.tsx
@@ -32,7 +32,7 @@ export const PageLayoutWrapper = ({ children }: PageLayoutWrapperProps): React.R
   const { pathname } = useLocation();
   const [searchString, setSearchString] = useState<string>('');
 
-  const onChangeLocale = async (event: ChangeEvent<HTMLInputElement>) => {
+  const onChangeLocale = (event: ChangeEvent<HTMLInputElement>) => {
     const newLocale = event.target.value;
     i18n.changeLanguage(newLocale);
     document.cookie = `selectedLanguage=${newLocale}; path=/; SameSite=Strict`;

--- a/src/features/amUI/common/PageLayoutWrapper/PageLayoutWrapper.tsx
+++ b/src/features/amUI/common/PageLayoutWrapper/PageLayoutWrapper.tsx
@@ -35,7 +35,7 @@ export const PageLayoutWrapper = ({ children }: PageLayoutWrapperProps): React.R
   const onChangeLocale = async (event: ChangeEvent<HTMLInputElement>) => {
     const newLocale = event.target.value;
     i18n.changeLanguage(newLocale);
-    document.cookie = `selectedLanguage=${newLocale}; path=/; SameSite=Lax`;
+    document.cookie = `selectedLanguage=${newLocale}; path=/; SameSite=Strict`;
   };
 
   const isSm = useIsTabletOrSmaller();

--- a/src/features/amUI/common/PageLayoutWrapper/PageLayoutWrapper.tsx
+++ b/src/features/amUI/common/PageLayoutWrapper/PageLayoutWrapper.tsx
@@ -26,13 +26,19 @@ const getAccountType = (type: string): 'company' | 'person' => {
 };
 
 export const PageLayoutWrapper = ({ children }: PageLayoutWrapperProps): React.ReactNode => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { data: reportee } = useGetReporteeQuery();
   const { data: userinfo } = useGetUserInfoQuery();
   const { pathname } = useLocation();
   const [searchString, setSearchString] = useState<string>('');
-  const isSm = useIsTabletOrSmaller();
 
+  const onChangeLocale = async (event: ChangeEvent<HTMLInputElement>) => {
+    const newLocale = event.target.value;
+    i18n.changeLanguage(newLocale);
+    document.cookie = `selectedLanguage=${newLocale}; path=/; SameSite=Lax`;
+  };
+
+  const isSm = useIsTabletOrSmaller();
   const headerLinks: MenuItemProps[] = [
     {
       groupId: 1,
@@ -123,13 +129,21 @@ export const PageLayoutWrapper = ({ children }: PageLayoutWrapperProps): React.R
         color={'company'}
         theme='subtle'
         header={{
+          locale: {
+            title: t('header.locale_title'),
+            options: [
+              { label: 'Norsk (bokmål)', value: 'no_nb', checked: i18n.language === 'no_nb' },
+              { label: 'Norsk (nynorsk)', value: 'no_nn', checked: i18n.language === 'no_nn' },
+              { label: 'English', value: 'en', checked: i18n.language === 'en' },
+            ],
+            onChange: onChangeLocale,
+          },
           logo: { href: getAltinnStartPageUrl(), title: 'Altinn' },
           currentAccount: {
             name: reportee?.name || '',
             type: getAccountType(reportee?.type ?? ''),
             id: reportee?.partyUuid || '',
           },
-
           menu: {
             menuLabel: t('header.menu-label'),
             backLabel: t('header.back-label'),

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -90,7 +90,8 @@
     "back-label": "Back",
     "all_services": "All services",
     "chat": "Get help on chat",
-    "log_out": "Log out"
+    "log_out": "Log out",
+    "locale_title": "Choose language"
   },
   "footer": {
     "about_altinn": "About Altinn",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -102,7 +102,8 @@
     "back-label": "Tilbake",
     "all_services": "Alle tjenester",
     "chat": "Få hjelp på chat",
-    "log_out": "Logg ut"
+    "log_out": "Logg ut",
+    "locale_title": "Velg språk"
   },
   "footer": {
     "about_altinn": "Om Altinn",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -87,7 +87,8 @@
     "back-label": "Tilbake",
     "all_services": "Alle tjenester",
     "chat": "Få hjelp på chat",
-    "log_out": "Logg ut"
+    "log_out": "Logg ut",
+    "locale_title": "Vel språk"
   },
   "footer": {
     "about_altinn": "Om Altinn",


### PR DESCRIPTION
Bruke språkvelger i nytt gui

## Description
- Denne PR-en introduserer en språkvelger i toppmenyen. Velgeren oppdaterer det valgte språket og lagrer valget i en sesjonskapsel slik at valgt språk huskes til fanen lukkes.
- Foreløpig er det ingen synkronisering mellom A2 og A3.
- Når et API blir tilgjengelig for å lagre dette i brukerens profil, vil dette bli endret til å bruke nevnte API.

## Related Issue(s)
- [#1386](https://github.com/Altinn/altinn-access-management-frontend/issues/1386)

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added a language selection option in the header, allowing users to choose between Norwegian Bokmål, Norwegian Nynorsk, and English.
- **Localization**
  - Introduced new translations for the language selection title in English, Norwegian Bokmål, and Norwegian Nynorsk.
- **Refactor**
  - Improved the logic for setting and checking the selected language cookie to enhance language preference handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->