### PR TITLE
Include "access" property in agent delegation

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/SystemUser/AgentDelegationRequest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/SystemUser/AgentDelegationRequest.cs
@@ -14,5 +14,10 @@ namespace Altinn.AccessManagement.UI.Core.Models.SystemUser
         /// PartyUuid of party which owns the agent system user
         /// </summary>
         public Guid FacilitatorId { get; set; }
+
+        /// <summary>
+        /// Gets or sets a collection of all access information for the client 
+        /// </summary>
+        public List<ClientRoleAccessPackages> Access { get; set; } = [];
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/SystemUser/ClientRoleAccessPackages.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/SystemUser/ClientRoleAccessPackages.cs
@@ -1,0 +1,18 @@
+namespace Altinn.AccessManagement.UI.Core.Models.SystemUser
+{
+    /// <summary>
+    /// Composite Key instances
+    /// </summary>
+    public class ClientRoleAccessPackages
+    {
+        /// <summary>
+        /// Role
+        /// </summary>
+        public string Role { get; set; }
+
+        /// <summary>
+        /// Packages
+        /// </summary>
+        public string[] Packages { get; set; }
+    }
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/SystemUser/Customer.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/SystemUser/Customer.cs
@@ -19,5 +19,10 @@ namespace Altinn.AccessManagement.UI.Core.Models.SystemUser
         /// Organisation number
         /// </summary>
         public required string OrganizationIdentifier { get; set; }
+
+        /// <summary>
+        /// Gets or sets a collection of all access information for the client 
+        /// </summary>
+        public List<ClientRoleAccessPackages> Access { get; set; } = [];
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/SystemUser/Frontend/AgentDelegationRequestFE.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/SystemUser/Frontend/AgentDelegationRequestFE.cs
@@ -9,5 +9,10 @@ namespace Altinn.AccessManagement.UI.Core.Models.SystemUser
         /// The party uuid to add
         /// </summary>
         public Guid CustomerId { get; set; }
+
+        /// <summary>
+        /// Gets or sets a collection of all access information for the client 
+        /// </summary>
+        public List<ClientRoleAccessPackages> Access { get; set; } = [];
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/SystemUser/Frontend/CustomerPartyFE.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/SystemUser/Frontend/CustomerPartyFE.cs
@@ -19,5 +19,10 @@ namespace Altinn.AccessManagement.UI.Core.Models.SystemUser.Frontend
         /// Party organization number
         /// </summary>
         public string OrgNo { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets a collection of all access information for the client 
+        /// </summary>
+        public List<ClientRoleAccessPackages> Access { get; set; } = [];
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/SystemUserAgentDelegationService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/SystemUserAgentDelegationService.cs
@@ -113,7 +113,8 @@ namespace Altinn.AccessManagement.UI.Core.Services
                 {
                     Id = x.PartyUuid,
                     Name = x.DisplayName,
-                    OrgNo = x.OrganizationIdentifier
+                    OrgNo = x.OrganizationIdentifier,
+                    Access = x.Access
                 };
             }).ToList();
         }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/SystemUserAgentDelegationService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/SystemUserAgentDelegationService.cs
@@ -68,6 +68,7 @@ namespace Altinn.AccessManagement.UI.Core.Services
             AgentDelegationRequest delegationRequest = new()
             {
                 CustomerId = delegationRequestFe.CustomerId,
+                Access = delegationRequestFe.Access,
                 FacilitatorId = partyUuid
             };
 

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/SystemUser/forretningsforerCustomers.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/SystemUser/forretningsforerCustomers.json
@@ -6,7 +6,7 @@
     "access": [
       {
         "role": "urn:altinn:external-role:ccr:forretningsforer",
-        "packages": ["urn:altinn:accesspackage:forretningsforer-eiendom"]
+        "packages": ["forretningsforer-eiendom"]
       }
     ]
   }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/SystemUser/forretningsforerCustomers.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/SystemUser/forretningsforerCustomers.json
@@ -2,6 +2,12 @@
   {
     "partyUuid": "b4c3ba12-7e87-4ae1-84f8-426b1decfacf",
     "displayName": "VIKESÅ OG ÅLVUNDFJORD",
-    "organizationIdentifier": "910510789"
+    "organizationIdentifier": "910510789",
+    "access": [
+      {
+        "role": "urn:altinn:external-role:ccr:forretningsforer",
+        "packages": ["urn:altinn:accesspackage:forretningsforer-eiendom"]
+      }
+    ]
   }
 ]

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/SystemUser/regnskapsforerCustomers.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/SystemUser/regnskapsforerCustomers.json
@@ -6,7 +6,7 @@
     "access": [
       {
         "role": "urn:altinn:external-role:ccr:regnskapsforer",
-        "packages": ["urn:altinn:accesspackage:regnskapsforer-med-signeringsrettighet"]
+        "packages": ["regnskapsforer-med-signeringsrettighet"]
       }
     ]
   },
@@ -17,7 +17,7 @@
     "access": [
       {
         "role": "urn:altinn:external-role:ccr:regnskapsforer",
-        "packages": ["urn:altinn:accesspackage:regnskapsforer-med-signeringsrettighet"]
+        "packages": ["regnskapsforer-med-signeringsrettighet"]
       }
     ]
   },
@@ -28,7 +28,7 @@
     "access": [
       {
         "role": "urn:altinn:external-role:ccr:regnskapsforer",
-        "packages": ["urn:altinn:accesspackage:regnskapsforer-med-signeringsrettighet"]
+        "packages": ["regnskapsforer-med-signeringsrettighet"]
       }
     ]
   },
@@ -39,7 +39,7 @@
     "access": [
       {
         "role": "urn:altinn:external-role:ccr:regnskapsforer",
-        "packages": ["urn:altinn:accesspackage:regnskapsforer-med-signeringsrettighet"]
+        "packages": ["regnskapsforer-med-signeringsrettighet"]
       }
     ]
   },
@@ -50,7 +50,7 @@
     "access": [
       {
         "role": "urn:altinn:external-role:ccr:regnskapsforer",
-        "packages": ["urn:altinn:accesspackage:regnskapsforer-med-signeringsrettighet"]
+        "packages": ["regnskapsforer-med-signeringsrettighet"]
       }
     ]
   }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/SystemUser/regnskapsforerCustomers.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/SystemUser/regnskapsforerCustomers.json
@@ -2,26 +2,56 @@
   {
     "partyUuid": "b4c3ba12-7e87-4ae1-84f8-426b1decfacf",
     "displayName": "VIKESÅ OG ÅLVUNDFJORD",
-    "organizationIdentifier": "910510789"
+    "organizationIdentifier": "910510789",
+    "access": [
+      {
+        "role": "urn:altinn:external-role:ccr:regnskapsforer",
+        "packages": ["urn:altinn:accesspackage:regnskapsforer-med-signeringsrettighet"]
+      }
+    ]
   },
   {
     "partyUuid": "60fb3d5b-99c2-4df0-aa77-f3fca3bc5199",
     "displayName": "RAKRYGGET UNG TIGER AS",
-    "organizationIdentifier": "313523497"
+    "organizationIdentifier": "313523497",
+    "access": [
+      {
+        "role": "urn:altinn:external-role:ccr:regnskapsforer",
+        "packages": ["urn:altinn:accesspackage:regnskapsforer-med-signeringsrettighet"]
+      }
+    ]
   },
   {
     "partyUuid": "6b0574ae-f569-4c0d-a8d4-8ad56f427890",
     "displayName": "Digitaliseringsdirektoratet",
-    "organizationIdentifier": "991825827"
+    "organizationIdentifier": "991825827",
+    "access": [
+      {
+        "role": "urn:altinn:external-role:ccr:regnskapsforer",
+        "packages": ["urn:altinn:accesspackage:regnskapsforer-med-signeringsrettighet"]
+      }
+    ]
   },
   {
     "partyUuid": "82cc64c5-60ff-4184-8c07-964c3a1e6fc7",
     "displayName": "Kan ikke legges til",
-    "organizationIdentifier": "881825827"
+    "organizationIdentifier": "881825827",
+    "access": [
+      {
+        "role": "urn:altinn:external-role:ccr:regnskapsforer",
+        "packages": ["urn:altinn:accesspackage:regnskapsforer-med-signeringsrettighet"]
+      }
+    ]
   },
   {
     "partyUuid": "56d8ef08-d1c3-4dac-8b62-461c18ce612b",
     "displayName": "Kan ikke fjernes",
-    "organizationIdentifier": "313131317"
+    "organizationIdentifier": "313131317",
+    "access": [
+      {
+        "role": "urn:altinn:external-role:ccr:regnskapsforer",
+        "packages": ["urn:altinn:accesspackage:regnskapsforer-med-signeringsrettighet"]
+      }
+    ]
   }
 ]

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/SystemUser/revisorCustomers.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/SystemUser/revisorCustomers.json
@@ -6,7 +6,7 @@
     "access": [
       {
         "role": "urn:altinn:external-role:ccr:revisor",
-        "packages": ["urn:altinn:accesspackage:ansvarlig-revisor"]
+        "packages": ["ansvarlig-revisor"]
       }
     ]
   }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/SystemUser/revisorCustomers.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/SystemUser/revisorCustomers.json
@@ -2,6 +2,12 @@
   {
     "partyUuid": "87ee6b0e-5d14-4365-82df-d1ee436b51a8",
     "displayName": "STA TOM TIGER AS",
-    "organizationIdentifier": "313160300"
+    "organizationIdentifier": "313160300",
+    "access": [
+      {
+        "role": "urn:altinn:external-role:ccr:revisor",
+        "packages": ["urn:altinn:accesspackage:ansvarlig-revisor"]
+      }
+    ]
   }
 ]

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/SystemUserAgentDelegationControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/SystemUserAgentDelegationControllerTest.cs
@@ -215,7 +215,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
                     new ClientRoleAccessPackages()
                     {
                         Role = "urn:altinn:external-role:ccr:regnskapsforer",
-                        Packages = ["urn:altinn:accesspackage:regnskapsforer-med-signeringsrettighet"]
+                        Packages = ["regnskapsforer-med-signeringsrettighet"]
                     }
                 ]
             };
@@ -258,7 +258,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
                     new ClientRoleAccessPackages()
                     {
                         Role = "urn:altinn:external-role:ccr:revisor",
-                        Packages = ["urn:altinn:accesspackage:ansvarlig-revisor"]
+                        Packages = ["ansvarlig-revisor"]
                     }
                 ]
             };
@@ -301,7 +301,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
                     new ClientRoleAccessPackages()
                     {
                         Role = "urn:altinn:external-role:ccr:regnskapsforer",
-                        Packages = ["urn:altinn:accesspackage:regnskapsforer-med-signeringsrettighet"]
+                        Packages = ["regnskapsforer-med-signeringsrettighet"]
                     }
                 ]
             };

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/SystemUserAgentDelegationControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/SystemUserAgentDelegationControllerTest.cs
@@ -209,7 +209,15 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             
             AgentDelegationRequestFE dto = new AgentDelegationRequestFE
             {
-                CustomerId = Guid.Parse(customerId)
+                CustomerId = Guid.Parse(customerId),
+                Access = 
+                [
+                    new ClientRoleAccessPackages()
+                    {
+                        Role = "urn:altinn:external-role:ccr:regnskapsforer",
+                        Packages = ["urn:altinn:accesspackage:regnskapsforer-med-signeringsrettighet"]
+                    }
+                ]
             };
             string jsonDto = JsonSerializer.Serialize(dto);
             HttpContent content = new StringContent(jsonDto, Encoding.UTF8, "application/json");
@@ -244,7 +252,15 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             
             AgentDelegationRequestFE dto = new AgentDelegationRequestFE
             {
-                CustomerId = Guid.Parse(customerId)
+                CustomerId = Guid.Parse(customerId),
+                Access = 
+                [
+                    new ClientRoleAccessPackages()
+                    {
+                        Role = "urn:altinn:external-role:ccr:revisor",
+                        Packages = ["urn:altinn:accesspackage:ansvarlig-revisor"]
+                    }
+                ]
             };
             string jsonDto = JsonSerializer.Serialize(dto);
             HttpContent content = new StringContent(jsonDto, Encoding.UTF8, "application/json");
@@ -280,6 +296,14 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             AgentDelegationRequestFE dto = new AgentDelegationRequestFE
             {
                 CustomerId = Guid.Parse(customerId),
+                Access = 
+                [
+                    new ClientRoleAccessPackages()
+                    {
+                        Role = "urn:altinn:external-role:ccr:regnskapsforer",
+                        Packages = ["urn:altinn:accesspackage:regnskapsforer-med-signeringsrettighet"]
+                    }
+                ]
             };
             string jsonDto = JsonSerializer.Serialize(dto);
             HttpContent content = new StringContent(jsonDto, Encoding.UTF8, "application/json");

--- a/src/features/amUI/systemUser/SystemUserAgentDelegationPage/CustomerList.tsx
+++ b/src/features/amUI/systemUser/SystemUserAgentDelegationPage/CustomerList.tsx
@@ -9,11 +9,11 @@ import {
 import { MinusCircleIcon, PlusCircleIcon } from '@navikt/aksel-icons';
 import { useTranslation } from 'react-i18next';
 
+import { AmPagination } from '@/components/Paginering';
+
 import type { AgentDelegation, AgentDelegationCustomer } from '../types';
 
 import classes from './CustomerList.module.css';
-
-import { AmPagination } from '@/components/Paginering';
 
 const filterCustomerList = (
   list: AgentDelegationCustomer[],
@@ -34,7 +34,7 @@ interface CustomerListProps {
   delegations?: AgentDelegation[];
   loadingIds?: string[];
   errorIds?: string[];
-  onAddCustomer?: (customerId: string, customerName: string) => void;
+  onAddCustomer?: (customer: AgentDelegationCustomer) => void;
   onRemoveCustomer?: (delegationToRemove: AgentDelegation, customerName: string) => void;
   children?: React.ReactNode;
 }
@@ -128,7 +128,7 @@ interface ListControlsProps {
   isLoading?: boolean;
   isError?: boolean;
   onRemoveCustomer?: (delegationToRemove: AgentDelegation, customerName: string) => void;
-  onAddCustomer?: (customerId: string, customerName: string) => void;
+  onAddCustomer?: (customer: AgentDelegationCustomer) => void;
 }
 const ListControls = ({
   customer,
@@ -180,7 +180,7 @@ const ListControls = ({
           aria-label={t('systemuser_agent_delegation.add_to_system_user_aria', {
             customerName: customer.name,
           })}
-          onClick={() => onAddCustomer(customer.id, customer.name)}
+          onClick={() => onAddCustomer(customer)}
         >
           <PlusCircleIcon /> {t('systemuser_agent_delegation.add_to_system_user')}
         </DsButton>

--- a/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPageContent.tsx
+++ b/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPageContent.tsx
@@ -99,22 +99,22 @@ export const SystemUserAgentDelegationPageContent = ({
     });
   };
 
-  const onAddCustomer = (customerId: string, customerName: string): void => {
-    setLoadingIds((oldLoadingIds) => [...oldLoadingIds, customerId]);
+  const onAddCustomer = (customer: AgentDelegationCustomer): void => {
+    setLoadingIds((oldLoadingIds) => [...oldLoadingIds, customer.id]);
     const onAddSuccess = (delegation: AgentDelegation) => {
       setDelegations((oldDelegations) => [...oldDelegations, delegation]);
       showConfirmationSnackbar(
         t('systemuser_agent_delegation.customer_added', {
-          customerName,
+          customerName: customer.name,
         }),
         'success',
       );
     };
-    assignCustomer({ partyId, systemUserId: id ?? '', customerId: customerId, partyUuid })
+    assignCustomer({ partyId, systemUserId: id ?? '', customer: customer, partyUuid })
       .unwrap()
       .then(onAddSuccess)
-      .catch(() => setErrorId(customerId))
-      .finally(() => resetLoadingId(customerId));
+      .catch(() => setErrorId(customer.id))
+      .finally(() => resetLoadingId(customer.id));
   };
 
   const onRemoveCustomer = (toRemove: AgentDelegation, customerName: string): void => {

--- a/src/features/amUI/systemUser/types.ts
+++ b/src/features/amUI/systemUser/types.ts
@@ -52,6 +52,10 @@ export interface AgentDelegationCustomer {
   id: string;
   name: string;
   orgNo: string;
+  access: {
+    role: string;
+    packages: string[];
+  }[];
 }
 
 export interface AgentDelegation {

--- a/src/rtk/features/systemUserApi.ts
+++ b/src/rtk/features/systemUserApi.ts
@@ -110,13 +110,19 @@ export const systemUserApi = createApi({
     }),
     assignCustomer: builder.mutation<
       AgentDelegation,
-      { partyId: string; systemUserId: string; customerId: string; partyUuid: string }
+      {
+        partyId: string;
+        systemUserId: string;
+        customer: AgentDelegationCustomer;
+        partyUuid: string;
+      }
     >({
-      query: ({ partyId, systemUserId, customerId, partyUuid }) => ({
+      query: ({ partyId, systemUserId, customer, partyUuid }) => ({
         url: `systemuser/agentdelegation/${partyId}/${systemUserId}/delegation?partyuuid=${partyUuid}`,
         method: 'POST',
         body: {
-          customerId: customerId,
+          customerId: customer.id,
+          access: customer.access,
         },
       }),
     }),


### PR DESCRIPTION
## Description
- Customer API returns property "access". Send this property back to backend when assigning clients to agent system user

## Related Issue(s)
- this PR

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for managing and displaying multiple access roles and associated packages for customers in agent delegation workflows.
- **Bug Fixes**
  - Improved the structure of delegation requests to include comprehensive access information.
- **Tests**
  - Updated tests to validate the new access roles and package structure in delegation requests.
- **Refactor**
  - Updated interfaces and function signatures to handle customer access data as structured objects rather than separate fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->