### PR TITLE
Show message for user being unable to create systemuser in Alert component

### DIFF
--- a/src/features/amUI/systemUser/components/CanCreateSystemUser/CanCreateSystemUser.module.css
+++ b/src/features/amUI/systemUser/components/CanCreateSystemUser/CanCreateSystemUser.module.css
@@ -1,8 +1,8 @@
-.noRightsParagraph {
+.noRightsAlert {
   margin: 2rem 0;
   font-style: italic;
   max-width: 40rem;
 }
-.noRightsParagraphBold {
+.noRightsAlertBold {
   font-weight: 600;
 }

--- a/src/features/amUI/systemUser/components/CanCreateSystemUser/CanCreateSystemUser.tsx
+++ b/src/features/amUI/systemUser/components/CanCreateSystemUser/CanCreateSystemUser.tsx
@@ -30,9 +30,9 @@ export const CreateSystemUserCheck = ({
       {reporteeData && !canCreateSystemUser(reporteeData) && (
         <DsAlert
           data-color='warning'
-          className={classes.noRightsParagraph}
+          className={classes.noRightsAlert}
         >
-          <span className={classes.noRightsParagraphBold}>
+          <span className={classes.noRightsAlertBold}>
             {t('systemuser_overviewpage.no_key_role1')}{' '}
           </span>
           {t('systemuser_overviewpage.no_key_role2')}


### PR DESCRIPTION
## Description
- Warning message is wrapped in Alert component with color warning

![image](https://github.com/user-attachments/assets/d4b43609-ce5a-419c-8ebf-3324a80c2536)


## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/981

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted the maximum width of warning messages for improved layout and readability.

* **New Features**
  * Warning messages for insufficient permissions are now displayed using a more prominent alert style.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->