### PR TITLE
Fix: use Europe/Oslo timezone for consent expiration texts + wrap in try-catch

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/ConsentService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/ConsentService.cs
@@ -30,7 +30,7 @@ namespace Altinn.AccessManagement.UI.Core.Services
         /// <param name="registerClient">The register client.</param>
         /// <param name="resourceRegistryClient">Resources client to load resources</param>
         public ConsentService(
-            ILogger<IConsentService> logger,
+            ILogger<ConsentService> logger,
             IConsentClient consentClient,
             IRegisterClient registerClient,
             IResourceRegistryClient resourceRegistryClient)
@@ -120,7 +120,7 @@ namespace Altinn.AccessManagement.UI.Core.Services
             }
             catch (TimeZoneNotFoundException e)
             {
-                _logger.LogWarning($"Could not find timezone Europe/Oslo. Defaulting to UTC. {e.Message}");
+                _logger.LogWarning(e, "Could not find timezone Europe/Oslo. Defaulting to UTC {Message}.", e.Message);
             }
 
             return new()


### PR DESCRIPTION
## Description
- Use Europe/Oslo timezone for consent expiration texts + wrap in try-catch (same logic as in apps PDF service)

## Related Issue(s)
- this PR

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of time zones for expiration dates by using "Europe/Oslo" and defaulting to UTC if unavailable.
  * Enhanced error handling with warning messages when the specified time zone is not found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->