### PR TITLE
Display number of packages in header on reportee as well

### DIFF
--- a/src/features/amUI/reporteeRightsPage/ReporteeAccessPackageSection.tsx
+++ b/src/features/amUI/reporteeRightsPage/ReporteeAccessPackageSection.tsx
@@ -2,31 +2,39 @@ import { useTranslation } from 'react-i18next';
 import { useEffect, useRef, useState } from 'react';
 import { DsHeading } from '@altinn/altinn-components';
 
-import type { AccessPackage } from '@/rtk/features/accessPackageApi';
+import { useGetUserDelegationsQuery, type AccessPackage } from '@/rtk/features/accessPackageApi';
 
 import { AccessPackageList } from '../common/AccessPackageList/AccessPackageList';
 import { DelegationAction } from '../common/DelegationModal/EditModal';
 import { AccessPackageInfoModal } from '../userRightsPage/AccessPackageSection/AccessPackageInfoModal';
 import { useDelegationModalContext } from '../common/DelegationModal/DelegationModalContext';
 import { AccessPackageInfoAlert } from '../userRightsPage/AccessPackageSection/AccessPackageInfoAlert';
+import { usePartyRepresentation } from '../common/PartyRepresentationContext/PartyRepresentationContext';
 
-interface ReporteeAccessPackageSectionProps {
-  numberOfAccesses?: number;
-}
-
-export const ReporteeAccessPackageSection = ({
-  numberOfAccesses,
-}: ReporteeAccessPackageSectionProps) => {
+export const ReporteeAccessPackageSection = () => {
   const { t } = useTranslation();
   const modalRef = useRef<HTMLDialogElement>(null);
   const [modalItem, setModalItem] = useState<AccessPackage | undefined>(undefined);
   const { setActionError } = useDelegationModalContext();
+
+  const { toParty, fromParty, actingParty } = usePartyRepresentation();
 
   useEffect(() => {
     const handleClose = () => setModalItem(undefined);
     modalRef.current?.addEventListener('close', handleClose);
     return () => modalRef.current?.removeEventListener('close', handleClose);
   }, []);
+
+  const { data: accesses } = useGetUserDelegationsQuery(
+    {
+      from: fromParty?.partyUuid ?? '',
+      to: toParty?.partyUuid ?? '',
+      party: actingParty?.partyUuid ?? '',
+    },
+    { skip: !toParty?.partyUuid || !fromParty?.partyUuid || !actingParty?.partyUuid },
+  );
+
+  const numberOfAccesses = accesses ? Object.values(accesses).flat().length : 0;
 
   return (
     <>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<img width="896" alt="image" src="https://github.com/user-attachments/assets/8bc7b3a5-5740-4427-be6c-540f52adcdaf" />

## Description
<!--- Describe your changes in detail -->
The number of access packages a user has is now displayed in the header on reporteeRighsPage, as it is on the UserRightsPage. In the future, we should consider consolidating the AccessPackageSection and ReporteeAccessPackageSection files into one component, as they aren't all that different. (This has been added to the task https://github.com/Altinn/altinn-access-management-frontend/issues/1387)

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/873

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
