### PR TITLE
Use partyId prop to get reportee for canCreateSystemUser check instead of using partyId from cookie

### DIFF
--- a/src/features/amUI/systemUser/CreateSystemUserPage/SelectRegisteredSystem.tsx
+++ b/src/features/amUI/systemUser/CreateSystemUserPage/SelectRegisteredSystem.tsx
@@ -3,15 +3,16 @@ import { useTranslation } from 'react-i18next';
 import { Link, useNavigate } from 'react-router';
 import { DsHeading, DsParagraph, DsAlert, DsButton, DsCombobox } from '@altinn/altinn-components';
 
+import { useGetRegisteredSystemsQuery } from '@/rtk/features/systemUserApi';
+import { SystemUserPath } from '@/routes/paths';
+import { PageContainer } from '@/features/amUI/common/PageContainer/PageContainer';
+import { getCookie } from '@/resources/Cookie/CookieMethods';
+
 import { ButtonRow } from '../components/ButtonRow/ButtonRow';
 import type { RegisteredSystem } from '../types';
 import { CreateSystemUserCheck } from '../components/CanCreateSystemUser/CanCreateSystemUser';
 
 import classes from './CreateSystemUser.module.css';
-
-import { useGetRegisteredSystemsQuery } from '@/rtk/features/systemUserApi';
-import { SystemUserPath } from '@/routes/paths';
-import { PageContainer } from '@/features/amUI/common/PageContainer/PageContainer';
 
 const isStringMatch = (inputString: string, matchString = ''): boolean => {
   return matchString.toLowerCase().indexOf(inputString.toLowerCase()) >= 0;
@@ -30,6 +31,7 @@ export const SelectRegisteredSystem = ({
 }: SelectRegisteredSystemProps) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const partyId = getCookie('AltinnPartyId');
 
   const {
     data: registeredSystems,
@@ -52,7 +54,7 @@ export const SelectRegisteredSystem = ({
         >
           {t('systemuser_creationpage.sub_title')}
         </DsHeading>
-        <CreateSystemUserCheck>
+        <CreateSystemUserCheck partyId={partyId}>
           <DsParagraph
             data-size='sm'
             className={classes.systemDescription}

--- a/src/features/amUI/systemUser/SystemUserAgentRequestPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserAgentRequestPage.tsx
@@ -7,7 +7,7 @@ import {
   useGetAgentSystemUserRequestQuery,
   useApproveAgentSystemUserRequestMutation,
   useRejectAgentSystemUserRequestMutation,
-  useGetSystemUserRequestReporteeQuery,
+  useGetSystemUserReporteeQuery,
 } from '@/rtk/features/systemUserApi';
 import { SystemUserPath } from '@/routes/paths';
 import { useDocumentTitle } from '@/resources/hooks/useDocumentTitle';
@@ -37,7 +37,7 @@ export const SystemUserAgentRequestPage = () => {
       skip: !requestId,
     },
   );
-  const { data: reporteeData } = useGetSystemUserRequestReporteeQuery(request?.partyId ?? '', {
+  const { data: reporteeData } = useGetSystemUserReporteeQuery(request?.partyId ?? '', {
     skip: !request?.partyId,
   });
 
@@ -163,7 +163,7 @@ export const SystemUserAgentRequestPage = () => {
                 {t('systemuser_request.reject_error')}
               </DsAlert>
             )}
-            <CreateSystemUserCheck>
+            <CreateSystemUserCheck partyId={request.partyId}>
               <ButtonRow>
                 <DsButton
                   variant='primary'

--- a/src/features/amUI/systemUser/SystemUserChangeRequestPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserChangeRequestPage.tsx
@@ -162,7 +162,7 @@ export const SystemUserChangeRequestPage = () => {
                 {t('systemuser_change_request.reject_error')}
               </DsAlert>
             )}
-            <CreateSystemUserCheck>
+            <CreateSystemUserCheck partyId={partyId}>
               <ButtonRow>
                 <DsButton
                   variant='primary'

--- a/src/features/amUI/systemUser/SystemUserRequestPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserRequestPage.tsx
@@ -9,7 +9,7 @@ import {
   useGetSystemUserRequestQuery,
   useApproveSystemUserRequestMutation,
   useRejectSystemUserRequestMutation,
-  useGetSystemUserRequestReporteeQuery,
+  useGetSystemUserReporteeQuery,
 } from '@/rtk/features/systemUserApi';
 
 import { RequestPageBase } from './components/RequestPageBase/RequestPageBase';
@@ -37,7 +37,7 @@ export const SystemUserRequestPage = () => {
       skip: !requestId,
     },
   );
-  const { data: reporteeData } = useGetSystemUserRequestReporteeQuery(request?.partyId ?? '', {
+  const { data: reporteeData } = useGetSystemUserReporteeQuery(request?.partyId ?? '', {
     skip: !request?.partyId,
   });
 
@@ -164,7 +164,7 @@ export const SystemUserRequestPage = () => {
                 {t('systemuser_request.reject_error')}
               </DsAlert>
             )}
-            <CreateSystemUserCheck>
+            <CreateSystemUserCheck partyId={request.partyId}>
               <ButtonRow>
                 <DsButton
                   variant='primary'

--- a/src/features/amUI/systemUser/SystemUsersOverviewPage/SystemUserOverviewPage.tsx
+++ b/src/features/amUI/systemUser/SystemUsersOverviewPage/SystemUserOverviewPage.tsx
@@ -11,17 +11,17 @@ import {
   List,
 } from '@altinn/altinn-components';
 
-import { CreateSystemUserCheck } from '../components/CanCreateSystemUser/CanCreateSystemUser';
-import type { SystemUser } from '../types';
-
-import classes from './SystemUserOverviewPage.module.css';
-
 import { useDocumentTitle } from '@/resources/hooks/useDocumentTitle';
 import { PageWrapper } from '@/components';
 import { useGetAgentSystemUsersQuery, useGetSystemUsersQuery } from '@/rtk/features/systemUserApi';
 import { getCookie } from '@/resources/Cookie/CookieMethods';
 import { SystemUserPath } from '@/routes/paths';
 import { PageLayoutWrapper } from '@/features/amUI/common/PageLayoutWrapper';
+
+import type { SystemUser } from '../types';
+import { CreateSystemUserCheck } from '../components/CanCreateSystemUser/CanCreateSystemUser';
+
+import classes from './SystemUserOverviewPage.module.css';
 
 export const SystemUserOverviewPage = () => {
   const { t } = useTranslation();
@@ -57,7 +57,7 @@ export const SystemUserOverviewPage = () => {
           >
             {t('systemuser_overviewpage.sub_title_text')}
           </DsParagraph>
-          <CreateSystemUserCheck>
+          <CreateSystemUserCheck partyId={partyId}>
             {isLoadingSystemUsers && isLoadingAgentSystemUsers && (
               <DsSpinner aria-label={t('systemuser_overviewpage.loading_systemusers')} />
             )}

--- a/src/features/amUI/systemUser/components/CanCreateSystemUser/CanCreateSystemUser.tsx
+++ b/src/features/amUI/systemUser/components/CanCreateSystemUser/CanCreateSystemUser.tsx
@@ -2,11 +2,13 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { DsSpinner, DsParagraph } from '@altinn/altinn-components';
 
+import { type ReporteeInfo } from '@/rtk/features/userInfoApi';
+import { useGetSystemUserReporteeQuery } from '@/rtk/features/systemUserApi';
+
 import classes from './CanCreateSystemUser.module.css';
 
-import { useGetReporteeQuery, type ReporteeInfo } from '@/rtk/features/userInfoApi';
-
 interface CreateSystemUserCheckProps {
+  partyId: string;
   children: React.ReactNode;
 }
 
@@ -19,11 +21,13 @@ const canCreateSystemUser = (reporteeInfo: ReporteeInfo): boolean => {
 };
 
 export const CreateSystemUserCheck = ({
+  partyId,
   children,
 }: CreateSystemUserCheckProps): React.ReactNode => {
   const { t } = useTranslation();
 
-  const { data: reporteeData, isLoading: isLoadingReporteeData } = useGetReporteeQuery();
+  const { data: reporteeData, isLoading: isLoadingReporteeData } =
+    useGetSystemUserReporteeQuery(partyId);
 
   return (
     <>

--- a/src/rtk/features/systemUserApi.ts
+++ b/src/rtk/features/systemUserApi.ts
@@ -36,8 +36,8 @@ export const systemUserApi = createApi({
   }),
   tagTypes: [Tags.SystemUsers],
   endpoints: (builder) => ({
-    // system user request reportee
-    getSystemUserRequestReportee: builder.query<ReporteeInfo, string>({
+    // system user reportee
+    getSystemUserReportee: builder.query<ReporteeInfo, string>({
       query: (partyId) => `user/reportee/${partyId}`,
     }),
 
@@ -211,7 +211,7 @@ const apiWithTag = systemUserApi.enhanceEndpoints({
 });
 
 export const {
-  useGetSystemUserRequestReporteeQuery,
+  useGetSystemUserReporteeQuery,
   useCreateSystemUserMutation,
   useDeleteSystemuserMutation,
   useGetSystemUserQuery,


### PR DESCRIPTION
## Description
- Refactor CanCreateSystemUser: send partyId as prop instead of using partyId set in cookie to get reportee.

## Related Issue(s)
- this PR

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
