### PR TITLE
Set cache time for assigned customers to 0

### DIFF
--- a/src/rtk/features/systemUserApi.ts
+++ b/src/rtk/features/systemUserApi.ts
@@ -115,6 +115,7 @@ export const systemUserApi = createApi({
     >({
       query: ({ partyId, systemUserId, partyUuid }) =>
         `systemuser/agentdelegation/${partyId}/${systemUserId}/delegation?partyuuid=${partyUuid}`,
+      keepUnusedDataFor: 0,
     }),
     assignCustomer: builder.mutation<
       AgentDelegation,


### PR DESCRIPTION
## Description
Set cache time for assigned customers to 0 instead of using RTK query default cache time of 60 seconds, to force reload whenever the assigned customer list is shown

## Related Issue(s)
- https://github.com/Altinn/altinn-access-management-frontend/issues/1487

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated data caching behavior for assigned customers so that data is cleared immediately after it is no longer in use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->