### PR TITLE
Fix: handle consent requests without message

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/Consent/ConsentRight.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/Consent/ConsentRight.cs
@@ -22,5 +22,5 @@ namespace Altinn.AccessManagement.UI.Core.Models.Consent
         /// Keys are case insensitive.
         /// </summary>
         public Dictionary<string, string>? MetaData { get; set; }
-     }
+    }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/ConsentService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/ConsentService.cs
@@ -145,7 +145,7 @@ namespace Altinn.AccessManagement.UI.Core.Services
 
         private static Dictionary<string, string> ReplaceMetadataInTranslationsDict(Dictionary<string, string> translations, Dictionary<string, string> metadata)
         {
-            if (metadata == null)
+            if (metadata == null || translations == null)
             {
                 return translations;
             }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/Consent/consentRequest_org_without_message.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/Consent/consentRequest_org_without_message.json
@@ -1,0 +1,27 @@
+{
+  "id": "1a04a7fa-24c1-4e06-9217-8aee89239a9f",
+  "from": "urn:altinn:organization:identifier-no:cd35779b-b174-4ecc-bbef-ece13611be7f",
+  "to": "urn:altinn:organization:identifier-no:60fb3d5b-99c2-4df0-aa77-f3fca3bc5199",
+  "handledBy": null,
+  "validTo": "2025-05-21T11:11:24.9535551+00:00",
+  "consentRights": [
+    {
+      "action": ["read"],
+      "resource": [{ "type": "urn:altinn:resource", "value": "consent-test-resource-poa" }],
+      "metadata": null
+    }
+  ],
+  "requestMessage": null,
+  "consentRequestEvents": [
+    {
+      "consentEventID": "0197cbaf-4fd2-70e5-9866-f13262afd85d",
+      "created": "2025-07-02T15:09:13.526811+00:00",
+      "performedBy": "urn:altinn:organization:identifier-no:991825827",
+      "eventType": "Created",
+      "consentRequestID": "b4f13aea-c996-437d-bb32-e2b81ccfb919"
+    }
+  ],
+  "redirectUrl": "https://smartbank.no/poa",
+  "templateId": "poa",
+  "templateVersion": 1
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/ConsentClientMock.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/ConsentClientMock.cs
@@ -16,6 +16,7 @@ namespace Altinn.AccessManagement.UI.Mocks.Mocks
 
         private readonly Guid PERSON_CONSENT_ID = Guid.Parse("e2071c55-6adf-487b-af05-9198a230ed44");
         private readonly Guid ORG_CONSENT_ID = Guid.Parse("7e540335-d82f-41e9-8b8f-619336d792b4");
+        private readonly Guid ORG_CONSENT_WITHOUT_MESSAGE_ID = Guid.Parse("1a04a7fa-24c1-4e06-9217-8aee89239a9f");
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="ConsentClientMock" /> class
@@ -35,6 +36,11 @@ namespace Altinn.AccessManagement.UI.Mocks.Mocks
             else if (consentRequestId == ORG_CONSENT_ID)
             {
                 ConsentRequestDetails request = Util.GetMockData<ConsentRequestDetails>($"{dataFolder}/Consent/consentRequest_org.json");
+                return Task.FromResult(new Result<ConsentRequestDetails>(request));
+            }
+            else if (consentRequestId == ORG_CONSENT_WITHOUT_MESSAGE_ID)
+            {
+                ConsentRequestDetails request = Util.GetMockData<ConsentRequestDetails>($"{dataFolder}/Consent/consentRequest_org_without_message.json");
                 return Task.FromResult(new Result<ConsentRequestDetails>(request));
             }
             return Task.FromResult(new Result<ConsentRequestDetails>(ConsentProblem.ConsentNotFound));

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/ConsentControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/ConsentControllerTest.cs
@@ -22,6 +22,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
 
         private readonly string PERSON_CONSENT_ID = "e2071c55-6adf-487b-af05-9198a230ed44";
         private readonly string ORG_CONSENT_ID = "7e540335-d82f-41e9-8b8f-619336d792b4";
+        private readonly string ORG_CONSENT_WITHOUT_MESSAGE_ID = "1a04a7fa-24c1-4e06-9217-8aee89239a9f";
 
         /// <summary>
         ///     Constructor setting up factory, test client and dependencies
@@ -66,6 +67,27 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             // Arrange
             string requestId = ORG_CONSENT_ID;
             string path = Path.Combine(_expectedDataPath, "Consent", "consentRequest_org.json");
+            ConsentRequestFE expectedResponse = Util.GetMockData<ConsentRequestFE>(path);
+
+            // Act
+            HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/consent/request/{requestId}");       
+            ConsentRequestFE actualResponse = await httpResponse.Content.ReadFromJsonAsync<ConsentRequestFE>();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, httpResponse.StatusCode);
+            AssertionUtil.AssertEqual(expectedResponse, actualResponse);
+        }
+
+        /// <summary>
+        ///     Test case: GetConsentRequest checks that consent request with expected texts is returned
+        ///     Expected: GetConsentRequest returns the consent request
+        /// </summary>
+        [Fact]
+        public async Task GetConsentRequest_ReturnsConsentRequestForOrgWithoutMessage()
+        {
+            // Arrange
+            string requestId = ORG_CONSENT_WITHOUT_MESSAGE_ID;
+            string path = Path.Combine(_expectedDataPath, "Consent", "consentRequest_org_without_message.json");
             ConsentRequestFE expectedResponse = Util.GetMockData<ConsentRequestFE>(path);
 
             // Act

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/Consent/consentRequest_org_without_message.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/Consent/consentRequest_org_without_message.json
@@ -1,0 +1,42 @@
+{
+  "id": "1a04a7fa-24c1-4e06-9217-8aee89239a9f",
+  "isPoa": true,
+  "title": {
+    "nb": "Fullmakt til å handle på vegne av DISKRET NÆR TIGER AS",
+    "nn": "Fullmakt til å handla på vegne av DISKRET NÆR TIGER AS",
+    "en": "Power of attorney to act on behalf of DISKRET NÆR TIGER AS"
+  },
+  "heading": {
+    "nb": "RAKRYGGET UNG TIGER AS ønsker å utføre tjenester på vegne av DISKRET NÆR TIGER AS",
+    "nn": "RAKRYGGET UNG TIGER AS ønsker å utføra tenester på vegne av DISKRET NÆR TIGER AS",
+    "en": "RAKRYGGET UNG TIGER AS requests power of attorney from DISKRET NÆR TIGER AS"
+  },
+  "serviceIntro": {
+    "nb": "Ved at du gir fullmakt, får RAKRYGGET UNG TIGER AS tilgang til følgende tjenester på vegne av DISKRET NÆR TIGER AS",
+    "nn": "Ved at du gjer fullmakt, får RAKRYGGET UNG TIGER AS tilgang til følgjande tenester på vegne av DISKRET NÆR TIGER AS",
+    "en": "By granting power of attorney, RAKRYGGET UNG TIGER AS get access to the following services on behalf of DISKRET NÆR TIGER AS"
+  },
+  "consentMessage": null,
+  "expiration": {
+    "nb": "Fullmakten gjelder én gangs bruk av tjenestene",
+    "nn": "Fullmakta gjeld bruk av tenestene éin gong",
+    "en": "The power of attorney applies for one-time access to the service."
+  },
+  "handledBy": null,
+  "fromPartyName": "DISKRET NÆR TIGER AS",
+  "rights": [
+    {
+      "identifier": "consent-test-resource-poa",
+      "title": {
+        "en": "Power of attorney to perform a service",
+        "nb": "Fullmakt til å utføre en tjeneste",
+        "nn": "Fullmakt til å utføre ei teneste"
+      },
+      "consentTextHtml": {
+        "en": "<p>Power of attorney to perform a great service.<h1>heading</h1></p>\n",
+        "nb": "<p>Fullmakt til å utføre en bra tjeneste.<h1>heading</h1></p>\n",
+        "nn": "<p>Fullmakt til å utføre ei bra teneste.<h1>heading</h1></p>\n"
+      }
+    }
+  ]
+}

--- a/src/features/amUI/consent/ConsentRequestPage/ConsentRequestPage.tsx
+++ b/src/features/amUI/consent/ConsentRequestPage/ConsentRequestPage.tsx
@@ -201,7 +201,7 @@ const ConsentRequestContent = ({
       <div className={classes.consentBlock}>
         <div className={classes.consentContent}>
           <DsParagraph className={classes.boldText}>{request.heading[language]}</DsParagraph>
-          <DsParagraph>{request.consentMessage[language]}</DsParagraph>
+          {request.consentMessage && <DsParagraph>{request.consentMessage[language]}</DsParagraph>}
           <DsHeading
             level={2}
             data-size='2xs'

--- a/src/features/amUI/consent/types.ts
+++ b/src/features/amUI/consent/types.ts
@@ -14,7 +14,7 @@ export interface ConsentRequest {
   title: ConsentLanguage;
   heading: ConsentLanguage;
   serviceIntro: ConsentLanguage;
-  consentMessage: ConsentLanguage;
+  consentMessage?: ConsentLanguage;
   expiration: ConsentLanguage;
   handledBy?: ConsentLanguage;
   fromPartyName?: string;


### PR DESCRIPTION
## Description
- Rendering consent request should not crash if requestMessage is null and template overriddenDelegationContext is null. Also added test

## Related Issue(s)
- this PR

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for consent requests without a consent message, including new mock and test data.
* **Bug Fixes**
  * Improved handling to prevent errors when consent messages are missing or null.
* **Tests**
  * Introduced new tests to verify correct behavior for consent requests without a consent message.
* **Style**
  * Minor formatting adjustment for improved code readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->