### PR TITLE
Make li interactive to enable links if isAdmin

### DIFF
--- a/src/features/amUI/common/UserList/ListWrapper.tsx
+++ b/src/features/amUI/common/UserList/ListWrapper.tsx
@@ -15,6 +15,7 @@ export interface UserListProps {
   indent?: boolean;
   isLoading?: boolean;
   listItemTitleAs?: 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+  interactive?: boolean;
 }
 
 export const ListWrapper = ({
@@ -24,6 +25,7 @@ export const ListWrapper = ({
   isLoading,
   indent,
   listItemTitleAs,
+  interactive,
 }: UserListProps) => {
   return (
     <div className={cn(indent ? classes.indent : '')}>
@@ -37,6 +39,7 @@ export const ListWrapper = ({
               key={user.partyUuid}
               user={user}
               titleAs={listItemTitleAs}
+              interactive={interactive}
             />
           ))
         )}

--- a/src/features/amUI/common/UserList/UserList.tsx
+++ b/src/features/amUI/common/UserList/UserList.tsx
@@ -1,20 +1,27 @@
 import { useTranslation } from 'react-i18next';
 import { Button, DsParagraph } from '@altinn/altinn-components';
 
-import type { User } from '@/rtk/features/userInfoApi';
-
 import { ListWrapper } from './ListWrapper';
 import { useFilteredUsers } from './useFilteredUsers';
 import classes from './UserList.module.css';
+
+import type { User } from '@/rtk/features/userInfoApi';
 
 export interface UserListProps {
   userList?: User[];
   searchString: string;
   isLoading?: boolean;
   listItemTitleAs?: 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+  interactive?: boolean;
 }
 
-export const UserList = ({ userList, searchString, isLoading, listItemTitleAs }: UserListProps) => {
+export const UserList = ({
+  userList,
+  searchString,
+  isLoading,
+  listItemTitleAs,
+  interactive,
+}: UserListProps) => {
   const { t } = useTranslation();
   const { users, hasNextPage, goNextPage } = useFilteredUsers({
     users: userList,
@@ -35,6 +42,7 @@ export const UserList = ({ userList, searchString, isLoading, listItemTitleAs }:
         size='md'
         isLoading={isLoading}
         listItemTitleAs={listItemTitleAs}
+        interactive={interactive}
       />
       {hasNextPage && (
         <div className={classes.showMoreButtonContainer}>

--- a/src/features/amUI/common/UserList/UserListItem.tsx
+++ b/src/features/amUI/common/UserList/UserListItem.tsx
@@ -7,8 +7,6 @@ import { Link } from 'react-router';
 import { ListWrapper } from './ListWrapper';
 import type { ExtendedUser } from './useFilteredUsers';
 
-import { useGetIsAdminQuery } from '@/rtk/features/userInfoApi';
-
 interface UserListItemProps extends ListItemProps {
   user: ExtendedUser;
 }
@@ -28,10 +26,15 @@ const userHeadingLevelForMapper = (level?: ElementType) => {
   }
 };
 
-export const UserListItem = ({ user, size = 'lg', titleAs, ...props }: UserListItemProps) => {
+export const UserListItem = ({
+  user,
+  size = 'lg',
+  titleAs,
+  interactive = false,
+  ...props
+}: UserListItemProps) => {
   const hasInheritingUsers = user.inheritingUsers?.length > 0;
   const [isExpanded, setExpanded] = useState(false);
-  const { data: isAdmin } = useGetIsAdminQuery();
 
   useEffect(
     () => setExpanded((user.matchInInheritingUsers && hasInheritingUsers) ?? false),
@@ -51,7 +54,7 @@ export const UserListItem = ({ user, size = 'lg', titleAs, ...props }: UserListI
         }}
         expanded={isExpanded}
         collapsible={hasInheritingUsers}
-        interactive={isAdmin}
+        interactive={interactive}
         linkIcon={!hasInheritingUsers}
         onClick={() => {
           if (hasInheritingUsers) setExpanded(!isExpanded);
@@ -75,6 +78,7 @@ export const UserListItem = ({ user, size = 'lg', titleAs, ...props }: UserListI
           spacing={1}
           indent
           listItemTitleAs={userHeadingLevelForMapper(titleAs)}
+          interactive={interactive}
         />
       )}
     </>

--- a/src/features/amUI/reportees/ReporteesList.tsx
+++ b/src/features/amUI/reportees/ReporteesList.tsx
@@ -55,6 +55,7 @@ export const ReporteesList = () => {
         searchString={searchString}
         isLoading={isLoading}
         listItemTitleAs='h2'
+        interactive
       />
     </div>
   );

--- a/src/features/amUI/users/UsersList.tsx
+++ b/src/features/amUI/users/UsersList.tsx
@@ -17,7 +17,6 @@ import {
   useGetUserInfoQuery,
 } from '@/rtk/features/userInfoApi';
 import { debounce } from '@/resources/utils';
-import { getCookie } from '@/resources/Cookie/CookieMethods';
 
 const extractFromList = (
   list: User[],
@@ -40,9 +39,7 @@ export const UsersList = () => {
   const { fromParty } = usePartyRepresentation();
   const displayLimitedPreviewLaunch = window.featureFlags?.displayLimitedPreviewLaunch;
 
-  const partyUuid = getCookie('AltinnPartyUuid');
-
-  const { data: isAdmin } = useGetIsAdminQuery({ partyUuid });
+  const { data: isAdmin } = useGetIsAdminQuery();
 
   const { data: rightHolders, isLoading: loadingRightHolders } = useGetRightHoldersQuery(
     {
@@ -137,6 +134,7 @@ export const UsersList = () => {
           searchString={searchString}
           isLoading={!userList || loadingRightHolders}
           listItemTitleAs='h2'
+          interactive={isAdmin}
         />
       )}
     </div>


### PR DESCRIPTION
Fix bug where links were not interactive due to a change component api


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated user list items to be interactive only for admin users, regardless of inheriting users. Non-admin users will see non-interactive list items.
  - Simplified admin status detection by removing cookie dependency.
  - Added a new option to control interactivity of user list items across related components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->