### PR TITLE
Test using avatars for both to- and from party

### DIFF
--- a/src/features/amUI/common/UserPageHeader/UserPageHeader.module.css
+++ b/src/features/amUI/common/UserPageHeader/UserPageHeader.module.css
@@ -6,6 +6,9 @@
 
 .avatar {
   grid-area: avatar;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 .name {
   grid-area: name;

--- a/src/features/amUI/common/UserPageHeader/UserPageHeader.tsx
+++ b/src/features/amUI/common/UserPageHeader/UserPageHeader.tsx
@@ -1,26 +1,59 @@
 import { Avatar, DsParagraph, DsHeading } from '@altinn/altinn-components';
 import type { ReactNode } from 'react';
-
-import classes from './UserPageHeader.module.css';
+import { ArrowRightIcon } from '@navikt/aksel-icons';
 
 import { PartyType } from '@/rtk/features/userInfoApi';
+
+import classes from './UserPageHeader.module.css';
 
 interface UserPageHeaderProps {
   userName?: string;
   userType?: PartyType;
   subHeading?: string;
   roles?: ReactNode;
+  secondaryAvatarName?: string;
+  secondaryAvatarType?: PartyType;
 }
 
-export const UserPageHeader = ({ userName, userType, subHeading, roles }: UserPageHeaderProps) => {
-  return (
-    <div className={classes.headingContainer}>
+export const UserPageHeader = ({
+  userName,
+  userType,
+  subHeading,
+  roles,
+  secondaryAvatarName,
+  secondaryAvatarType,
+}: UserPageHeaderProps) => {
+  const avatar = () => {
+    if (secondaryAvatarName && secondaryAvatarType) {
+      return (
+        <div className={classes.avatar}>
+          <Avatar
+            name={userName || ''}
+            size={'lg'}
+            type={userType === PartyType.Organization ? 'company' : 'person'}
+          />
+          <ArrowRightIcon style={{ fontSize: '1.5rem' }} />
+          <Avatar
+            name={secondaryAvatarName}
+            size={'lg'}
+            type={secondaryAvatarType === PartyType.Organization ? 'company' : 'person'}
+          />
+        </div>
+      );
+    }
+    return (
       <Avatar
         className={classes.avatar}
         name={userName || ''}
         size={'lg'}
         type={userType === PartyType.Organization ? 'company' : 'person'}
       />
+    );
+  };
+
+  return (
+    <div className={classes.headingContainer}>
+      {avatar()}
       <DsHeading
         level={1}
         data-size='sm'

--- a/src/features/amUI/reporteeRightsPage/ReporteeAccessPackageSection.tsx
+++ b/src/features/amUI/reporteeRightsPage/ReporteeAccessPackageSection.tsx
@@ -2,13 +2,13 @@ import { useTranslation } from 'react-i18next';
 import { useEffect, useRef, useState } from 'react';
 import { DsHeading } from '@altinn/altinn-components';
 
+import type { AccessPackage } from '@/rtk/features/accessPackageApi';
+
 import { AccessPackageList } from '../common/AccessPackageList/AccessPackageList';
 import { DelegationAction } from '../common/DelegationModal/EditModal';
 import { AccessPackageInfoModal } from '../userRightsPage/AccessPackageSection/AccessPackageInfoModal';
 import { useDelegationModalContext } from '../common/DelegationModal/DelegationModalContext';
 import { OldRolesAlert } from '../common/OldRolesAlert/OldRolesAlert';
-
-import type { AccessPackage } from '@/rtk/features/accessPackageApi';
 
 interface ReporteeAccessPackageSectionProps {
   numberOfAccesses?: number;
@@ -42,6 +42,7 @@ export const ReporteeAccessPackageSection = ({
         availableActions={[DelegationAction.REVOKE, DelegationAction.REQUEST]}
         useDeleteConfirm
         showAllPackages
+        minimizeAvailablePackages
         onSelect={(accessPackage) => {
           setModalItem(accessPackage);
           modalRef.current?.showModal();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

![image](https://github.com/user-attachments/assets/0946b017-648e-4adf-9013-72c95e964166)

## Description
<!--- Describe your changes in detail -->
Added use of multiple avatars to highlight the relationships between parts on "Accessess we have for others".

Also fixed so that packages the user does not already have, are not visible by default, so it matches the view of the rightholder pages.

## Related Issue(s)
- https://github.com/Altinn/altinn-access-management-frontend/issues/1365

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - User pages can now display a secondary avatar alongside the primary avatar, with an arrow icon between them, when additional party information is available.

- **Style**
  - Avatar images are now centered both vertically and horizontally within their container for improved alignment.

- **Refactor**
  - Improved handling and display of party information on the reportee rights page, distinguishing between "from" and "to" parties for clearer context.
  - Enhanced import organization for better code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->