### PR TITLE
Add nullable Role-EntityTypeId and truncate roles

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/User/Connection/RoleInfo.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/User/Connection/RoleInfo.cs
@@ -13,7 +13,7 @@ public class RoleInfo
     /// <summary>
     /// Gets or sets the unique identifier for the entity type associated with the role.
     /// </summary>
-    public Guid EntityTypeId { get; set; }
+    public Guid? EntityTypeId { get; set; }
 
     /// <summary>
     /// Gets or sets the unique identifier for the provider of the role.

--- a/src/features/amUI/common/CurrentUserPageHeader/CurrentUserPageHeader.tsx
+++ b/src/features/amUI/common/CurrentUserPageHeader/CurrentUserPageHeader.tsx
@@ -12,6 +12,8 @@ interface CurrentUserPageHeaderProps {
 }
 
 export const CurrentUserPageHeader = ({ currentUser, as, loading }: CurrentUserPageHeaderProps) => {
+  const description = currentUser?.roles?.join(', ') ?? '';
+
   return (
     <div className={classes.currentUser}>
       {loading ? (
@@ -26,7 +28,7 @@ export const CurrentUserPageHeader = ({ currentUser, as, loading }: CurrentUserP
           <ListItemHeader
             size='xl'
             title={currentUser?.name}
-            description={currentUser?.roles?.join(', ')}
+            description={`${description.slice(0, 100)}${description.length > 100 && '...'}`}
             avatar={{
               type: 'person',
               name: currentUser?.name || '',

--- a/src/features/amUI/common/UserList/UserListItem.tsx
+++ b/src/features/amUI/common/UserList/UserListItem.tsx
@@ -41,13 +41,15 @@ export const UserListItem = ({
     [user.matchInInheritingUsers, hasInheritingUsers],
   );
 
+  const description = user.roles?.join(', ') ?? '';
+
   return (
     <>
       <ListItem
         {...props}
         size={size}
         title={`${user.name} ${user.organizationNumber && !hasInheritingUsers ? `(${user.organizationNumber})` : ''}`}
-        description={user.roles?.join(', ') ?? ''}
+        description={`${description.slice(0, 100)}${description.length > 100 && '...'}`}
         avatar={{
           name: user.name,
           type: user.partyType.toString() === 'Organization' ? 'company' : 'person',


### PR DESCRIPTION
Fix a bug where role.EntityTypeId can be null. 
Also truncates the roles displayed in user list to the first 100 chars to make it look ok. 

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
