### PR TITLE
Fix: set escapeValue: false for i18n interpolation

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -45,6 +45,9 @@ use(LanguageDetector)
     fallbackLng: getConfig('defaultLocale'),
     keySeparator: '.',
     returnNull: false,
+    interpolation: {
+      escapeValue: false, // React already escapes values
+    },
   });
 
 // Configure react-query


### PR DESCRIPTION
## Description
- This will render characters like `&`, `<`, `>`, `'` correctly in all interpolated string in solution

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/970

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated translation settings to improve compatibility with React's built-in escaping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->