### PR TITLE
Fix: one time consent for consent requests with multiple resources

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/ConsentService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/ConsentService.cs
@@ -217,11 +217,9 @@ namespace Altinn.AccessManagement.UI.Core.Services
                 {
                     string resourceId = right.Resource.Find(x => x.Type == "urn:altinn:resource")?.Value;
                     ServiceResource resource = await _resourceRegistryClient.GetResource(resourceId);
-                    if (isOneTimeConsent == false && resource.IsOneTimeConsent)
-                    {
-                        // If one of the resources is one-time consent, the whole consent is one-time consent
-                        isOneTimeConsent = resource.IsOneTimeConsent;
-                    }
+
+                    // If one of the resources is one-time consent, the whole consent is one-time consent
+                    isOneTimeConsent = isOneTimeConsent || resource.IsOneTimeConsent;
 
                     rights.Add(new()
                     {


### PR DESCRIPTION
## Description
- If at least one resource used in consent has isOneTimeConsent: true, the whole consent will be one time consent

## Related Issue(s)
- this PR

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the logic for marking consents as one-time consent, ensuring that if any resource requires one-time consent, the entire consent is correctly flagged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->