### PR TITLE
Serialize partyId as int instead of string

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/SystemUser/Frontend/SystemUserAgentRequestFE.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/SystemUser/Frontend/SystemUserAgentRequestFE.cs
@@ -23,7 +23,7 @@ namespace Altinn.AccessManagement.UI.Core.Models.SystemUser.Frontend
         /// </summary>
         [Required]
         [JsonPropertyName("partyId")]
-        public string PartyId { get; set; }
+        public int PartyId { get; set; }
 
         /// <summary>
         /// PartyUuid of the SystemUser's Party (the customer that delegates rights to the systemuser).

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/SystemUser/Frontend/SystemUserRequestFE.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/SystemUser/Frontend/SystemUserRequestFE.cs
@@ -23,7 +23,7 @@ namespace Altinn.AccessManagement.UI.Core.Models.SystemUser.Frontend
         /// </summary>
         [Required]
         [JsonPropertyName("partyId")]
-        public string PartyId { get; set; }
+        public int PartyId { get; set; }
 
         /// <summary>
         /// PartyUuid of the SystemUser's Party (the customer that delegates rights to the systemuser).

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/SystemUser/SystemUserAgentRequest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/SystemUser/SystemUserAgentRequest.cs
@@ -21,7 +21,7 @@ namespace Altinn.AccessManagement.UI.Core.Models.SystemUser
         /// </summary>
         [Required]
         [JsonPropertyName("partyId")]
-        public string PartyId { get; set; }
+        public int PartyId { get; set; }
 
         /// <summary>
         /// PartyUuid of the SystemUser's Party (the customer that delegates rights to the systemuser).

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/SystemUser/SystemUserRequest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/SystemUser/SystemUserRequest.cs
@@ -21,7 +21,7 @@ namespace Altinn.AccessManagement.UI.Core.Models.SystemUser
         /// </summary>
         [Required]
         [JsonPropertyName("partyId")]
-        public string PartyId { get; set; }
+        public int PartyId { get; set; }
 
         /// <summary>
         /// PartyUuid of the SystemUser's Party (the customer that delegates rights to the systemuser).


### PR DESCRIPTION
## Description
Backend sends partyId as int, so we should deserialize it as int.

## Related Issue(s)
- this PR

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
