### PR TITLE
Grant organizations access to access packages

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/ClientInterfaces/IAccessManagementClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/ClientInterfaces/IAccessManagementClient.cs
@@ -116,15 +116,6 @@ namespace Altinn.AccessManagement.UI.Core.ClientInterfaces
         Task<HttpResponseMessage> RevokeAccessPackage(Guid from, Guid to, string packageId);
 
         /// <summary>
-        ///    Creates a new delegation of an access package
-        /// </summary>
-        /// <param name="party">The party that is delegating the access</param>
-        /// <param name="to">The id of the right holder that will receive the delegation</param>
-        /// <param name="packageId">The id of the package to be delegated</param>
-        /// <param name="languageCode">The code of the language on which texts are to be returned</param>
-        Task<HttpResponseMessage> CreateAccessPackageDelegation(string party, Guid to, string packageId, string languageCode);
-
-        /// <summary>
         ///   Checks if the user can delegate access packages on behalf of the specified reportee
         /// </summary>
         /// <param name="delegationCheckRequest">The request containing the packages to check and the reportee to check on behalf of</param>

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/ClientInterfaces/IAccessPackageClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/ClientInterfaces/IAccessPackageClient.cs
@@ -3,17 +3,27 @@ using Altinn.AccessManagement.UI.Core.Models.Common;
 
 namespace Altinn.AccessManagement.UI.Core.ClientInterfaces
 {
+    /// <summary>
+    /// Interface for client to integrate with access package metadata
+    /// </summary>
+    public interface IAccessPackageClient
+    {
         /// <summary>
-        /// Interface for client to integrate with access package metadata
+        /// Retrieve result of a search in all access packages. If no parameters are given, all access packages are returned
         /// </summary>
-        public interface IAccessPackageClient
-        {
-                /// <summary>
-                /// Retrieve result of a search in all access packages. If no parameters are given, all access packages are returned
-                /// </summary>
-                /// <param name="languageCode">the language to use in texts returned and searched in</param>
-                /// <param name="searchString">the text to be searched for</param>
-                /// <returns>List of access packages matching the search parameters</returns>
-                Task<IEnumerable<SearchObject<AccessPackage>>> GetAccessPackageSearchMatches(string languageCode, string searchString);
-        }
+        /// <param name="languageCode">the language to use in texts returned and searched in</param>
+        /// <param name="searchString">the text to be searched for</param>
+        /// <returns>List of access packages matching the search parameters</returns>
+        Task<IEnumerable<SearchObject<AccessPackage>>> GetAccessPackageSearchMatches(string languageCode, string searchString);
+
+        /// <summary>
+        ///    Creates a new delegation of an access package
+        /// </summary>
+        /// <param name="party">The party that is performing the access delegation</param>
+        /// <param name="to">The id of the right holder that will receive the access</param>
+        /// <param name="from">The id of the party that the rightholder will be granted access on behalf of</param>
+        /// <param name="packageId">The id of the package to be delegated</param>
+        /// <param name="languageCode">The code of the language on which texts are to be returned</param>
+        Task<HttpResponseMessage> CreateAccessPackageDelegation(Guid party, Guid to, Guid from, string packageId, string languageCode);
+    }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/AccessPackageService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/AccessPackageService.cs
@@ -95,9 +95,9 @@ namespace Altinn.AccessManagement.UI.Core.Services
         }
 
         /// <inheritdoc/>
-        public async Task<HttpResponseMessage> CreateDelegation(string party, Guid to, string packageId, string languageCode)
+        public async Task<HttpResponseMessage> CreateDelegation(Guid party, Guid to, Guid from, string packageId, string languageCode)
         {
-            return await _accessManagementClient.CreateAccessPackageDelegation(party, to, packageId, languageCode);
+            return await _accessPackageClient.CreateAccessPackageDelegation(party, to, from, packageId, languageCode);
         }
 
         /// <inheritdoc/>

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/Interfaces/IAccessPackageService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/Interfaces/IAccessPackageService.cs
@@ -39,12 +39,13 @@ namespace Altinn.AccessManagement.UI.Core.Services.Interfaces
                 /// <summary>
                 ///    Creates a new delegation of an access package
                 /// </summary>
-                /// <param name="party">Identifies the selected party the authenticated user is acting on behalf of.</param>
-                /// <param name="to">The id of the right holder that will recieve the delegation</param>
+                /// <param name="party">The party that is performing the access delegation</param>
+                /// <param name="to">The id of the right holder that will receive the access</param>
+                /// <param name="from">The id of the party that the rightholder will be granted access on behalf of</param>
                 /// <param name="packageId">The id of the package to be delegated</param>
                 /// <param name="languageCode">The code of the language on which texts are to be returned</param>
                 /// <returns></returns> 
-                Task<HttpResponseMessage> CreateDelegation(string party, Guid to, string packageId, string languageCode);
+                Task<HttpResponseMessage> CreateDelegation(Guid party, Guid to, Guid from, string packageId, string languageCode);
 
                 /// <summary>
                 ///    Checks if the user can delegate access packages on behalf of the specified reportee

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/AccessManagementClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/AccessManagementClient.cs
@@ -247,20 +247,6 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
         }
 
         /// <inheritdoc />
-        public async Task<HttpResponseMessage> CreateAccessPackageDelegation(string party, Guid to, string packageId, string languageCode)
-        {
-            string endpointUrl = $"http://localhost:5117/accessmanagement/api/v1/accessmanagement/api/v1/enduser/access/accesspackages/{packageId}?to={to}"; // TODO: Switch with actual backend endpoint when available
-            string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
-            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, endpointUrl);
-            request.Headers.Add("Authorization", $"Bearer {token}");
-            request.Headers.Add("party", "{party}");
-
-            HttpResponseMessage response = await _client.SendAsync(request);
-
-            return response;
-        }
-
-        /// <inheritdoc />
         public Task<List<AccessPackageDelegationCheckResponse>> AccessPackageDelegationCheck(DelegationCheckRequest delegationCheckRequest)
         {
             throw new NotImplementedException();

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/AccessPackageClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/AccessPackageClient.cs
@@ -78,7 +78,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
         /// <inheritdoc />
         public async Task<HttpResponseMessage> CreateAccessPackageDelegation(Guid party, Guid to, Guid from, string packageId, string languageCode)
         {
-            string endpointUrl = $"enduser/connections/accesspackages?party={party}&to={to}&from={party}&package={packageId}&packageUrn={""}";
+            string endpointUrl = $"enduser/connections/accesspackages?party={party}&to={to}&from={party}&package={packageId}";
             string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
 
             var httpResponse = await _client.PostAsync(token, endpointUrl, null);

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/AccessPackageClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/AccessPackageClient.cs
@@ -74,5 +74,18 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
                 throw error;
             }
         }
+
+        /// <inheritdoc />
+        public async Task<HttpResponseMessage> CreateAccessPackageDelegation(Guid party, Guid to, Guid from, string packageId, string languageCode)
+        {
+            string endpointUrl = $"enduser/connections/accesspackages?party={party}&to={to}&from={party}&package={packageId}&packageUrn={""}";
+            string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
+
+            var httpResponse = await _client.PostAsync(token, endpointUrl, null);
+
+            var content = await httpResponse.Content.ReadAsStringAsync();
+
+            return httpResponse;
+        }
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/AccessPackageClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/AccessPackageClient.cs
@@ -83,8 +83,6 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
 
             var httpResponse = await _client.PostAsync(token, endpointUrl, null);
 
-            var content = await httpResponse.Content.ReadAsStringAsync();
-
             return httpResponse;
         }
     }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/AccessManagementClientMock.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/AccessManagementClientMock.cs
@@ -235,25 +235,6 @@ namespace Altinn.AccessManagement.UI.Mocks.Mocks
         }
 
         /// <inheritdoc />
-        public Task<HttpResponseMessage> CreateAccessPackageDelegation(string party, Guid to, string packageId, string languageCode)
-        {
-            ThrowExceptionIfTriggerParty(party);
-
-            if (packageId == string.Empty)
-            {
-                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.BadRequest));
-            }
-            else if (packageId == "5eb07bdc-5c3c-4c85-add3-5405b214b8a3") // Package is Renovasjon
-            {
-                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.BadRequest));
-            }
-            else
-            {
-                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Created));
-            }
-        }
-
-        /// <inheritdoc />
         public Task<List<AccessPackageDelegationCheckResponse>> AccessPackageDelegationCheck(DelegationCheckRequest delegationCheckRequest)
         {
             var res = new List<AccessPackageDelegationCheckResponse>();

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/AccessPackageClientMock.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/AccessPackageClientMock.cs
@@ -46,7 +46,7 @@ namespace Altinn.AccessManagement.UI.Mocks.Mocks
         {
             Util.ThrowExceptionIfTriggerParty(party.ToString());
 
-            if (packageId == string.Empty)
+            if (packageId == string.Empty || packageId == null)
             {
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.BadRequest));
             }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/AccessPackageClientMock.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/AccessPackageClientMock.cs
@@ -40,5 +40,24 @@ namespace Altinn.AccessManagement.UI.Mocks.Mocks
 
             return searchString != null ? Task.FromResult(searchResults.Where(sr => sr.Object.Name.ToLower().Contains(searchString.ToLower()))) : Task.FromResult(searchResults);
         }
+
+        /// <inheritdoc />
+        public Task<HttpResponseMessage> CreateAccessPackageDelegation(Guid party, Guid to, Guid from, string packageId, string languageCode)
+        {
+            Util.ThrowExceptionIfTriggerParty(party.ToString());
+
+            if (packageId == string.Empty)
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.BadRequest));
+            }
+            else if (packageId == "5eb07bdc-5c3c-4c85-add3-5405b214b8a3") // Package is Renovasjon
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.BadRequest));
+            }
+            else
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Created));
+            }
+        }
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Utils/Util.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Utils/Util.cs
@@ -57,5 +57,14 @@ namespace Altinn.AccessManagement.UI.Mocks.Utils
             }
         }
 
+        // A helper for testing handling of exceptions in clients
+        public static void ThrowExceptionIfTriggerParty(string id)
+        {
+            if (id == "********" || id == "00000000-0000-0000-0000-000000000000")
+            {
+                throw new Exception();
+            }
+        }
+
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/AccessPackageControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/AccessPackageControllerTest.cs
@@ -207,12 +207,13 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         public async Task CreateAccessPackageDelegation_ValidRequest_ReturnsCreated()
         {
             // Arrange
-            var party = "51329012";
-            var packageId = "test_package_id";
+            var party = "cd35779b-b174-4ecc-bbef-ece13611be7f";
+            var from = "cd35779b-b174-4ecc-bbef-ece13611be7f";
             var to = "167536b5-f8ed-4c5a-8f48-0279507e53ae";
+            var packageId = "test_package_id";
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/accesspackage/delegate/{party}/{packageId}/{to}", null);
+            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/accesspackage/delegations?party={party}&to={to}&from={from}&package={packageId}", null);
 
             // Assert
             response.EnsureSuccessStatusCode();
@@ -227,12 +228,13 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         public async Task CreateAccessPackageDelegation_UnexpectedException()
         {
             // Arrange
-            var party = "********";
-            var packageId = "test_package_id";
+            var party = Guid.Empty;
+            var from = "cd35779b-b174-4ecc-bbef-ece13611be7f";
             var to = "167536b5-f8ed-4c5a-8f48-0279507e53ae";
+            var packageId = "test_package_id";
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/accesspackage/delegate/{party}/{packageId}/{to}", null);
+            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/accesspackage/delegations?party={party}&to={to}&from={from}&package={packageId}", null);
 
             // Assert
             Assert.False(response.IsSuccessStatusCode);
@@ -248,12 +250,13 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         {
             // Arrange
 
-            var party = "51329012";
-            var packageId = "";
+            var party = "cd35779b-b174-4ecc-bbef-ece13611be7f";
+            var from = "cd35779b-b174-4ecc-bbef-ece13611be7f";
             var to = "167536b5-f8ed-4c5a-8f48-0279507e53ae";
+            var packageId = string.Empty;
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/accesspackage/delegate/{party}/{packageId}/{to}", null);
+            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/accesspackage/delegations?party={party}&to={to}&from={from}&package={packageId}", null);
 
             // Assert
             Assert.False(response.IsSuccessStatusCode);

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/AccessPackageControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/AccessPackageControllerTest.cs
@@ -213,7 +213,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             var packageId = "test_package_id";
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/accesspackage/delegations?party={party}&to={to}&from={from}&package={packageId}", null);
+            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/accesspackage/delegations?party={party}&to={to}&from={from}&packageId={packageId}", null);
 
             // Assert
             response.EnsureSuccessStatusCode();
@@ -234,7 +234,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             var packageId = "test_package_id";
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/accesspackage/delegations?party={party}&to={to}&from={from}&package={packageId}", null);
+            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/accesspackage/delegations?party={party}&to={to}&from={from}&packageId={packageId}", null);
 
             // Assert
             Assert.False(response.IsSuccessStatusCode);
@@ -256,7 +256,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             var packageId = string.Empty;
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/accesspackage/delegations?party={party}&to={to}&from={from}&package={packageId}", null);
+            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/accesspackage/delegations?party={party}&to={to}&from={from}&packageId={packageId}", null);
 
             // Assert
             Assert.False(response.IsSuccessStatusCode);

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/AccessPackageController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/AccessPackageController.cs
@@ -92,18 +92,22 @@ namespace Altinn.AccessManagement.UI.Controllers
         /// <summary>
         ///     Endpoint for delegating a accesspackage from the reportee party to a third party
         /// </summary>
+        /// <param name="party">The uuid of the party that is performing the access delegation</param>
+        /// <param name="to">The id of the right holder that will receive the access</param>
+        /// <param name="from">The id of the party that the rightholder will be granted access on behalf of</param>
+        /// <param name="packageId">The id of the package to be delegated</param>
         /// <response code="400">Bad Request</response>
         /// <response code="500">Internal Server Error</response>
         [HttpPost]
         [Authorize]
-        [Route("delegate/{party}/{packageId}/{to}")]
-        public async Task<ActionResult> CreateAccessPackageDelegation([FromRoute] string party, [FromRoute] string packageId, [FromRoute] Guid to)
+        [Route("delegations")]
+        public async Task<ActionResult> CreateAccessPackageDelegation([FromQuery] Guid party, [FromQuery] Guid to, [FromQuery] Guid from, [FromQuery] string packageId)
         {
             try
             {
                 var languageCode = LanguageHelper.GetSelectedLanguageCookieValueBackendStandard(_httpContextAccessor.HttpContext);
 
-                HttpResponseMessage response = await _accessPackageService.CreateDelegation(party, to, packageId, languageCode);
+                HttpResponseMessage response = await _accessPackageService.CreateDelegation(party, to, from, packageId, languageCode);
                 if (response.IsSuccessStatusCode)
                 {
                     return Ok(await response.Content.ReadAsStringAsync());
@@ -176,7 +180,7 @@ namespace Altinn.AccessManagement.UI.Controllers
         [HttpPost]
         [Authorize]
         [Route("delegationcheck")]
-        public async Task<ActionResult<List<AccessPackageDelegationCheckResponse>>> RoleDelegationCheck([FromBody] DelegationCheckRequest delegationCheckRequest)
+        public async Task<ActionResult<List<AccessPackageDelegationCheckResponse>>> DelegationCheck([FromBody] DelegationCheckRequest delegationCheckRequest)
         {
             if (!ModelState.IsValid || delegationCheckRequest.PackageIds == null || delegationCheckRequest.PackageIds.Length == 0)
             {

--- a/src/rtk/features/accessPackageApi.ts
+++ b/src/rtk/features/accessPackageApi.ts
@@ -90,11 +90,19 @@ export const accessPackageApi = createApi({
       },
       invalidatesTags: ['AccessPackages'],
     }),
-    delegatePackage: builder.mutation<void, { to: string; packageId: string }>({
+    delegatePackage: builder.mutation<
+      void,
+      { to: string; packageId: string; party?: string; from?: string }
+    >({
       invalidatesTags: ['AccessPackages'],
-      query: (args) => {
+      query: ({
+        to,
+        from = getCookie('AltinnPartyUuid'),
+        packageId,
+        party = getCookie('AltinnPartyUuid'),
+      }) => {
         return {
-          url: `delegate/${getCookie('AltinnPartyId')}/${args.packageId}/${args.to}`,
+          url: `delegations?party=${party}&to=${to}&from=${from}&packageId=${packageId}`,
           method: 'POST',
         };
       },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
![image](https://github.com/user-attachments/assets/be27b7ec-98ee-4bcf-bd71-303b8e317a1e)

Access managers can now grant organizations access to access packages through the use of the new backend endpoint for posting. The new delegation will, however, not show up on the user's page, as this part is still mocked.

So far, I have only been able to test posting through granting access to an org that is also in the mocked data. When attempting to grant access to a person, the operation fails with a 500 response.

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/467

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
