### PR TITLE
fix: Update systemuser request page background color with new variable from designsystemet

### DIFF
--- a/src/features/amUI/systemUser/components/RequestPageBase/RequestPageBase.module.css
+++ b/src/features/amUI/systemUser/components/RequestPageBase/RequestPageBase.module.css
@@ -10,7 +10,7 @@
 
 .requestPage {
   min-height: 100vh;
-  background-color: var(--ds-color-neutral-background-subtle);
+  background-color: var(--ds-color-neutral-background-tinted);
 }
 
 .requestWrapper {


### PR DESCRIPTION
## Description
Color variable `--ds-color-neutral-background-subtle` does not exist, use `--ds-color-neutral-background-tinted` for background color on systemuser request page instead

## Related Issue(s)
- this PR

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the background color of request pages for a refreshed visual appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->