### PR TITLE
Fix bug where service owner was not provided to the translated error-message

### DIFF
--- a/src/features/singleRight/delegate/ChooseRightsPage/RightsActionBarContent/RightsActionBarContent.stories.tsx
+++ b/src/features/singleRight/delegate/ChooseRightsPage/RightsActionBarContent/RightsActionBarContent.stories.tsx
@@ -2,53 +2,108 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import { RightsActionBarContent } from './RightsActionBarContent';
 
+import { ErrorCode } from '@/resources/utils/errorCodeUtils';
+
 export default {
   title: 'Features/SingleRight/ChooseRightsPage/RightsActionBarContent',
   component: RightsActionBarContent,
 } as Meta;
 
-export const Default: StoryObj = {
-  args: {
-    toggleRight: (serviceIdentifier: string, action: string) => {
-      console.log(serviceIdentifier, action);
-    },
-    serviceDescription: 'Service description',
-    rightDescription: 'Right description',
-    serviceIdentifier: 'serviceIdentifier',
-    serviceType: 'serviceType',
-    serviceOwner: 'serviceOwner',
-    reportee: 'Superbuisness AS',
-    rights: [
-      {
-        action: 'action A',
-        rightKey: 'rightKey A',
-        delegable: true,
-        checked: true,
-        resourceReference: [
-          {
-            id: 'id A',
-            value: 'value A',
-          },
-        ],
-        details: [
-          {
-            code: 'code',
-            description: 'description',
-          },
-        ],
-      },
-      {
-        action: 'action B',
-        rightKey: 'rightKey B',
-        delegable: true,
-        checked: false,
-      },
-      {
-        action: 'action C',
-        rightKey: 'rightKey C',
-        delegable: false,
-        checked: false,
-      },
-    ],
+const defaultProps = (errorCode?: string) => ({
+  toggleRight: (serviceIdentifier: string, action: string) => {
+    console.log(serviceIdentifier, action);
   },
+  serviceDescription: 'Service description',
+  rightDescription: 'Right description',
+  serviceIdentifier: 'serviceIdentifier',
+  serviceType: 'ServiceType',
+  serviceOwner: 'Servicedirektoratet',
+  reportee: 'Best Buisness AS',
+  rights: [
+    {
+      action: 'action A',
+      rightKey: 'rightKey A',
+      delegable: true,
+      checked: true,
+      resourceReference: [
+        {
+          id: 'id A',
+          value: 'value A',
+        },
+      ],
+      details: [
+        {
+          code: 'code',
+          description: 'description',
+        },
+      ],
+    },
+    {
+      action: 'action B',
+      rightKey: 'rightKey B',
+      delegable: true,
+      checked: false,
+    },
+    errorCode
+      ? {
+          action: 'action C',
+          rightKey: 'rightKey C',
+          delegable: false,
+          checked: false,
+          details: [
+            {
+              code: errorCode,
+              description: 'description',
+            },
+          ],
+        }
+      : {
+          action: 'action C',
+          rightKey: 'rightKey C',
+          delegable: true,
+          checked: false,
+        },
+  ],
+});
+
+export const Default: StoryObj = {
+  args: defaultProps(),
+};
+
+export const Error_MissingSrrRightAccess: StoryObj = {
+  args: defaultProps(ErrorCode.MissingSrrRightAccess),
+};
+
+export const Error_AccessListValidationFail: StoryObj = {
+  args: defaultProps(ErrorCode.AccessListValidationFail),
+};
+
+export const Error_MissingRoleAccess: StoryObj = {
+  args: defaultProps(ErrorCode.MissingRoleAccess),
+};
+
+export const Error_MissingDelegationAccess: StoryObj = {
+  args: defaultProps(ErrorCode.MissingDelegationAccess),
+};
+
+export const Error_Unknown: StoryObj = {
+  args: defaultProps(ErrorCode.Unknown),
+};
+
+export const HTTPError: StoryObj = {
+  args: defaultProps(ErrorCode.HTTPError),
+};
+
+export const Unauthorized: StoryObj = {
+  args: defaultProps(ErrorCode.Unauthorized),
+};
+export const InsufficientAuthenticationLevel: StoryObj = {
+  args: defaultProps(ErrorCode.InsufficientAuthenticationLevel),
+};
+export const ErrorCodeUndefined: StoryObj = {
+  args: defaultProps(undefined),
+};
+
+export const ErrorCodeEmpty: StoryObj = {
+  args: defaultProps(''),
 };

--- a/src/features/singleRight/delegate/ChooseRightsPage/RightsActionBarContent/RightsActionBarContent.tsx
+++ b/src/features/singleRight/delegate/ChooseRightsPage/RightsActionBarContent/RightsActionBarContent.tsx
@@ -150,7 +150,7 @@ export const RightsActionBarContent = ({
           {t('single_rights.one_or_more_rights_is_undelegable', {
             reason: t(`${getErrorCodeTextKey(errorList[0])}`, {
               you: t('common.you_lowercase'),
-              resourceowner: serviceOwner,
+              serviceowner: serviceOwner,
               reporteeorg: reportee,
             }),
           })}


### PR DESCRIPTION

## Description
- Fix bug where service owner was not provided to the translated error-message
- Adding stories to storybook for testing

## Related Issue(s)
- #[4464](https://github.com/Altinn/altinn-support-private/issues/4464)
 
## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
<img width="904" alt="Screenshot 2025-05-21 at 12 57 44" src="https://github.com/user-attachments/assets/9894da80-7174-4006-a7e5-a75e186645e5" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added multiple new Storybook stories for the RightsActionBarContent component, showcasing different error states and scenarios.
- **Refactor**
  - Updated Storybook stories to use a factory function for props, improving consistency and flexibility.
- **Bug Fixes**
  - Corrected a translation key in alert messages to ensure proper localization of service owner information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->