### PR TITLE
Add validation error message when delegation fails

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Constants/AmProblem.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Constants/AmProblem.cs
@@ -1,0 +1,25 @@
+using System.Net;
+using Altinn.Authorization.ProblemDetails;
+
+namespace Altinn.AccessManagement.UI.Core.Constants
+{
+    /// <summary>
+    /// Validation problem descriptors for the Access management UI BFF.
+    /// </summary>
+    public static class AmProblem
+    {
+        private static readonly ValidationErrorDescriptorFactory _factory
+      = ValidationErrorDescriptorFactory.New("AM");
+
+        /// <summary>
+        /// The field is required.
+        /// </summary>
+        public static ValidationErrorDescriptor Required => StdValidationErrors.Required;
+
+        /// <summary>
+        /// Gets a validation error descriptor for when an invalid Resource is provided.
+        /// </summary>
+        public static ValidationErrorDescriptor InvalidResource { get; }
+            = _factory.Create(2, $"Resource must be valid.");
+    }
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Helpers/ProblemMapper.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Helpers/ProblemMapper.cs
@@ -28,5 +28,20 @@ namespace Altinn.AccessManagement.UI.Core.Helpers
                 _ => Problem.Generic_EndOfMethod,
             };
         }
+
+        /// <summary>
+        /// Map error codes from AM to AMUI error codes
+        /// </summary>
+        public static AltinnValidationError MapToAmUiError(string amErrorCode)
+        {
+            return amErrorCode switch
+            {
+                // We only handle "Resource must be valid" for now
+                // Add more cases here when available
+                // "AM.VLD-00001" => AmProblem.InvalidPartyUrn.ToValidationError(),
+                "AM.VLD-00002" => AmProblem.InvalidResource.ToValidationError(),
+                _ => null
+            };
+        }
     }
 }

--- a/src/features/amUI/common/AccessPackageList/useAccessPackageActions.ts
+++ b/src/features/amUI/common/AccessPackageList/useAccessPackageActions.ts
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { SnackbarDuration, useSnackbar } from '@altinn/altinn-components';
 
+import type { DelegationErrorDetails } from '@/resources/hooks/useDelegateAccessPackage';
 import { useDelegateAccessPackage } from '@/resources/hooks/useDelegateAccessPackage';
 import { useRevokeAccessPackage } from '@/resources/hooks/useRevokeAccessPackage';
 import type { AccessPackage } from '@/rtk/features/accessPackageApi';
@@ -48,8 +49,9 @@ export const useAccessPackageActions = ({
     toParty: Party,
     httpStatus: string,
     timestamp: string,
+    details?: DelegationErrorDetails,
   ) => {
-    if (onDelegateError) onDelegateError(accessPackage, { httpStatus, timestamp });
+    if (onDelegateError) onDelegateError(accessPackage, { httpStatus, timestamp, details });
     else {
       openSnackbar({
         message: t('access_packages.package_delegation_error', {
@@ -106,12 +108,13 @@ export const useAccessPackageActions = ({
       () => {
         handleDelegateSuccess(accessPackage, toParty);
       },
-      (httpStatus) => {
+      (httpStatus, details) => {
         handleDelegateError(
           accessPackage,
           toParty,
           httpStatus.toString(),
           new Date().toISOString(),
+          details,
         );
       },
     );

--- a/src/features/amUI/common/DelegationModal/AccessPackages/AccessPackageInfo.tsx
+++ b/src/features/amUI/common/DelegationModal/AccessPackages/AccessPackageInfo.tsx
@@ -68,6 +68,7 @@ export const AccessPackageInfo = ({ accessPackage, availableActions = [] }: Pack
     return null;
   }, [activeDelegations, isFetching, accessPackage.id]);
 
+  const { displayLimitedPreviewLaunch } = window.featureFlags;
   const userHasPackage = delegationAccess !== null;
   const accessIsInherited =
     (delegationAccess &&
@@ -80,7 +81,8 @@ export const AccessPackageInfo = ({ accessPackage, availableActions = [] }: Pack
     setDelegationCheckError(error);
   };
 
-  const shouldShowDelegationCheck = availableActions.includes(DelegationAction.DELEGATE);
+  const shouldShowDelegationCheck =
+    availableActions.includes(DelegationAction.DELEGATE) && !displayLimitedPreviewLaunch;
 
   // memorize this to prevent unnecessary re-renders
   const accessPackageIds = React.useMemo(() => {
@@ -169,6 +171,11 @@ export const AccessPackageInfo = ({ accessPackage, availableActions = [] }: Pack
                 size='xs'
                 status={actionError.httpStatus}
                 time={actionError.timestamp}
+                message={
+                  actionError.details?.detail
+                    ? t(`delegation_modal.validation_error.${actionError.details?.detail}`)
+                    : undefined
+                }
               />
             </DsAlert>
           )}

--- a/src/features/amUI/common/DelegationModal/DelegationModal.tsx
+++ b/src/features/amUI/common/DelegationModal/DelegationModal.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 
+import { AreaExpandedStateProvider } from '../AccessPackageList/AccessPackageExpandedContext';
+
 import { DelegationModalContent } from './DelegationModalContent';
 import type { DelegationAction } from './EditModal';
-import { AreaExpandedStateProvider } from '../AccessPackageList/AccessPackageExpandedContext';
 
 export enum DelegationType {
   SingleRights = 'SingleRights',

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -306,7 +306,7 @@
     "resource_type_text": "Single right",
     "delete_confirm_message": "Are you sure you want to delete this?"
   },
- "delete_user": {
+  "delete_user": {
     "user_trigger_button": "Delete user",
     "user_heading": "Are you sure you want to delete this user?",
     "user_message": "<p>{{to_name}} will lose all authorizations they have for {{from_name}}. <i>This action cannot be undone.</i></p>",
@@ -315,7 +315,7 @@
     "user_deletion_not_allowed_heading": "The user cannot be deleted",
     "user_deletion_not_allowed_message": "<p>{{to_name}} only has authorizations through their roles in the Central Coordinating Register for Legal Entities and therefore cannot be deleted from {{from_name}} in Altinn. If you wish to change this, you can do so via the <erLink>Coordinated Register Notification</erLink>.</p>",
     "yes_button": "Yes, delete",
-    
+
     "yourself_trigger_button": "Delete all permissions",
     "yourself_heading": "Are you sure you want to delete all your permissions?",
     "yourself_message": "<p>You will lose all authorizations you have for {{from_name}} and will no longer have access to their content or be able to represent them in Altinn. <i>This action cannot be undone.</i></p>",
@@ -323,7 +323,7 @@
     "yourself_limited_deletion_message": "<p>Your rights cannot be completely removed from {{from_name}} in Altinn as they are linked to roles in the Central Coordinating Register for Legal Entities. If you wish to change this, you can do so via the <erLink>Coordinated Register Notification</erLink>.</p><p>Do you want to delete all permissions not linked to the Central Coordinating Register for Legal Entities? <i>This action cannot be undone.</i></p>",
     "yourself_deletion_not_allowed_heading": "Your permissions cannot be deleted",
     "yourself_deletion_not_allowed_message": "<p>You only have authorizations through your roles in the Central Coordinating Register for Legal Entities and therefore cannot be deleted from {{from_name}} in Altinn. If you wish to change this, you can do so via the <erLink>Coordinated Register Notification</erLink>.</p>",
-    
+
     "reportee_trigger_button": "Delete all permissions",
     "reportee_heading": "Are you sure you want to delete all their permissions?",
     "reportee_message": "<p>{{to_name}} will lose all their authorizations for {{from_name}}. They will no longer have access to their content or be able to represent them in Altinn. <i>This action cannot be undone.</i></p>",
@@ -362,6 +362,9 @@
     "general_error": {
       "revoke_heading": "Could not delete power of attorney",
       "delegate_heading": "Could not give power of attorney"
+    },
+    "validation_error": {
+      "AM.VLD-00002": "You do not have permission to grant this authorization."
     },
     "service_error": {
       "general_heading": "You cannot give access to this service",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -314,7 +314,7 @@
     "user_deletion_not_allowed_heading": "Brukeren kan ikke slettes",
     "user_deletion_not_allowed_message": "<p>{{to_name}} har kun fullmakter gjennom sine roller i Enhetsregisteret og kan derfor ikke slettes fra {{from_name}} i Altinn. Dersom du ønsker å endre dette, kan du gjøre det via <erLink>Samordnet registermelding</erLink>.</p>",
     "yes_button": "Ja, slett",
-    
+
     "yourself_trigger_button": "Slett alle tilganger",
     "yourself_heading": "Er du sikker på at du vil slette alle dine tilganger?",
     "yourself_message": "<p>Du vil miste alle fullmakter du har for {{from_name}} og vil ikke lenger ha tilgang til deres innhold eller til å representere dem i Altinn. <i>Denne handlingen kan ikke angres.</i></p>",
@@ -361,6 +361,9 @@
     "general_error": {
       "revoke_heading": "Kunne ikke slette fullmakt",
       "delegate_heading": "Kunne ikke gi fullmakt"
+    },
+    "validation_error": {
+      "AM.VLD-00002": "Du mangler tilgang til å gi denne fullmakten."
     },
     "service_error": {
       "general_heading": "Du kan ikke gi fullmakt til denne tjenesten",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -357,6 +357,9 @@
       "revoke_heading": "Kunne ikkje slette fullmakt",
       "delegate_heading": "Kunne ikkje gi fullmakt"
     },
+    "validation_error": {
+      "AM.VLD-00002": "Du manglar tilgang til å gje denne fullmakta."
+    },
     "service_error": {
       "general_heading": "Du kan ikkje gi fullmakt til denne tenesta",
       "technical_error_heading": "Noko gjekk gale",

--- a/src/resources/hooks/useActionError.tsx
+++ b/src/resources/hooks/useActionError.tsx
@@ -1,11 +1,15 @@
 import { useState } from 'react';
 
+import type { DelegationErrorDetails } from './useDelegateAccessPackage';
+
 /** A standardized error for any type of delegation, request, or revoking action */
 export type ActionError = {
   /** The http status received with the error */
   httpStatus: string;
   /** When the error happened */
   timestamp: string;
+  /** Additional information if available */
+  details?: DelegationErrorDetails;
 };
 
 /** Use state for the ActionError type */

--- a/src/resources/hooks/useDelegateAccessPackage.tsx
+++ b/src/resources/hooks/useDelegateAccessPackage.tsx
@@ -2,6 +2,13 @@ import type { AccessPackage } from '@/rtk/features/accessPackageApi';
 import { useDelegatePackageMutation } from '@/rtk/features/accessPackageApi';
 import type { Party } from '@/rtk/features/lookupApi';
 
+export interface DelegationErrorDetails {
+  title?: string;
+  detail?: string;
+  traceId?: string;
+  errorCode?: string;
+}
+
 export const useDelegateAccessPackage = () => {
   const [delegate, { isLoading }] = useDelegatePackageMutation();
 
@@ -11,7 +18,7 @@ export const useDelegateAccessPackage = () => {
     actingParty: Party,
     resource: AccessPackage,
     onSuccess?: () => void,
-    onError?: (status: string | number) => void,
+    onError?: (status: string | number, details?: DelegationErrorDetails) => void,
   ) => {
     delegate({
       to: toParty.partyUuid,
@@ -24,7 +31,7 @@ export const useDelegateAccessPackage = () => {
         onSuccess?.();
       })
       .catch((response) => {
-        onError?.(response.status);
+        onError?.(response.status, response.data);
       });
   };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR returns the relevant error codes for failed delegations and adds them to the error message.
- We currently only handle all cases of "not allowed" as one. We will hopefully be able to expand this with more granular validation messages soon.
- Hopefully this can be used as a framework to build upon as we handle more cases for validation and error messages.

## Related Issue(s)
[872](https://github.com/Altinn/altinn-authorization-tmp/issues/872)

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
