### PR TITLE
Fix deserialization of access package resource resourceType

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Helpers/ResourceHelper.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Helpers/ResourceHelper.cs
@@ -93,7 +93,7 @@ namespace Altinn.AccessManagement.UI.Core.Helpers
                         Urn = accessPackage.Urn,
                         Description = accessPackage.Description,
                         Name = accessPackage.Name,
-                        Resources = await EnrichResources(accessPackage.Resources.Select(x => x.Id.ToString()), languageCode)
+                        Resources = [] // TODO: fix mapping to correct type
                     });
                 }
             }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/AccessPackage/ResourceAM.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/AccessPackage/ResourceAM.cs
@@ -1,4 +1,5 @@
-﻿using Altinn.AccessManagement.UI.Core.Enums;
+﻿using System.Text.Json.Serialization;
+using Altinn.AccessManagement.UI.Core.Enums;
 using Altinn.AccessManagement.UI.Core.Models.Common;
 
 namespace Altinn.AccessManagement.UI.Core.Models.AccessPackage
@@ -46,6 +47,18 @@ namespace Altinn.AccessManagement.UI.Core.Models.AccessPackage
         /// <summary>
         /// Type
         /// </summary>
-        public ResourceType Type { get; set; }
+        public AccessPackageResourceType Type { get; set; }
+    }
+
+    /// <summary>
+    /// AccessPackageResourceType
+    /// </summary>
+    public class AccessPackageResourceType
+    {
+        /// <summary>
+        /// Name
+        /// </summary>
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public ResourceType Name { get; set; }
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/AccessPackage/packages.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/AccessPackage/packages.json
@@ -566,6 +566,9 @@
             "id": "c4c4c4c4-c4c4-c4c4-c4c4-c4c4c4c4c4c4",
             "name": "Digitaliseringsdirektoratet",
             "logoUrl": "https://profilveileder.digdir.no/sites/leikanger/files/styles/xxxs/public/2022-04/Ikon_Emblem-blaasvart.png?itok=QU5K_ApH"
+          },
+          "type": {
+            "name": "GenericAccessResource"
           }
         },
         {
@@ -579,6 +582,9 @@
             "id": "c5c5c5c5-c5c5-c5c5-c5c5-c5c5c5c5c5c5",
             "name": "Direktoratet for samfunnssikkerhet og beredskap",
             "logoUrl": "https://elvirksomhetsregisteret.dsb.no/assets/dsb_logo.png"
+          },
+          "type": {
+            "name": "GenericAccessResource"
           }
         },
         {
@@ -592,6 +598,9 @@
             "id": "c4c4c4c4-c4c4-c4c4-c4c4-c4c4c4c4c4c4",
             "name": "Arbeidstilsynet",
             "logoUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/03/Emblem_of_the_Norwegian_Labour_Inspection_Authority.svg/1200px-Emblem_of_the_Norwegian_Labour_Inspection_Authority.svg.png"
+          },
+          "type": {
+            "name": "GenericAccessResource"
           }
         },
         {
@@ -605,6 +614,9 @@
             "id": "c6c6c6c6-c6c6-c6c6-c6c6-c6c6c6c6c6c6",
             "name": "Næringslivets sikkerhetsråd",
             "logoUrl": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRN0P4ygJ_NZXANCOzMyKonqsKRP4zCPDSp866h4tyh7-9kLWOs09wEeKygX2WsaMVpLQI&usqp=CAU"
+          },
+          "type": {
+            "name": "GenericAccessResource"
           }
         },
         {
@@ -618,6 +630,9 @@
             "id": "c5c5c5c5-c5c5-c5c5-c5c5-c5c5c5c5c5c5",
             "name": "Direktoratet for samfunnssikkerhet og beredskap",
             "logoUrl": "https://elvirksomhetsregisteret.dsb.no/assets/dsb_logo.png"
+          },
+          "type": {
+            "name": "GenericAccessResource"
           }
         },
         {
@@ -631,6 +646,9 @@
             "id": "c7c7c7c7-c7c7-c7c7-c7c7-c7c7c7c7c7c7",
             "name": "Datatilsynet",
             "logoUrl": "https://www.datatilsynet.no/globalassets/global/bilder/logoer/pvo_logo?width=756&height=710&quality=80&h=4c22bcfb2f8f388c55db321994144cb6d8fcba42"
+          },
+          "type": {
+            "name": "GenericAccessResource"
           }
         },
         {
@@ -644,6 +662,9 @@
             "id": "c6c6c6c6-c6c6-c6c6-c6c6-c6c6c6c6c6c6",
             "name": "Næringslivets sikkerhetsråd",
             "logoUrl": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRN0P4ygJ_NZXANCOzMyKonqsKRP4zCPDSp866h4tyh7-9kLWOs09wEeKygX2WsaMVpLQI&usqp=CAU"
+          },
+          "type": {
+            "name": "GenericAccessResource"
           }
         }
       ]

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/AccessPackage/Search/emptySearch.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/AccessPackage/Search/emptySearch.json
@@ -473,7 +473,9 @@
               "refId": null,
               "logoUrl": "https://profilveileder.digdir.no/sites/leikanger/files/styles/xxxs/public/2022-04/Ikon_Emblem-blaasvart.png?itok=QU5K_ApH"
             },
-            "type": 0
+            "type": {
+              "name": "GenericAccessResource"
+            }
           },
           {
             "id": "b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2",
@@ -488,7 +490,9 @@
               "refId": null,
               "logoUrl": "https://elvirksomhetsregisteret.dsb.no/assets/dsb_logo.png"
             },
-            "type": 0
+            "type": {
+              "name": "GenericAccessResource"
+            }
           },
           {
             "id": "b3b3b3b3-b3b3-b3b3-b3b3-b3b3b3b3b3b3",
@@ -503,7 +507,9 @@
               "refId": null,
               "logoUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/03/Emblem_of_the_Norwegian_Labour_Inspection_Authority.svg/1200px-Emblem_of_the_Norwegian_Labour_Inspection_Authority.svg.png"
             },
-            "type": 0
+            "type": {
+              "name": "GenericAccessResource"
+            }
           },
           {
             "id": "b4b4b4b4-b4b4-b4b4-b4b4-b4b4b4b4b4b4",
@@ -518,7 +524,9 @@
               "refId": null,
               "logoUrl": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRN0P4ygJ_NZXANCOzMyKonqsKRP4zCPDSp866h4tyh7-9kLWOs09wEeKygX2WsaMVpLQI&usqp=CAU"
             },
-            "type": 0
+            "type": {
+              "name": "GenericAccessResource"
+            }
           },
           {
             "id": "b5b5b5b5-b5b5-b5b5-b5b5-b5b5b5b5b5b5",
@@ -533,7 +541,9 @@
               "refId": null,
               "logoUrl": "https://elvirksomhetsregisteret.dsb.no/assets/dsb_logo.png"
             },
-            "type": 0
+            "type": {
+              "name": "GenericAccessResource"
+            }
           },
           {
             "id": "b6b6b6b6-b6b6-b6b6-b6b6-b6b6b6b6b6b6",
@@ -548,7 +558,9 @@
               "refId": null,
               "logoUrl": "https://www.datatilsynet.no/globalassets/global/bilder/logoer/pvo_logo?width=756&height=710&quality=80&h=4c22bcfb2f8f388c55db321994144cb6d8fcba42"
             },
-            "type": 0
+            "type": {
+              "name": "GenericAccessResource"
+            }
           },
           {
             "id": "b7b7b7b7-b7b7-b7b7-b7b7-b7b7b7b7b7b7",
@@ -563,7 +575,9 @@
               "refId": null,
               "logoUrl": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRN0P4ygJ_NZXANCOzMyKonqsKRP4zCPDSp866h4tyh7-9kLWOs09wEeKygX2WsaMVpLQI&usqp=CAU"
             },
-            "type": 0
+            "type": {
+              "name": "GenericAccessResource"
+            }
           }
         ]
       },

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Utils/AssertionUtil.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Utils/AssertionUtil.cs
@@ -205,7 +205,7 @@ namespace Altinn.AccessManagement.UI.Tests.Utils
             Assert.Equal(expected.Name, actual.Name);
             Assert.Equal(expected.Description, actual.Description);
             Assert.Equal(expected.ProviderId, actual.ProviderId);
-            Assert.Equal(expected.Type, actual.Type);
+            Assert.Equal(expected.Type.Name, actual.Type.Name);
             Assert.NotNull(expected.Provider);
             Assert.NotNull(actual.Provider);
             Assert.Equal(expected.Provider.Name, actual.Provider.Name);


### PR DESCRIPTION
## Description
- Fix deserialization of access package resource resourceType
- Remove resource mapping of resources in access package temporary

## Related Issue(s)
- this PR

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handling of resource type information for access packages, now using a dedicated structure for better clarity and serialization.

* **Bug Fixes**
  * Temporarily set resource lists in access packages to empty to address issues with resource mapping.

* **Chores**
  * Updated internal structures to support enhanced JSON serialization of resource types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->