### PR TITLE
Fix hook call order when changing viewport size

### DIFF
--- a/src/features/amUI/common/PageLayoutWrapper/PageLayoutWrapper.tsx
+++ b/src/features/amUI/common/PageLayoutWrapper/PageLayoutWrapper.tsx
@@ -8,6 +8,7 @@ import { HandshakeIcon, InboxIcon, MenuGridIcon, PersonChatIcon } from '@navikt/
 
 import type { ReporteeInfo } from '@/rtk/features/userInfoApi';
 import {
+  useGetIsAdminQuery,
   useGetReporteeListForAuthorizedUserQuery,
   useGetReporteeQuery,
   useGetUserInfoQuery,
@@ -33,6 +34,8 @@ export const PageLayoutWrapper = ({ children }: PageLayoutWrapperProps): React.R
   const { data: reporteeList } = useGetReporteeListForAuthorizedUserQuery();
   const { pathname } = useLocation();
   const [searchString, setSearchString] = useState<string>('');
+
+  const { data: isAdmin } = useGetIsAdminQuery();
 
   const onChangeLocale = (event: ChangeEvent<HTMLInputElement>) => {
     const newLocale = event.target.value;
@@ -68,7 +71,7 @@ export const PageLayoutWrapper = ({ children }: PageLayoutWrapperProps): React.R
         />
       ),
     },
-    ...(isSm ? SidebarItems(true, pathname) : []),
+    ...(isSm ? SidebarItems(true, pathname, isAdmin) : []),
     {
       id: 'all-services',
       groupId: 10,
@@ -190,7 +193,7 @@ export const PageLayoutWrapper = ({ children }: PageLayoutWrapperProps): React.R
         sidebar={{
           menu: {
             groups: {},
-            items: SidebarItems(false, pathname),
+            items: SidebarItems(false, pathname, isAdmin),
           },
         }}
         content={{ color: 'company' }}

--- a/src/features/amUI/common/PageLayoutWrapper/SidebarItems.tsx
+++ b/src/features/amUI/common/PageLayoutWrapper/SidebarItems.tsx
@@ -5,7 +5,6 @@ import { t } from 'i18next';
 import { Link } from 'react-router';
 
 import { amUIPath, SystemUserPath } from '@/routes/paths';
-import { useGetIsAdminQuery } from '@/rtk/features/userInfoApi';
 
 /**
  * Generates a list of sidebar items for the page layout.
@@ -13,9 +12,12 @@ import { useGetIsAdminQuery } from '@/rtk/features/userInfoApi';
  * @returns {MenuItemProps[]} A list of sidebar items, including a heading,
  *                            and optionally a confetti package if the feature flag is enabled.
  */
-export const SidebarItems = (isSmall: boolean = false, pathname: string = '') => {
+export const SidebarItems = (
+  isSmall: boolean = false,
+  pathname: string = '',
+  isAdmin: boolean | undefined,
+) => {
   const displayConfettiPackage = window.featureFlags?.displayConfettiPackage;
-  const { data: isAdmin } = useGetIsAdminQuery();
   const heading: MenuItemProps = {
     id: '1',
     groupId: 1,


### PR DESCRIPTION
## Description
On narrow screens, the Sidebar component will not be displayed. The Sidebar component has a hook call, and React expects all hooks to be called in the same order. Changing the viewport width do the Sidebar menu is hidden or displayed will cause a crash. Fix: Move useIsAdminQuery hook call to PageLayoutWrapper to avoid hook order issue when changing viewport width


https://github.com/user-attachments/assets/2da8baa7-f231-4cf4-a172-54b2e559a88c


## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/839

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Sidebar menu now adapts its content based on whether the user has admin privileges, providing a tailored navigation experience for admins and non-admins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->