### PR TITLE
Fixed wrong defaulting for acting party

### DIFF
--- a/src/features/amUI/common/AccessPackageList/AccessPackageList.tsx
+++ b/src/features/amUI/common/AccessPackageList/AccessPackageList.tsx
@@ -50,14 +50,15 @@ export const AccessPackageList = ({
   const { data: allPackageAreas, isLoading: loadingPackageAreas } = useSearchQuery(
     searchString ?? '',
   );
-  const { fromParty, toParty } = usePartyRepresentation();
+  const { fromParty, toParty, actingParty } = usePartyRepresentation();
   const { data: activeDelegations, isLoading: loadingDelegations } = useGetUserDelegationsQuery(
     {
       from: fromParty?.partyUuid ?? '',
       to: toParty?.partyUuid ?? '',
+      party: actingParty?.partyUuid ?? '',
     },
     {
-      skip: !toParty?.partyUuid || !fromParty?.partyUuid,
+      skip: !toParty?.partyUuid || !fromParty?.partyUuid || !actingParty?.partyUuid,
     },
   );
 

--- a/src/features/amUI/common/PartyRepresentationContext/PartyRepresentationContext.tsx
+++ b/src/features/amUI/common/PartyRepresentationContext/PartyRepresentationContext.tsx
@@ -69,7 +69,7 @@ export const PartyRepresentationProvider = ({
     isLoading: isConnectionLoading,
     error,
   } = useGetRightHoldersQuery(
-    { fromUuid: fromPartyUuid ?? '', toUuid: toPartyUuid ?? '', partyUuid: fromPartyUuid ?? '' },
+    { fromUuid: fromPartyUuid ?? '', toUuid: toPartyUuid ?? '', partyUuid: actingPartyUuid ?? '' },
     { skip: !fromPartyUuid || !toPartyUuid },
   );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Default (that is, user flow) behavior was still in place for reportee-flow. Now, the the party parameter is set to the correct acting party for the flow.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy of user and rights holder data by ensuring queries use the correct party context for fetching information.
  - Adjusted conditions to prevent unnecessary data fetching when required party information is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->