### PR TITLE
Use new A3-app for e2e testing

### DIFF
--- a/playwright/config/.env.at24
+++ b/playwright/config/.env.at24
@@ -1,6 +1,6 @@
 ENV_NAME="at24"
 BASE_URL="https://at24.altinn.cloud"
-APP_URL="https://ttd.apps.at24.altinn.cloud/ttd/autorisasjon-autotest-app"
+APP_URL="https://ttd.apps.at24.altinn.cloud/ttd/autorisasjon-autotest-app-2"
 
 ## System user configs
 SYSTEMUSER_URL="https://am.ui.at24.altinn.cloud/accessmanagement/ui/systemuser/overview"

--- a/playwright/config/.env.tt02
+++ b/playwright/config/.env.tt02
@@ -1,6 +1,6 @@
 ENV_NAME="tt02"
 BASE_URL="https://tt02.altinn.no"
-APP_URL="https://ttd.apps.tt02.altinn.no/ttd/autorisasjon-autotest-app"
+APP_URL="https://ttd.apps.tt02.altinn.no/ttd/autorisasjon-autotest-app-2"
 
 ## System user configs
 SYSTEMUSER_URL="https://am.ui.tt02.altinn.no/accessmanagement/ui/systemuser/overview"

--- a/playwright/e2eTests/singleRightsDelegering.spec.ts
+++ b/playwright/e2eTests/singleRightsDelegering.spec.ts
@@ -32,7 +32,7 @@ test.describe('User with DAGL/HADM role without having resource access themselve
       'SKYFRI GATE',
     );
     await delegateRights.delegateRightsToSSN('Ressurs for enkeltrettigheter testing');
-    await delegateRights.delegateRightsToSSN('autorisasjon-autotest-app');
+    await delegateRights.delegateRightsToSSN('autorisasjon-autotest-app-2');
     await delegateRights.delegateRightsToSSN('Altinn2 reporting service for authorization tests');
     await logoutUser.gotoLogoutPage('ULIK FLAT TIGER AS');
     // await context1.close();
@@ -51,7 +51,7 @@ test.describe('User with DAGL/HADM role without having resource access themselve
     //To delegate rights
     // WHEN user delegates to KLIPPFISK
     await delegate.delegateToSSN('04880748144', 'KLIPPFISK');
-    await delegateRights.delegateRightsToSSN('autorisasjon-autotest-app');
+    await delegateRights.delegateRightsToSSN('autorisasjon-autotest-app-2');
     await logoutUser.gotoLogoutPage('ULIK FLAT TIGER AS');
     await context.clearCookies();
 
@@ -93,7 +93,7 @@ test.describe('User with DAGL/HADM role without having resource access themselve
       'GJESTFRI RESERVERT HUND DA',
     );
     await delegateRights.delegateRightsToSSN('Ressurs for enkeltrettigheter testing');
-    await delegateRights.delegateRightsToSSN('autorisasjon-autotest-app');
+    await delegateRights.delegateRightsToSSN('autorisasjon-autotest-app-2');
     await delegateRights.delegateRightsToSSN('Altinn2 reporting service for authorization tests');
     await logoutUser.gotoLogoutPage('ULIK FLAT TIGER AS');
     // await context1.close();
@@ -114,7 +114,7 @@ test.describe('User with DAGL/HADM role without having resource access themselve
 
     //Delegate to another org
     await delegate.delegateToOrg('313948579', 'UNDERFUNDIG TROFAST TIGER AS');
-    await delegateRights.delegateRightsToSSN('autorisasjon-autotest-app');
+    await delegateRights.delegateRightsToSSN('autorisasjon-autotest-app-2');
     await logoutUser.gotoLogoutPage('ULIK FLAT TIGER AS');
     await context.clearCookies();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The old app was created in studio's staging env, and was not responding (other than with the "I'm a tea pot" error). I do not have access to the staging env, and I think we should probably have our test applications in studios prod env anyway, I created a new application and changed the e2e-tests to use this one instead. The test application is deployed to AT22, AT24, and TT02.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated environment URLs for the "at24" and "tt02" configurations.
  * Adjusted test scripts to use the new application identifier for delegation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->