### PR TITLE
Log out user on approve or reject systemuser request/changerequest/agentrequest without redirectUrl

### DIFF
--- a/src/features/amUI/systemUser/SystemUserAgentRequestPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserAgentRequestPage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation, Trans } from 'react-i18next';
-import { useSearchParams, useNavigate } from 'react-router';
+import { useSearchParams } from 'react-router';
 import { DsAlert, DsSpinner, DsHeading, DsParagraph, DsButton } from '@altinn/altinn-components';
 
 import {
@@ -9,7 +9,6 @@ import {
   useRejectAgentSystemUserRequestMutation,
   useGetSystemUserReporteeQuery,
 } from '@/rtk/features/systemUserApi';
-import { SystemUserPath } from '@/routes/paths';
 import { useDocumentTitle } from '@/resources/hooks/useDocumentTitle';
 
 import { RequestPageBase } from './components/RequestPageBase/RequestPageBase';
@@ -22,7 +21,6 @@ import { RightsList } from './components/RightsList/RightsList';
 
 export const SystemUserAgentRequestPage = () => {
   const { t } = useTranslation();
-  const navigate = useNavigate();
   useDocumentTitle(t('systemuser_agent_request.page_title'));
   const [searchParams] = useSearchParams();
   const requestId = searchParams.get('id') ?? '';
@@ -63,13 +61,7 @@ export const SystemUserAgentRequestPage = () => {
       const partyId = request.partyId;
       postAcceptCreationRequest({ partyId, requestId: request.id })
         .unwrap()
-        .then(() => {
-          if (request.redirectUrl) {
-            logoutAndRedirectToVendor();
-          } else {
-            navigate(`/${SystemUserPath.SystemUser}/${SystemUserPath.Overview}`);
-          }
-        });
+        .then(onRejectOrApprove);
     }
   };
 
@@ -78,18 +70,15 @@ export const SystemUserAgentRequestPage = () => {
       const partyId = request.partyId;
       postRejectCreationRequest({ partyId, requestId: request.id })
         .unwrap()
-        .then(() => {
-          if (request.redirectUrl) {
-            logoutAndRedirectToVendor();
-          } else {
-            window.location.assign(getLogoutUrl());
-          }
-        });
+        .then(onRejectOrApprove);
     }
   };
 
-  const logoutAndRedirectToVendor = (): void => {
-    window.location.assign(`${getApiBaseUrl()}/agentrequest/${request?.id}/logout`);
+  const onRejectOrApprove = (): void => {
+    const url = request?.redirectUrl
+      ? `${getApiBaseUrl()}/agentrequest/${request?.id}/logout`
+      : getLogoutUrl();
+    window.location.assign(url);
   };
 
   return (

--- a/src/features/amUI/systemUser/SystemUserChangeRequestPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserChangeRequestPage.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import { useTranslation, Trans } from 'react-i18next';
-import { useSearchParams, useNavigate } from 'react-router';
+import { useSearchParams } from 'react-router';
 import { DsAlert, DsSpinner, DsHeading, DsParagraph, DsButton } from '@altinn/altinn-components';
 
 import { useDocumentTitle } from '@/resources/hooks/useDocumentTitle';
-import { SystemUserPath } from '@/routes/paths';
 import {
   useApproveChangeRequestMutation,
   useGetChangeRequestQuery,
@@ -22,7 +21,6 @@ import { CreateSystemUserCheck } from './components/CanCreateSystemUser/CanCreat
 
 export const SystemUserChangeRequestPage = () => {
   const { t } = useTranslation();
-  const navigate = useNavigate();
   useDocumentTitle(t('systemuser_change_request.page_title'));
   const [searchParams] = useSearchParams();
   const changeRequestId = searchParams.get('id') ?? '';
@@ -63,13 +61,7 @@ export const SystemUserChangeRequestPage = () => {
       const partyId = changeRequest.partyId;
       postAcceptChangeRequest({ partyId, changeRequestId: changeRequest.id })
         .unwrap()
-        .then(() => {
-          if (changeRequest.redirectUrl) {
-            logoutAndRedirectToVendor();
-          } else {
-            navigate(`/${SystemUserPath.SystemUser}/${SystemUserPath.Overview}`);
-          }
-        });
+        .then(onRejectOrApprove);
     }
   };
 
@@ -78,18 +70,15 @@ export const SystemUserChangeRequestPage = () => {
       const partyId = changeRequest.partyId;
       postRejectChangeRequest({ partyId, changeRequestId: changeRequest.id })
         .unwrap()
-        .then(() => {
-          if (changeRequest.redirectUrl) {
-            logoutAndRedirectToVendor();
-          } else {
-            window.location.assign(getLogoutUrl());
-          }
-        });
+        .then(onRejectOrApprove);
     }
   };
 
-  const logoutAndRedirectToVendor = (): void => {
-    window.location.assign(`${getApiBaseUrl()}/changerequest/${changeRequest?.id}/logout`);
+  const onRejectOrApprove = (): void => {
+    const url = changeRequest?.redirectUrl
+      ? `${getApiBaseUrl()}/changerequest/${changeRequest?.id}/logout`
+      : getLogoutUrl();
+    window.location.assign(url);
   };
 
   return (

--- a/src/features/amUI/systemUser/SystemUserRequestPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserRequestPage.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import { useTranslation, Trans } from 'react-i18next';
-import { useSearchParams, useNavigate } from 'react-router';
+import { useSearchParams } from 'react-router';
 import { DsAlert, DsSpinner, DsHeading, DsParagraph, DsButton } from '@altinn/altinn-components';
 
 import { useDocumentTitle } from '@/resources/hooks/useDocumentTitle';
-import { SystemUserPath } from '@/routes/paths';
 import {
   useGetSystemUserRequestQuery,
   useApproveSystemUserRequestMutation,
@@ -22,7 +21,6 @@ import { CreateSystemUserCheck } from './components/CanCreateSystemUser/CanCreat
 
 export const SystemUserRequestPage = () => {
   const { t } = useTranslation();
-  const navigate = useNavigate();
   useDocumentTitle(t('systemuser_request.page_title'));
   const [searchParams] = useSearchParams();
   const requestId = searchParams.get('id') ?? '';
@@ -63,13 +61,7 @@ export const SystemUserRequestPage = () => {
       const partyId = request.partyId;
       postAcceptCreationRequest({ partyId, requestId: request.id })
         .unwrap()
-        .then(() => {
-          if (request.redirectUrl) {
-            logoutAndRedirectToVendor();
-          } else {
-            navigate(`/${SystemUserPath.SystemUser}/${SystemUserPath.Overview}`);
-          }
-        });
+        .then(onRejectOrApprove);
     }
   };
 
@@ -78,18 +70,15 @@ export const SystemUserRequestPage = () => {
       const partyId = request.partyId;
       postRejectCreationRequest({ partyId, requestId: request.id })
         .unwrap()
-        .then(() => {
-          if (request.redirectUrl) {
-            logoutAndRedirectToVendor();
-          } else {
-            window.location.assign(getLogoutUrl());
-          }
-        });
+        .then(onRejectOrApprove);
     }
   };
 
-  const logoutAndRedirectToVendor = (): void => {
-    window.location.assign(`${getApiBaseUrl()}/request/${request?.id}/logout`);
+  const onRejectOrApprove = (): void => {
+    const url = request?.redirectUrl
+      ? `${getApiBaseUrl()}/request/${request?.id}/logout`
+      : getLogoutUrl();
+    window.location.assign(url);
   };
 
   return (


### PR DESCRIPTION
## Description
Since request can be opened by a party other than the selected party, redirecting to system user overview page after approve/reject doesn't make sense as the new systemuser might be for a different party.

## Related Issue(s)
- this PR

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
