### PR TITLE
Feat/amUI/906-vise-tjenestebilder-i-pakke-modalen

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/ClientInterfaces/IAltinnCdnClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/ClientInterfaces/IAltinnCdnClient.cs
@@ -1,0 +1,16 @@
+﻿using Altinn.AccessManagement.UI.Core.Models.Common;
+
+namespace Altinn.AccessManagement.UI.Core.ClientInterfaces
+{
+    /// <summary>
+    /// Interface for client wrapper for integration with profile endpoints in access management component
+    /// </summary>
+    public interface IAltinnCdnClient
+    {
+        /// <summary>
+        /// Retrieves organization data from the CDN.
+        /// </summary>
+        /// <returns>A task that represents the asynchronous operation. The task result contains a dictionary with organization data.</returns>
+        Task<Dictionary<string, OrgData>> GetOrgData();
+    }
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Configuration/MockSettings.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Configuration/MockSettings.cs
@@ -69,6 +69,10 @@ namespace Altinn.AccessManagement.UI.Core.Configuration
         /// Set to run ConsentClient locally during runtime
         /// </summary>
         public bool Consent { get; set; }
+
+        /// <summary>
+        /// Set to run AltinnCdnClient locally during runtime
+        /// </summary>
         public bool AltinnCdn { get; set; }
 
         /// <summary>

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Configuration/MockSettings.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Configuration/MockSettings.cs
@@ -69,6 +69,7 @@ namespace Altinn.AccessManagement.UI.Core.Configuration
         /// Set to run ConsentClient locally during runtime
         /// </summary>
         public bool Consent { get; set; }
+        public bool AltinnCdn { get; set; }
 
         /// <summary>
         /// Default constructor

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/Common/OrgData.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/Common/OrgData.cs
@@ -1,0 +1,61 @@
+#nullable enable
+namespace Altinn.AccessManagement.UI.Core.Models.Common
+{
+    /// <summary>
+    /// Represents organization data from Altinn CDN.
+    /// </summary>
+    public class OrgData
+    {
+        /// <summary>
+        /// Gets or sets the organization name in different languages.
+        /// </summary>
+        // Use Dictionary<string, string> to match the JSON structure
+        public Dictionary<string, string>? Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the organization logo url.
+        /// </summary>
+        public string? Logo { get; set; }
+
+        /// <summary>
+        /// Gets or sets the organization emblem url.
+        /// </summary>
+        public string? Emblem { get; set; }
+
+        /// <summary>
+        /// Gets or sets the organization number.
+        /// </summary>
+        public string? Orgnr { get; set; }
+
+        /// <summary>
+        /// Gets or sets the organization's homepage URL.
+        /// </summary>
+        public string? Homepage { get; set; }
+
+        /// <summary>
+        /// Gets or sets the environments where the organization is available.
+        /// </summary>
+        public List<string>? Environments { get; set; }
+
+        /// <summary>
+        /// Gets or sets the contact information for the organization.
+        /// </summary>
+        public OrgContact? Contact { get; set; } // Assuming you have an OrgContact model
+    }
+
+    /// <summary>
+    /// Represents organization contact information.
+    /// </summary>
+    public class OrgContact
+    {
+        /// <summary>
+        /// Gets or sets the phone number.
+        /// </summary>
+        public string? Phone { get; set; }
+
+        /// <summary>
+        /// Gets or sets the contact URL.
+        /// </summary>
+        public string? Url { get; set; }
+    }
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/AltinnCdnService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/AltinnCdnService.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Altinn.AccessManagement.UI.Core.ClientInterfaces;
+using Altinn.AccessManagement.UI.Core.Models;
+using Altinn.AccessManagement.UI.Core.Models.Common;
+using Altinn.AccessManagement.UI.Core.Services.Interfaces;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Altinn.AccessManagement.UI.Core.Services
+{
+    /// <summary>
+    /// Service for retrieving and caching organization logo mappings from a remote JSON source.
+    /// </summary>
+    public class AltinnCdnService : IAltinnCdnService
+    {
+        private readonly HttpClient _httpClient;
+        private readonly IMemoryCache _cache;
+        private readonly ILogger<AltinnCdnService> _logger;
+        private readonly IAltinnCdnClient _altinnCdnClient;
+
+        private const string CacheKey = "OrgLogoMap";
+        private readonly TimeSpan cacheDuration = TimeSpan.FromHours(1);
+        private static readonly JsonSerializerOptions _jsonOptions = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OrgLogoService"/> class.
+        /// </summary>
+        /// <param name="altinnCdnClient">The client used to fetch organization data from Altinn CDN.</param>
+        /// <param name="httpClient">The HTTP client used to fetch organization logo data.</param>
+        /// <param name="cache">The memory cache for storing logo mappings.</param>
+        /// <param name="logger">The logger instance for logging errors and information.</param>
+        public AltinnCdnService(IAltinnCdnClient altinnCdnClient, HttpClient httpClient, IMemoryCache cache, ILogger<AltinnCdnService> logger)
+        {
+            _altinnCdnClient = altinnCdnClient;
+            _httpClient = httpClient;
+            _cache = cache;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Retrieves organization data from the Altinn CDN.
+        /// Caches the result for a specified duration to improve performance.
+        /// </summary>
+        /// <returns>A dictionary containing organization data, where the key is the organization code and the value is the <see cref="OrgData"/> object.</returns>
+        public async Task<Dictionary<string, OrgData>> GetOrgData()
+        {
+            try
+            {
+                if (_cache.TryGetValue(CacheKey, out Dictionary<string, OrgData> orgData) && orgData != null)
+                {
+                    return orgData;
+                }
+                else
+                {
+                    var cacheEntryOptions = new MemoryCacheEntryOptions()
+                        .SetAbsoluteExpiration(cacheDuration);
+
+                    orgData = await _altinnCdnClient.GetOrgData();
+                    _cache.Set(CacheKey, orgData, cacheEntryOptions);
+                    return orgData;
+                }
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "Error retrieving organization data from Altinn CDN.");
+                return new Dictionary<string, OrgData>();
+            }
+        }
+    }
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/AltinnCdnService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/AltinnCdnService.cs
@@ -26,7 +26,6 @@ namespace Altinn.AccessManagement.UI.Core.Services
 
         private const string CacheKey = "CdnOrgDataDictionary";
         private readonly TimeSpan cacheDuration = TimeSpan.FromHours(1);
-        private static readonly JsonSerializerOptions _jsonOptions = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AltinnCdnService"/> class.

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/AltinnCdnService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/AltinnCdnService.cs
@@ -24,12 +24,12 @@ namespace Altinn.AccessManagement.UI.Core.Services
         private readonly ILogger<AltinnCdnService> _logger;
         private readonly IAltinnCdnClient _altinnCdnClient;
 
-        private const string CacheKey = "OrgLogoMap";
+        private const string CacheKey = "CdnOrgDataDictionary";
         private readonly TimeSpan cacheDuration = TimeSpan.FromHours(1);
         private static readonly JsonSerializerOptions _jsonOptions = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="OrgLogoService"/> class.
+        /// Initializes a new instance of the <see cref="AltinnCdnService"/> class.
         /// </summary>
         /// <param name="altinnCdnClient">The client used to fetch organization data from Altinn CDN.</param>
         /// <param name="httpClient">The HTTP client used to fetch organization logo data.</param>

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/Interfaces/IAltinnCdnService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/Interfaces/IAltinnCdnService.cs
@@ -1,0 +1,18 @@
+#nullable enable
+
+using Altinn.AccessManagement.UI.Core.Models.Common;
+
+namespace Altinn.AccessManagement.UI.Core.Services.Interfaces
+{
+    /// <summary>
+    /// Interface for Altinn CDN service that provides methods to retrieve organization data.
+    /// </summary>
+    public interface IAltinnCdnService
+    {
+        /// <summary>
+        /// Retrieves organization data from the Altinn CDN.
+        /// </summary>
+        /// <returns>A dictionary containing organization data, where the key is the organization code and the value is the <see cref="OrgData"/> object.</returns>
+        Task<Dictionary<string, OrgData>> GetOrgData();
+    }
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/AltinnCdnClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/AltinnCdnClient.cs
@@ -1,11 +1,7 @@
 ﻿using System.Text.Json;
 using Altinn.AccessManagement.UI.Core.ClientInterfaces;
 using Altinn.AccessManagement.UI.Core.Models.Common;
-using Altinn.AccessManagement.UI.Core.Services.Interfaces;
-using Altinn.AccessManagement.UI.Integration.Configuration;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace Altinn.AccessManagement.UI.Integration.Clients
 {
@@ -16,32 +12,18 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
     {
         private readonly ILogger _logger;
         private readonly HttpClient _client;
-        private readonly IHttpContextAccessor _httpContextAccessor;
-        private readonly PlatformSettings _platformSettings;
-        private readonly IAccessTokenProvider _accessTokenProvider;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AltinnCdnClient"/> class
         /// </summary>
         /// <param name="httpClient">the handler for httpclient service</param>
         /// <param name="logger">the handler for logger service</param>
-        /// <param name="httpContextAccessor">the handler for httpcontextaccessor service</param>
-        /// <param name="platformSettings"> platform settings configuration</param>
-        /// <param name="accessTokenProvider">the handler for access token generator</param>
         public AltinnCdnClient(
             HttpClient httpClient,
-            ILogger<AltinnCdnClient> logger,
-            IHttpContextAccessor httpContextAccessor,
-            IOptions<PlatformSettings> platformSettings,
-            IAccessTokenProvider accessTokenProvider)
+            ILogger<AltinnCdnClient> logger)
         {
             _logger = logger;
-            _platformSettings = platformSettings.Value;
-            httpClient.BaseAddress = new Uri(_platformSettings.ApiProfileEndpoint);
-            httpClient.DefaultRequestHeaders.Add(_platformSettings.SubscriptionKeyHeaderName, _platformSettings.SubscriptionKey);
             _client = httpClient;
-            _httpContextAccessor = httpContextAccessor;
-            _accessTokenProvider = accessTokenProvider;
         }
 
         private readonly string altinnCdnUrl = "https://altinncdn.no/";

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/AltinnCdnClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/AltinnCdnClient.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Logging;
 namespace Altinn.AccessManagement.UI.Integration.Clients
 {
     /// <summary>
-    /// client that integrates with the platform profile api
+    /// client that retrieves organization data from the Altinn CDN.
     /// </summary>
     public class AltinnCdnClient : IAltinnCdnClient
     {

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/AltinnCdnClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/AltinnCdnClient.cs
@@ -30,7 +30,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
         /// <param name="accessTokenProvider">the handler for access token generator</param>
         public AltinnCdnClient(
             HttpClient httpClient,
-            ILogger<ProfileClient> logger,
+            ILogger<AltinnCdnClient> logger,
             IHttpContextAccessor httpContextAccessor,
             IOptions<PlatformSettings> platformSettings,
             IAccessTokenProvider accessTokenProvider)

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/AltinnCdnClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/AltinnCdnClient.cs
@@ -1,0 +1,73 @@
+﻿using System.Text.Json;
+using Altinn.AccessManagement.UI.Core.ClientInterfaces;
+using Altinn.AccessManagement.UI.Core.Models.Common;
+using Altinn.AccessManagement.UI.Core.Services.Interfaces;
+using Altinn.AccessManagement.UI.Integration.Configuration;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Altinn.AccessManagement.UI.Integration.Clients
+{
+    /// <summary>
+    /// client that integrates with the platform profile api
+    /// </summary>
+    public class AltinnCdnClient : IAltinnCdnClient
+    {
+        private readonly ILogger _logger;
+        private readonly HttpClient _client;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly PlatformSettings _platformSettings;
+        private readonly IAccessTokenProvider _accessTokenProvider;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AltinnCdnClient"/> class
+        /// </summary>
+        /// <param name="httpClient">the handler for httpclient service</param>
+        /// <param name="logger">the handler for logger service</param>
+        /// <param name="httpContextAccessor">the handler for httpcontextaccessor service</param>
+        /// <param name="platformSettings"> platform settings configuration</param>
+        /// <param name="accessTokenProvider">the handler for access token generator</param>
+        public AltinnCdnClient(
+            HttpClient httpClient,
+            ILogger<ProfileClient> logger,
+            IHttpContextAccessor httpContextAccessor,
+            IOptions<PlatformSettings> platformSettings,
+            IAccessTokenProvider accessTokenProvider)
+        {
+            _logger = logger;
+            _platformSettings = platformSettings.Value;
+            httpClient.BaseAddress = new Uri(_platformSettings.ApiProfileEndpoint);
+            httpClient.DefaultRequestHeaders.Add(_platformSettings.SubscriptionKeyHeaderName, _platformSettings.SubscriptionKey);
+            _client = httpClient;
+            _httpContextAccessor = httpContextAccessor;
+            _accessTokenProvider = accessTokenProvider;
+        }
+
+        private readonly string altinnCdnUrl = "https://altinncdn.no/";
+        private static readonly JsonSerializerOptions _jsonOptions = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+
+        /// <inheritdoc/>
+        public async Task<Dictionary<string, OrgData>> GetOrgData()
+        {
+            var response = await _client.GetAsync($"{altinnCdnUrl}orgs/altinn-orgs.json", HttpCompletionOption.ResponseHeadersRead);
+            response.EnsureSuccessStatusCode();
+            string responseContent = await response.Content.ReadAsStringAsync();
+
+            Dictionary<string, Dictionary<string, OrgData>> rawOrgData = JsonSerializer.Deserialize<Dictionary<string, Dictionary<string, OrgData>>>(responseContent, _jsonOptions);
+
+            Dictionary<string, OrgData> orgData = new Dictionary<string, OrgData>();
+
+            if (rawOrgData != null && rawOrgData.TryGetValue("orgs", out var innerOrgData) && innerOrgData != null)
+            {
+                orgData = innerOrgData;
+            }
+            else
+            {
+                _logger.LogError("Failed to deserialize org data or 'orgs' property is missing/null from {AltinnCdnUrl}", altinnCdnUrl);
+            }
+
+            return orgData;
+        }
+    }
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/AltinnCdn/altinn-orgs.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/AltinnCdn/altinn-orgs.json
@@ -1,0 +1,128 @@
+{
+  "orgs": {
+    "digdir": {
+      "name": {
+        "en": "Norwegian Digitalisation Agency",
+        "nb": "Digitaliseringsdirektoratet",
+        "nn": "Digitaliseringsdirektoratet"
+      },
+      "logo": "https://altinncdn.no/orgs/digdir/digdir.png",
+      "emblem": "https://altinncdn.no/orgs/digdir/digdir.svg",
+      "orgnr": "991825827",
+      "homepage": "https://www.digdir.no",
+      "environments": [
+        "tt02",
+        "production"
+      ],
+      "contact": {
+        "phone": "+4722451000",
+        "url": "https://www.digdir.no/digdir/kontakt-oss/943"
+      }
+    },
+    "skd": {
+      "name": {
+        "en": "Norwegian Tax Administration",
+        "nb": "Skatteetaten",
+        "nn": "Skatteetaten"
+      },
+      "logo": "https://altinncdn.no/orgs/skd/skd.png",
+      "emblem": "https://altinncdn.no/orgs/skd/skd.svg",
+      "orgnr": "974761076",
+      "homepage": "https://www.skatteetaten.no",
+      "environments": [
+        "tt02",
+        "yt01",
+        "production"
+      ],
+      "contact": {
+        "phone": "+4780080000",
+        "url": "https://www.skatteetaten.no/kontakt"
+      }
+    },
+    "brg": {
+      "name": {
+        "en": "Brønnøysund Register Centre",
+        "nb": "Brønnøysundregistrene",
+        "nn": "Brønnøysundregistera"
+      },
+      "logo": "https://altinncdn.no/orgs/brg/brreg.png",
+      "emblem": null,
+      "orgnr": "974760673",
+      "homepage": "https://www.brreg.no",
+      "environments": [
+        "tt02",
+        "production"
+      ],
+      "contact": null
+    },
+    "nav": {
+      "name": {
+        "en": "Norwegian Labour and Welfare Administration (NAV)",
+        "nb": "Arbeids- og velferdsetaten (NAV)",
+        "nn": "Arbeids- og velferdsetaten (NAV)"
+      },
+      "logo": "https://altinncdn.no/orgs/nav/nav.png",
+      "emblem": "https://altinncdn.no/orgs/nav/nav.svg",
+      "orgnr": "889640782",
+      "homepage": "https://www.nav.no",
+      "environments": [
+        "tt02"
+      ],
+      "contact": {
+        "phone": "+4755553333",
+        "url": "https://www.nav.no/kontaktoss"
+      }
+    },
+    "ttd": {
+      "name": {
+        "en": "Test Ministry",
+        "nb": "Testdepartementet",
+        "nn": "Testdepartementet"
+      },
+      "logo": "https://altinncdn.no/orgs/ttd/ttd.png",
+      "emblem": "https://altinncdn.no/orgs/ttd/ttd.svg",
+      "orgnr": "",
+      "homepage": "",
+      "environments": [
+        "at22",
+        "at23",
+        "at24",
+        "tt02",
+        "yt01",
+        "production"
+      ],
+      "contact": {
+        "phone": "+4722451000",
+        "url": "https://altinn.studio/info/contact"
+      }
+    },
+    "mat": {
+      "name": {
+        "en": "Norwegian Food Safety Authority",
+        "nb": "Mattilsynet",
+        "nn": "Mattilsynet"
+      },
+      "logo": "https://altinncdn.no/orgs/mat/mat.png",
+      "emblem": null,
+      "orgnr": "985399077",
+      "homepage": "https://www.mattilsynet.no/",
+      "environments": [
+        "tt02",
+        "production"
+      ],
+      "contact": null
+    },
+    "testorg": {
+      "name": {
+        "nb": "Minimal Test Org",
+        "en": "Minimal Test Org"
+      },
+      "logo": null,
+      "emblem": null,
+      "orgnr": "999000111",
+      "homepage": null,
+      "environments": ["test"],
+      "contact": null
+    }
+  }
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/AltinnCdn/altinn-orgs.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/AltinnCdn/altinn-orgs.json
@@ -6,14 +6,14 @@
         "nb": "Digitaliseringsdirektoratet",
         "nn": "Digitaliseringsdirektoratet"
       },
-      "logo": "https://altinncdn.no/orgs/digdir/digdir.png",
-      "emblem": "https://altinncdn.no/orgs/digdir/digdir.svg",
+      "logo": "/orgs/digdir/digdir.png",
+      "emblem": "/orgs/digdir/digdir.svg",
       "orgnr": "991825827",
-      "homepage": "https://www.digdir.no",
-      "environments": ["tt02", "production"],
+      "homepage": "",
+      "environments": ["tt02"],
       "contact": {
-        "phone": "+4722451000",
-        "url": "https://www.digdir.no/digdir/kontakt-oss/943"
+        "phone": "+47123456",
+        "url": "/digdir/kontakt-oss/943"
       }
     },
     "skd": {
@@ -22,14 +22,14 @@
         "nb": "Skatteetaten",
         "nn": "Skatteetaten"
       },
-      "logo": "https://altinncdn.no/orgs/skd/skd.png",
-      "emblem": "https://altinncdn.no/orgs/skd/skd.svg",
+      "logo": "/orgs/skd/skd.png",
+      "emblem": "/orgs/skd/skd.svg",
       "orgnr": "974761076",
-      "homepage": "https://www.skatteetaten.no",
-      "environments": ["tt02", "yt01", "production"],
+      "homepage": "",
+      "environments": ["tt02"],
       "contact": {
-        "phone": "+4780080000",
-        "url": "https://www.skatteetaten.no/kontakt"
+        "phone": "+47123456",
+        "url": "/kontakt"
       }
     }
   }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/AltinnCdn/altinn-orgs.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/AltinnCdn/altinn-orgs.json
@@ -10,10 +10,7 @@
       "emblem": "https://altinncdn.no/orgs/digdir/digdir.svg",
       "orgnr": "991825827",
       "homepage": "https://www.digdir.no",
-      "environments": [
-        "tt02",
-        "production"
-      ],
+      "environments": ["tt02", "production"],
       "contact": {
         "phone": "+4722451000",
         "url": "https://www.digdir.no/digdir/kontakt-oss/943"
@@ -29,100 +26,11 @@
       "emblem": "https://altinncdn.no/orgs/skd/skd.svg",
       "orgnr": "974761076",
       "homepage": "https://www.skatteetaten.no",
-      "environments": [
-        "tt02",
-        "yt01",
-        "production"
-      ],
+      "environments": ["tt02", "yt01", "production"],
       "contact": {
         "phone": "+4780080000",
         "url": "https://www.skatteetaten.no/kontakt"
       }
-    },
-    "brg": {
-      "name": {
-        "en": "Brønnøysund Register Centre",
-        "nb": "Brønnøysundregistrene",
-        "nn": "Brønnøysundregistera"
-      },
-      "logo": "https://altinncdn.no/orgs/brg/brreg.png",
-      "emblem": null,
-      "orgnr": "974760673",
-      "homepage": "https://www.brreg.no",
-      "environments": [
-        "tt02",
-        "production"
-      ],
-      "contact": null
-    },
-    "nav": {
-      "name": {
-        "en": "Norwegian Labour and Welfare Administration (NAV)",
-        "nb": "Arbeids- og velferdsetaten (NAV)",
-        "nn": "Arbeids- og velferdsetaten (NAV)"
-      },
-      "logo": "https://altinncdn.no/orgs/nav/nav.png",
-      "emblem": "https://altinncdn.no/orgs/nav/nav.svg",
-      "orgnr": "889640782",
-      "homepage": "https://www.nav.no",
-      "environments": [
-        "tt02"
-      ],
-      "contact": {
-        "phone": "+4755553333",
-        "url": "https://www.nav.no/kontaktoss"
-      }
-    },
-    "ttd": {
-      "name": {
-        "en": "Test Ministry",
-        "nb": "Testdepartementet",
-        "nn": "Testdepartementet"
-      },
-      "logo": "https://altinncdn.no/orgs/ttd/ttd.png",
-      "emblem": "https://altinncdn.no/orgs/ttd/ttd.svg",
-      "orgnr": "",
-      "homepage": "",
-      "environments": [
-        "at22",
-        "at23",
-        "at24",
-        "tt02",
-        "yt01",
-        "production"
-      ],
-      "contact": {
-        "phone": "+4722451000",
-        "url": "https://altinn.studio/info/contact"
-      }
-    },
-    "mat": {
-      "name": {
-        "en": "Norwegian Food Safety Authority",
-        "nb": "Mattilsynet",
-        "nn": "Mattilsynet"
-      },
-      "logo": "https://altinncdn.no/orgs/mat/mat.png",
-      "emblem": null,
-      "orgnr": "985399077",
-      "homepage": "https://www.mattilsynet.no/",
-      "environments": [
-        "tt02",
-        "production"
-      ],
-      "contact": null
-    },
-    "testorg": {
-      "name": {
-        "nb": "Minimal Test Org",
-        "en": "Minimal Test Org"
-      },
-      "logo": null,
-      "emblem": null,
-      "orgnr": "999000111",
-      "homepage": null,
-      "environments": ["test"],
-      "contact": null
     }
   }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/AltinnCdnClientMock.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/AltinnCdnClientMock.cs
@@ -1,0 +1,72 @@
+#nullable enable
+
+using System.Text.Json;
+using Altinn.AccessManagement.UI.Core.ClientInterfaces;
+using Altinn.AccessManagement.UI.Core.Models.Common;
+using Altinn.AccessManagement.UI.Core.Services.Interfaces;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Altinn.AccessManagement.UI.Mocks.Mocks
+{
+    /// <summary>
+    /// Mock class for <see cref="IAltinnCdnClient"/> interface
+    /// </summary>
+    public class AltinnCdnClientMock : IAltinnCdnClient
+    {
+        private static readonly JsonSerializerOptions _options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AltinnCdnClientMock"/> class
+        /// </summary>
+        public AltinnCdnClientMock()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AltinnCdnClientMock"/> class with dependencies
+        /// </summary>
+        /// <param name="httpClient">The HTTP client (not used in mock)</param>
+        /// <param name="logger">The logger (not used in mock)</param>
+        /// <param name="httpContextAccessor">The HTTP context accessor (not used in mock)</param>
+        /// <param name="accessTokenProvider">The access token provider (not used in mock)</param>
+        public AltinnCdnClientMock(
+            HttpClient httpClient,
+            ILogger<AltinnCdnClientMock> logger,
+            IHttpContextAccessor httpContextAccessor,
+            IAccessTokenProvider accessTokenProvider)
+        {
+            // Parameters not used in mock implementation
+        }
+
+        /// <inheritdoc/>
+        public async Task<Dictionary<string, OrgData>> GetOrgData()
+        {
+            var orgData = new Dictionary<string, OrgData>();
+
+            string testDataPath = GetDataPath();
+
+            if (File.Exists(testDataPath))
+            {
+                string content = await File.ReadAllTextAsync(testDataPath);
+                var rawData = JsonSerializer.Deserialize<Dictionary<string, Dictionary<string, OrgData>>>(content, _options);
+
+                if (rawData != null && rawData.TryGetValue("orgs", out var innerOrgData) && innerOrgData != null)
+                {
+                    orgData = innerOrgData;
+                }
+            }
+            return orgData;
+        }
+
+        /// <summary>
+        /// Gets the path to the test data file
+        /// </summary>
+        /// <returns>The path to the altinn-orgs.json test data file</returns>
+        private static string GetDataPath()
+        {
+            string folder = Path.GetDirectoryName(new Uri(typeof(ResourceRegistryClientMock).Assembly.Location).LocalPath) ?? string.Empty;
+            return Path.Combine(folder, "Data", "AltinnCdn", "altinn-orgs.json");
+        }
+    }
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/AltinnCdnClientMock.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/AltinnCdnClientMock.cs
@@ -65,7 +65,7 @@ namespace Altinn.AccessManagement.UI.Mocks.Mocks
         /// <returns>The path to the altinn-orgs.json test data file</returns>
         private static string GetDataPath()
         {
-            string folder = Path.GetDirectoryName(new Uri(typeof(ResourceRegistryClientMock).Assembly.Location).LocalPath) ?? string.Empty;
+            string folder = Path.GetDirectoryName(new Uri(typeof(AltinnCdnClientMock).Assembly.Location).LocalPath) ?? string.Empty;
             return Path.Combine(folder, "Data", "AltinnCdn", "altinn-orgs.json");
         }
     }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/AltinnCdnControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/AltinnCdnControllerTest.cs
@@ -1,0 +1,107 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using Altinn.AccessManagement.UI.Controllers;
+using Altinn.AccessManagement.UI.Core.Models.Common;
+using Altinn.AccessManagement.UI.Core.Services.Interfaces;
+using Altinn.AccessManagement.UI.Mocks.Mocks;
+using Altinn.AccessManagement.UI.Mocks.Utils;
+using Altinn.AccessManagement.UI.Tests.Utils;
+using AltinnCore.Authentication.JwtCookie;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace Altinn.AccessManagement.UI.Tests.Controllers
+{
+    /// <summary>
+    /// Test class for <see cref="AltinnCdnController"/>
+    /// </summary>
+    [Collection("AltinnCdnController Tests")]
+    public class AltinnCdnControllerTest : IClassFixture<CustomWebApplicationFactory<AltinnCdnController>>
+    {
+        private readonly CustomWebApplicationFactory<AltinnCdnController> _factory;
+        private readonly Mock<IAltinnCdnService> _mockAltinnCdnService;
+        private readonly Mock<ILogger<AltinnCdnController>> _mockLogger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AltinnCdnControllerTest"/> class.
+        /// </summary>
+        /// <param name="factory">CustomWebApplicationFactory</param>
+        public AltinnCdnControllerTest(CustomWebApplicationFactory<AltinnCdnController> factory)
+        {
+            _factory = factory;
+            _mockAltinnCdnService = new Mock<IAltinnCdnService>();
+            _mockLogger = new Mock<ILogger<AltinnCdnController>>();
+        }
+
+        /// <summary>
+        /// Successfully get organization data
+        /// </summary>
+        [Fact]
+        public async Task GetOrgData_ReturnsOrgData()
+        {
+            // Arrange
+            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(AltinnCdnControllerTest).Assembly.Location).LocalPath);
+            string path = Path.Combine(unitTestFolder, "Data", "ExpectedResults", "AltinnCdn", "orgData.json");
+            Dictionary<string, OrgData> expectedOrgData = Util.GetMockData<Dictionary<string, OrgData>>(path);
+
+            var client = GetTestClient(expectedOrgData);
+            // No authentication header needed since this is public data
+
+            // Act
+            var response = await client.GetAsync("accessmanagement/api/v1/cdn/orgdata");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var actualOrgData = await response.Content.ReadFromJsonAsync<Dictionary<string, OrgData>>();
+            Assert.NotNull(actualOrgData);
+            AssertionUtil.AssertEqual(expectedOrgData, actualOrgData);
+        }
+
+        /// <summary>
+        /// Test that when service returns empty data, the endpoint returns empty dictionary
+        /// </summary>
+        [Fact]
+        public async Task GetOrgData_ServiceReturnsEmptyData_ReturnsEmptyDictionary()
+        {
+            // Arrange
+            var client = GetTestClient(new Dictionary<string, OrgData>());
+
+            // Act
+            var response = await client.GetAsync("accessmanagement/api/v1/cdn/orgdata");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var actualOrgData = await response.Content.ReadFromJsonAsync<Dictionary<string, OrgData>>();
+            Assert.NotNull(actualOrgData);
+            Assert.Empty(actualOrgData);
+        }
+
+        private HttpClient GetTestClient(Dictionary<string, OrgData> orgDataToReturn)
+        {
+            var mockService = new Mock<IAltinnCdnService>();
+            mockService.Setup(s => s.GetOrgData()).ReturnsAsync(orgDataToReturn);
+
+            var httpClient = _factory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.AddSingleton(mockService.Object);
+                    services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+                    services.AddSingleton<IPostConfigureOptions<JwtCookieOptions>, JwtCookiePostConfigureOptionsStub>();
+                });
+            }).CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+
+            httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+            return httpClient;
+        }
+
+    }
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/AltinnCdnControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/AltinnCdnControllerTest.cs
@@ -26,8 +26,8 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
     public class AltinnCdnControllerTest : IClassFixture<CustomWebApplicationFactory<AltinnCdnController>>
     {
         private readonly CustomWebApplicationFactory<AltinnCdnController> _factory;
-        private readonly Mock<IAltinnCdnService> _mockAltinnCdnService;
-        private readonly Mock<ILogger<AltinnCdnController>> _mockLogger;
+        
+        private readonly HttpClient _client;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AltinnCdnControllerTest"/> class.
@@ -36,8 +36,11 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         public AltinnCdnControllerTest(CustomWebApplicationFactory<AltinnCdnController> factory)
         {
             _factory = factory;
-            _mockAltinnCdnService = new Mock<IAltinnCdnService>();
-            _mockLogger = new Mock<ILogger<AltinnCdnController>>();
+            _client = SetupUtils.GetTestClient(new CustomWebApplicationFactory<UserController>(), null);
+
+            string token = PrincipalUtil.GetAccessToken("accessmanagement.api");
+            _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            _client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
         }
 
         /// <summary>
@@ -51,11 +54,9 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             string path = Path.Combine(unitTestFolder, "Data", "ExpectedResults", "AltinnCdn", "orgData.json");
             Dictionary<string, OrgData> expectedOrgData = Util.GetMockData<Dictionary<string, OrgData>>(path);
 
-            var client = GetTestClient(expectedOrgData);
-            // No authentication header needed since this is public data
 
             // Act
-            var response = await client.GetAsync("accessmanagement/api/v1/cdn/orgdata");
+            var response = await _client.GetAsync("accessmanagement/api/v1/cdn/orgdata");
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -70,11 +71,9 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         [Fact]
         public async Task GetOrgData_ServiceReturnsEmptyData_ReturnsEmptyDictionary()
         {
-            // Arrange
-            var client = GetTestClient(new Dictionary<string, OrgData>());
 
             // Act
-            var response = await client.GetAsync("accessmanagement/api/v1/cdn/orgdata");
+            var response = await _client.GetAsync("accessmanagement/api/v1/cdn/orgdata");
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/AltinnCdnControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/AltinnCdnControllerTest.cs
@@ -2,7 +2,9 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using Altinn.AccessManagement.UI.Controllers;
+using Altinn.AccessManagement.UI.Core.ClientInterfaces;
 using Altinn.AccessManagement.UI.Core.Models.Common;
+using Altinn.AccessManagement.UI.Core.Services;
 using Altinn.AccessManagement.UI.Core.Services.Interfaces;
 using Altinn.AccessManagement.UI.Mocks.Mocks;
 using Altinn.AccessManagement.UI.Mocks.Utils;
@@ -15,6 +17,8 @@ using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Moq;
 
 namespace Altinn.AccessManagement.UI.Tests.Controllers
@@ -26,7 +30,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
     public class AltinnCdnControllerTest : IClassFixture<CustomWebApplicationFactory<AltinnCdnController>>
     {
         private readonly CustomWebApplicationFactory<AltinnCdnController> _factory;
-        
+
         private readonly HttpClient _client;
 
         /// <summary>
@@ -71,15 +75,40 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         [Fact]
         public async Task GetOrgData_ServiceReturnsEmptyData_ReturnsEmptyDictionary()
         {
+            // Arrange
+            var emptyOrgData = new Dictionary<string, OrgData>();
+            var testClient = GetTestClient(emptyOrgData);
 
             // Act
-            var response = await _client.GetAsync("accessmanagement/api/v1/cdn/orgdata");
+            var response = await testClient.GetAsync("accessmanagement/api/v1/cdn/orgdata");
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var actualOrgData = await response.Content.ReadFromJsonAsync<Dictionary<string, OrgData>>();
             Assert.NotNull(actualOrgData);
             Assert.Empty(actualOrgData);
+        }
+
+        /// <summary>
+        /// Test that when service throws an exception, controller returns 500 status code
+        /// </summary>
+        [Fact]
+        public async Task GetOrgData_ServiceThrowsException_ReturnsInternalServerError()
+        {
+            // Arrange
+            var mockService = new Mock<IAltinnCdnService>();
+            mockService.Setup(s => s.GetOrgData())
+                .ThrowsAsync(new InvalidOperationException("Service error"));
+
+            var testClient = GetTestClientWithExceptionService(mockService.Object);
+
+            // Act
+            var response = await testClient.GetAsync("accessmanagement/api/v1/cdn/orgdata");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+            var content = await response.Content.ReadAsStringAsync();
+            Assert.Contains("An error occurred while retrieving organization data", content);
         }
 
         private HttpClient GetTestClient(Dictionary<string, OrgData> orgDataToReturn)
@@ -97,10 +126,98 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
                 });
             }).CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
 
+            string token = PrincipalUtil.GetAccessToken("accessmanagement.api");
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
             httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 
             return httpClient;
         }
 
+
+        /// <summary>
+        /// Test that verifies data is cached after first request and subsequent requests use cached data
+        /// </summary>
+        [Fact]
+        public async Task GetOrgData_CachesDataAfterFirstRequest_AndUsesCache()
+        {
+            // Arrange
+            var expectedOrgData = new Dictionary<string, OrgData>
+            {
+                {
+                    "cto",
+                    new OrgData
+                    {
+                        Name = new Dictionary<string, string> { { "nb", "Cache Test Organization" } },
+                        Logo = "/cache-logo.png",
+                    }
+                }
+            };
+
+            var mockCdnClient = new Mock<IAltinnCdnClient>();
+            mockCdnClient.Setup(c => c.GetOrgData()).ReturnsAsync(expectedOrgData);
+
+            var testClient = _factory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.AddSingleton(mockCdnClient.Object);
+                    services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+                    services.AddSingleton<IPostConfigureOptions<JwtCookieOptions>, JwtCookiePostConfigureOptionsStub>();
+                    services.AddMemoryCache();
+                    services.AddSingleton<IAltinnCdnService, AltinnCdnService>();
+                });
+            }).CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+
+            string token = PrincipalUtil.GetAccessToken("accessmanagement.api");
+            testClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            testClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+            // Act - First request (should cache the data)
+            var response1 = await testClient.GetAsync("accessmanagement/api/v1/cdn/orgdata");
+
+            // Act - Second request (should use cached data)
+            var response2 = await testClient.GetAsync("accessmanagement/api/v1/cdn/orgdata");
+
+            // Act - Third request (should still use cached data)
+            var response3 = await testClient.GetAsync("accessmanagement/api/v1/cdn/orgdata");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response1.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, response2.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, response3.StatusCode);
+
+            var actualOrgData1 = await response1.Content.ReadFromJsonAsync<Dictionary<string, OrgData>>();
+            var actualOrgData2 = await response2.Content.ReadFromJsonAsync<Dictionary<string, OrgData>>();
+            var actualOrgData3 = await response3.Content.ReadFromJsonAsync<Dictionary<string, OrgData>>();
+
+            Assert.NotNull(actualOrgData1);
+            Assert.NotNull(actualOrgData2);
+            Assert.NotNull(actualOrgData3);
+            Assert.Equal(expectedOrgData.Count, actualOrgData1.Count);
+            Assert.Equal(expectedOrgData.Count, actualOrgData2.Count);
+            Assert.Equal(expectedOrgData.Count, actualOrgData3.Count);
+
+            // Verify the underlying client was called exactly once - proving cache is working
+            mockCdnClient.Verify(c => c.GetOrgData(), Times.Once);
+        }
+
+        private HttpClient GetTestClientWithExceptionService(IAltinnCdnService mockService)
+        {
+            var httpClient = _factory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.AddSingleton(mockService);
+                    services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+                    services.AddSingleton<IPostConfigureOptions<JwtCookieOptions>, JwtCookiePostConfigureOptionsStub>();
+                });
+            }).CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+
+            string token = PrincipalUtil.GetAccessToken("accessmanagement.api");
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+            return httpClient;
+        }
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/AltinnCdnControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/AltinnCdnControllerTest.cs
@@ -87,9 +87,6 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             Assert.Contains("An error occurred while retrieving organization data", content);
         }
 
-
-
-
         /// <summary>
         /// Test that verifies data is cached after first request and subsequent requests use cached data
         /// </summary>

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/AltinnCdnControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/AltinnCdnControllerTest.cs
@@ -66,26 +66,6 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         }
 
         /// <summary>
-        /// Test that when service returns empty data, the endpoint returns empty dictionary
-        /// </summary>
-        [Fact]
-        public async Task GetOrgData_ServiceReturnsEmptyData_ReturnsEmptyDictionary()
-        {
-            // Arrange
-            var emptyOrgData = new Dictionary<string, OrgData>();
-            var testClient = GetTestClient(emptyOrgData);
-
-            // Act
-            var response = await testClient.GetAsync("accessmanagement/api/v1/cdn/orgdata");
-
-            // Assert
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            var actualOrgData = await response.Content.ReadFromJsonAsync<Dictionary<string, OrgData>>();
-            Assert.NotNull(actualOrgData);
-            Assert.Empty(actualOrgData);
-        }
-
-        /// <summary>
         /// Test that when service throws an exception, controller returns 500 status code
         /// </summary>
         [Fact]
@@ -177,8 +157,6 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             mockCdnClient.Verify(c => c.GetOrgData(), Times.Once);
         }
 
-
-
         private HttpClient GetTestClientWithExceptionService(IAltinnCdnService mockService)
         {
             var httpClient = _factory.WithWebHostBuilder(builder =>
@@ -186,28 +164,6 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
                 builder.ConfigureTestServices(services =>
                 {
                     services.AddSingleton(mockService);
-                    services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
-                    services.AddSingleton<IPostConfigureOptions<JwtCookieOptions>, JwtCookiePostConfigureOptionsStub>();
-                });
-            }).CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
-
-            string token = PrincipalUtil.GetAccessToken("accessmanagement.api");
-            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-
-            return httpClient;
-        }
-        
-        private HttpClient GetTestClient(Dictionary<string, OrgData> orgDataToReturn)
-        {
-            var mockService = new Mock<IAltinnCdnService>();
-            mockService.Setup(s => s.GetOrgData()).ReturnsAsync(orgDataToReturn);
-
-            var httpClient = _factory.WithWebHostBuilder(builder =>
-            {
-                builder.ConfigureTestServices(services =>
-                {
-                    services.AddSingleton(mockService.Object);
                     services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
                     services.AddSingleton<IPostConfigureOptions<JwtCookieOptions>, JwtCookiePostConfigureOptionsStub>();
                 });

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/AltinnCdnControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/AltinnCdnControllerTest.cs
@@ -36,7 +36,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         public AltinnCdnControllerTest(CustomWebApplicationFactory<AltinnCdnController> factory)
         {
             _factory = factory;
-            _client = SetupUtils.GetTestClient(factory, null);
+            _client = SetupUtils.GetTestClient(factory);
 
             string token = PrincipalUtil.GetAccessToken("accessmanagement.api");
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/AltinnCdn/orgData.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/AltinnCdn/orgData.json
@@ -1,0 +1,41 @@
+{
+  "digdir": {
+    "name": {
+      "en": "Norwegian Digitalisation Agency",
+      "nb": "Digitaliseringsdirektoratet",
+      "nn": "Digitaliseringsdirektoratet"
+    },
+    "logo": "https://altinncdn.no/orgs/digdir/digdir.png",
+    "emblem": "https://altinncdn.no/orgs/digdir/digdir.svg",
+    "orgnr": "991825827",
+    "homepage": "https://www.digdir.no",
+    "environments": [
+      "tt02",
+      "production"
+    ],
+    "contact": {
+      "phone": "+4722451000",
+      "url": "https://www.digdir.no/digdir/kontakt-oss/943"
+    }
+  },
+  "skd": {
+    "name": {
+      "en": "Norwegian Tax Administration",
+      "nb": "Skatteetaten",
+      "nn": "Skatteetaten"
+    },
+    "logo": "https://altinncdn.no/orgs/skd/skd.png",
+    "emblem": "https://altinncdn.no/orgs/skd/skd.svg",
+    "orgnr": "974761076",
+    "homepage": "https://www.skatteetaten.no",
+    "environments": [
+      "tt02",
+      "yt01",
+      "production"
+    ],
+    "contact": {
+      "phone": "+4780080000",
+      "url": "https://www.skatteetaten.no/kontakt"
+    }
+  }
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/AltinnCdn/orgData.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/AltinnCdn/orgData.json
@@ -5,17 +5,16 @@
       "nb": "Digitaliseringsdirektoratet",
       "nn": "Digitaliseringsdirektoratet"
     },
-    "logo": "https://altinncdn.no/orgs/digdir/digdir.png",
-    "emblem": "https://altinncdn.no/orgs/digdir/digdir.svg",
+    "logo": "/orgs/digdir/digdir.png",
+    "emblem": "/orgs/digdir/digdir.svg",
     "orgnr": "991825827",
-    "homepage": "https://www.digdir.no",
+    "homepage": "",
     "environments": [
-      "tt02",
-      "production"
+      "tt02"
     ],
     "contact": {
-      "phone": "+4722451000",
-      "url": "https://www.digdir.no/digdir/kontakt-oss/943"
+      "phone": "+47123456",
+      "url": "/digdir/kontakt-oss/943"
     }
   },
   "skd": {
@@ -24,18 +23,16 @@
       "nb": "Skatteetaten",
       "nn": "Skatteetaten"
     },
-    "logo": "https://altinncdn.no/orgs/skd/skd.png",
-    "emblem": "https://altinncdn.no/orgs/skd/skd.svg",
+    "logo": "/orgs/skd/skd.png",
+    "emblem": "/orgs/skd/skd.svg",
     "orgnr": "974761076",
-    "homepage": "https://www.skatteetaten.no",
+    "homepage": "",
     "environments": [
-      "tt02",
-      "yt01",
-      "production"
+      "tt02"
     ],
     "contact": {
-      "phone": "+4780080000",
-      "url": "https://www.skatteetaten.no/kontakt"
+      "phone": "+47123456",
+      "url": "/kontakt"
     }
   }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Utils/AssertionUtil.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Utils/AssertionUtil.cs
@@ -661,5 +661,99 @@ namespace Altinn.AccessManagement.UI.Tests.Utils
             AssertCollections(actual.Roles, expected.Roles, AssertEqual);
             AssertCollections(expected.Connections, actual.Connections, AssertEqual);
         }
+
+        /// <summary>
+        ///     Assert that two <see cref="OrgData" /> have the same property values.
+        /// </summary>
+        /// <param name="expected">An instance with the expected values.</param>
+        /// <param name="actual">The instance to verify.</param>
+        public static void AssertEqual(OrgData expected, OrgData actual)
+        {
+            Assert.NotNull(actual);
+            Assert.NotNull(expected);
+
+            Assert.Equal(expected?.Orgnr, actual.Orgnr);
+            Assert.Equal(expected?.Logo, actual.Logo);
+            Assert.Equal(expected?.Emblem, actual.Emblem);
+            Assert.Equal(expected?.Homepage, actual.Homepage);
+
+            // Assert Name dictionary
+            if (expected?.Name == null)
+            {
+                Assert.Null(actual.Name);
+            }
+            else
+            {
+                Assert.NotNull(actual.Name);
+                Assert.Equal(expected.Name.Count, actual.Name.Count);
+                foreach (var kvp in expected.Name)
+                {
+                    Assert.True(actual.Name.ContainsKey(kvp.Key));
+                    Assert.Equal(kvp.Value, actual.Name[kvp.Key]);
+                }
+            }
+
+            // Assert Environments list
+            if (expected?.Environments == null)
+            {
+                Assert.Null(actual.Environments);
+            }
+            else
+            {
+                Assert.NotNull(actual.Environments);
+                Assert.Equal(expected.Environments.Count, actual.Environments.Count);
+                for (int i = 0; i < expected.Environments.Count; i++)
+                {
+                    Assert.Equal(expected.Environments[i], actual.Environments[i]);
+                }
+            }
+
+            // Assert Contact
+            if (expected?.Contact == null)
+            {
+                Assert.Null(actual.Contact);
+            }
+            else
+            {
+                AssertEqual(expected.Contact, actual.Contact);
+            }
+        }
+
+        /// <summary>
+        ///     Assert that two <see cref="OrgContact" /> have the same property values.
+        /// </summary>
+        /// <param name="expected">An instance with the expected values.</param>
+        /// <param name="actual">The instance to verify.</param>
+        public static void AssertEqual(OrgContact expected, OrgContact actual)
+        {
+            Assert.NotNull(actual);
+            Assert.NotNull(expected);
+
+            Assert.Equal(expected?.Phone, actual.Phone);
+            Assert.Equal(expected?.Url, actual.Url);
+        }
+
+        /// <summary>
+        ///     Assert that two dictionaries of <see cref="OrgData" /> have the same property values.
+        /// </summary>
+        /// <param name="expected">A dictionary with the expected values.</param>
+        /// <param name="actual">The dictionary to verify.</param>
+        public static void AssertEqual(Dictionary<string, OrgData> expected, Dictionary<string, OrgData> actual)
+        {
+            if (expected == null)
+            {
+                Assert.Null(actual);
+                return;
+            }
+
+            Assert.NotNull(actual);
+            Assert.Equal(expected.Count, actual.Count);
+
+            foreach (var kvp in expected)
+            {
+                Assert.True(actual.ContainsKey(kvp.Key), $"Expected key '{kvp.Key}' not found in actual dictionary");
+                AssertEqual(kvp.Value, actual[kvp.Key]);
+            }
+        }
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Utils/SetupUtils.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Utils/SetupUtils.cs
@@ -427,7 +427,7 @@ namespace Altinn.AccessManagement.UI.Tests.Utils
         /// <param name="customFactory">Web app factory to configure test services for AltinnCdnController tests</param>
         /// <param name="value">An object to be used in the setup, can be null</param>
         /// <returns>HttpClient</returns>
-        internal static HttpClient GetTestClient(CustomWebApplicationFactory<AltinnCdnController> customFactory, object value)
+        internal static HttpClient GetTestClient(CustomWebApplicationFactory<AltinnCdnController> customFactory)
         {
             WebApplicationFactory<AltinnCdnController> factory = customFactory.WithWebHostBuilder(builder =>
             {

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Utils/SetupUtils.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Utils/SetupUtils.cs
@@ -420,5 +420,30 @@ namespace Altinn.AccessManagement.UI.Tests.Utils
 
             return client;
         }
+
+        /// <summary>
+        /// Gets a HttpClient for unittests testing for AltinnCdnController
+        /// </summary>
+        /// <param name="customFactory">Web app factory to configure test services for AltinnCdnController tests</param>
+        /// <param name="value">An object to be used in the setup, can be null</param>
+        /// <returns>HttpClient</returns>
+        internal static HttpClient GetTestClient(CustomWebApplicationFactory<AltinnCdnController> customFactory, object value)
+        {
+            WebApplicationFactory<AltinnCdnController> factory = customFactory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.AddSingleton<IAltinnCdnClient, AltinnCdnClientMock>();
+                    services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+                    services.AddSingleton<IPostConfigureOptions<JwtCookieOptions>, JwtCookiePostConfigureOptionsStub>();
+                });
+            });
+            WebApplicationFactoryClientOptions opts = new WebApplicationFactoryClientOptions
+            {
+                AllowAutoRedirect = false,
+            };
+            factory.Server.AllowSynchronousIO = true;
+            return factory.CreateClient(opts);
+        }
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/AltinnCdnController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/AltinnCdnController.cs
@@ -1,0 +1,55 @@
+using Altinn.AccessManagement.UI.Core.Models.Common;
+using Altinn.AccessManagement.UI.Core.Services.Interfaces;
+using Altinn.AccessManagement.UI.Filters;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Altinn.AccessManagement.UI.Controllers
+{
+    /// <summary>
+    /// Controller responsible for operations related to Altinn CDN data
+    /// </summary>
+    [ApiController]
+    [AutoValidateAntiforgeryTokenIfAuthCookie]
+    [Route("accessmanagement/api/v1/cdn")]
+    public class AltinnCdnController : ControllerBase
+    {
+        private readonly ILogger<AltinnCdnController> _logger;
+        private readonly IAltinnCdnService _altinnCdnService;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AltinnCdnController"/> class.
+        /// </summary>
+        /// <param name="logger">The logger instance.</param>
+        /// <param name="altinnCdnService">Service implementation for Altinn CDN operations.</param>
+        public AltinnCdnController(
+            ILogger<AltinnCdnController> logger,
+            IAltinnCdnService altinnCdnService)
+        {
+            _logger = logger;
+            _altinnCdnService = altinnCdnService;
+        }
+
+        /// <summary>
+        /// Retrieves organization data from the Altinn CDN.
+        /// </summary>
+        /// <returns>A dictionary containing organization data, where the key is the organization code and the value is the organization data object.</returns>
+        [HttpGet]
+        [Authorize]
+        [Route("orgdata")]
+        public async Task<ActionResult<Dictionary<string, OrgData>>> GetOrgData()
+        {
+            try
+            {
+                var orgData = await _altinnCdnService.GetOrgData();
+                
+                return Ok(orgData);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error occurred while retrieving organization data");
+                return StatusCode(500, "An error occurred while retrieving organization data");
+            }
+        }
+    }
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Program.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Program.cs
@@ -231,6 +231,7 @@ void ConfigureServices(IServiceCollection services, IConfiguration config)
     services.AddSingleton<IRoleService, RoleService>();
     services.AddTransient<ISigningCredentialsResolver, SigningCredentialsResolver>();
     services.AddTransient<ResourceHelper, ResourceHelper>();
+    services.AddTransient<IAltinnCdnService, AltinnCdnService>();
 
     PlatformSettings platformSettings = config.GetSection("PlatformSettings").Get<PlatformSettings>();
     services.AddAuthentication(JwtCookieDefaults.AuthenticationScheme)
@@ -389,6 +390,15 @@ void ConfigureMockableClients(IServiceCollection services, IConfiguration config
     else
     {
         services.AddSingleton<ISystemRegisterClient, SystemRegisterClient>();
+    }
+
+    if (mockSettings.AltinnCdn)
+    {
+        services.AddSingleton<IAltinnCdnClient, AltinnCdnClientMock>();
+    }
+    else
+    {
+        services.AddSingleton<IAltinnCdnClient, AltinnCdnClient>();
     }
 
     if (mockSettings.SystemUser)

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.AT22.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.AT22.json
@@ -23,7 +23,8 @@
     "SystemRegister": false,
     "SystemUser": false,
     "SystemUserAgentDelegation": false,
-    "Consent": false
+    "Consent": false,
+    "AltinnCdn": false
   },
   "KeyVaultSettings": {
     "SecretUri": "https://altinn-at22-am-kv.vault.azure.net/"

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.Development.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.Development.json
@@ -25,7 +25,8 @@
     "SystemRegister": false,
     "SystemUser": false,
     "SystemUserAgentDelegation": false,
-    "Consent": false
+    "Consent": false,
+    "AltinnCdn": false
   },
   "KeyVaultSettings": {
     "SecretUri": "https://altinn-dev-amui-kv.vault.azure.net/"

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.Test.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.Test.json
@@ -15,6 +15,7 @@
     "SystemRegister": true,
     "SystemUser": true,
     "SystemUserAgentDelegation": true,
-    "Consent": true
+    "Consent": true,
+    "AltinnCdn": true
   }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.json
@@ -33,7 +33,8 @@
     "SystemRegister": false,
     "SystemUser": false,
     "SystemUserAgentDelegation": false,
-    "Consent": false
+    "Consent": false,
+    "AltinnCdn": false
   },
   "KeyVaultSettings": {
     "SecretUri": ""

--- a/src/features/amUI/common/DelegationModal/AccessPackages/AccessPackageInfo.tsx
+++ b/src/features/amUI/common/DelegationModal/AccessPackages/AccessPackageInfo.tsx
@@ -1,16 +1,14 @@
 import * as React from 'react';
-import type { ListItemProps } from '@altinn/altinn-components';
 import { List, Button, Icon, DsAlert, DsHeading, DsParagraph } from '@altinn/altinn-components';
 import { useTranslation } from 'react-i18next';
-import { MenuElipsisHorizontalIcon, PackageIcon } from '@navikt/aksel-icons';
+import { PackageIcon } from '@navikt/aksel-icons';
 import { useState } from 'react';
 
 import { useAccessPackageDelegationCheck } from '@/resources/hooks/useAccessPackageDelegationCheck';
 import type { ActionError } from '@/resources/hooks/useActionError';
 import { useAccessPackageActions } from '@/features/amUI/common/AccessPackageList/useAccessPackageActions';
-import { useGetUserDelegationsQuery, type PackageResource } from '@/rtk/features/accessPackageApi';
+import { useGetUserDelegationsQuery } from '@/rtk/features/accessPackageApi';
 import { TechnicalErrorParagraphs } from '@/features/amUI/common/TechnicalErrorParagraphs';
-import { useGetOrgDataQuery } from '@/rtk/features/altinnCdnApi';
 
 import { useDelegationModalContext } from '../DelegationModalContext';
 import { DelegationAction } from '../EditModal';
@@ -26,6 +24,7 @@ import {
 import { ValidationErrorMessage } from '../../ValidationErrorMessage';
 import { PackageIsPartiallyDeletableAlert } from '../../AccessPackageList/PackageIsPartiallyDeletableAlert/PackageIsPartiallyDeletableAlert';
 
+import { useMinimizableResourceList } from './useMinimizableResourceList';
 import classes from './AccessPackageInfo.module.css';
 
 export interface PackageInfoProps {
@@ -265,51 +264,4 @@ export const AccessPackageInfo = ({ accessPackage, availableActions = [] }: Pack
       )}
     </div>
   );
-};
-
-const MINIMIZED_LIST_SIZE = 5;
-
-const useMinimizableResourceList = (list: PackageResource[]) => {
-  const { t } = useTranslation();
-  const [showAll, setShowAll] = React.useState(false);
-  const { data: orgData, isLoading: orgDataIsLoading } = useGetOrgDataQuery();
-
-  const getProviderLogoUrl = (orgCode: string | null): string | undefined => {
-    if (!orgData || orgDataIsLoading) {
-      return undefined;
-    }
-    const org = orgData[orgCode ?? ''];
-    return org?.emblem ?? org?.logo ?? undefined;
-  };
-
-  const mapResourceToListItem = (resource: PackageResource): ListItemProps => {
-    const logo = getProviderLogoUrl(resource.provider?.code ?? '');
-    return {
-      loading: orgDataIsLoading,
-      title: resource.name,
-      description: resource.provider.name,
-      icon: { iconUrl: logo ?? resource.provider.logoUrl },
-      as: 'div' as React.ElementType,
-      size: 'xs',
-      interactive: false,
-    };
-  };
-
-  if (list.length <= MINIMIZED_LIST_SIZE) {
-    return {
-      listItems: list.map(mapResourceToListItem),
-    };
-  }
-  const showMoreListItem: ListItemProps = {
-    title: t('common.show_more'),
-    description: '',
-    onClick: () => setShowAll(!showAll),
-    icon: MenuElipsisHorizontalIcon,
-    as: 'button' as React.ElementType,
-    size: 'xs',
-  };
-  const minimizedList = list
-    .slice(0, showAll ? list.length : MINIMIZED_LIST_SIZE)
-    .map(mapResourceToListItem);
-  return { listItems: showAll ? minimizedList : [...minimizedList, showMoreListItem] };
 };

--- a/src/features/amUI/common/DelegationModal/AccessPackages/useMinimizableResourceList.ts
+++ b/src/features/amUI/common/DelegationModal/AccessPackages/useMinimizableResourceList.ts
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import type { ListItemProps } from '@altinn/altinn-components';
+import { useTranslation } from 'react-i18next';
+import { MenuElipsisHorizontalIcon } from '@navikt/aksel-icons';
+
+import type { PackageResource } from '@/rtk/features/accessPackageApi';
+import { useGetOrgDataQuery } from '@/rtk/features/altinnCdnApi';
+
+const MINIMIZED_LIST_SIZE = 5;
+
+export const useMinimizableResourceList = (list: PackageResource[]) => {
+  const { t } = useTranslation();
+  const [showAll, setShowAll] = React.useState(false);
+  const { data: orgData, isLoading: orgDataIsLoading } = useGetOrgDataQuery();
+
+  const getProviderLogoUrl = (orgCode: string | null): string | undefined => {
+    if (!orgData || orgDataIsLoading) {
+      return undefined;
+    }
+    const org = orgData[orgCode ?? ''];
+    return org?.emblem ?? org?.logo ?? undefined;
+  };
+
+  const mapResourceToListItem = (resource: PackageResource): ListItemProps => {
+    const emblem = getProviderLogoUrl(resource.provider?.code ?? '');
+    return {
+      loading: orgDataIsLoading,
+      title: resource.name,
+      description: resource.provider.name,
+      icon: { iconUrl: emblem ?? resource.provider.logoUrl },
+      as: 'div' as React.ElementType,
+      size: 'xs',
+      interactive: false,
+    };
+  };
+
+  if (list.length <= MINIMIZED_LIST_SIZE) {
+    return {
+      listItems: list.map(mapResourceToListItem),
+    };
+  }
+  const showMoreListItem: ListItemProps = {
+    title: t('common.show_more'),
+    description: '',
+    onClick: () => setShowAll(!showAll),
+    icon: MenuElipsisHorizontalIcon,
+    as: 'button' as React.ElementType,
+    size: 'xs',
+  };
+  const minimizedList = list
+    .slice(0, showAll ? list.length : MINIMIZED_LIST_SIZE)
+    .map(mapResourceToListItem);
+  return { listItems: showAll ? minimizedList : [...minimizedList, showMoreListItem] };
+};

--- a/src/features/amUI/common/DelegationModal/AccessPackages/useMinimizableResourceList.ts
+++ b/src/features/amUI/common/DelegationModal/AccessPackages/useMinimizableResourceList.ts
@@ -17,7 +17,7 @@ export const useMinimizableResourceList = (list: PackageResource[]) => {
     if (!orgData || orgDataIsLoading) {
       return undefined;
     }
-    const org = orgData[orgCode ?? ''];
+    const org = orgCode ? orgData[orgCode] : undefined;
     return org?.emblem ?? org?.logo ?? undefined;
   };
 

--- a/src/features/amUI/systemUser/components/RightsList/AccessPackageInfo.tsx
+++ b/src/features/amUI/systemUser/components/RightsList/AccessPackageInfo.tsx
@@ -4,6 +4,7 @@ import { PackageIcon } from '@navikt/aksel-icons';
 import { useTranslation } from 'react-i18next';
 
 import type { ServiceResource } from '@/rtk/features/singleRights/singleRightsApi';
+import { useGetOrgDataQuery } from '@/rtk/features/altinnCdnApi';
 
 import type { SystemUserAccessPackage } from '../../types';
 
@@ -18,6 +19,16 @@ export const AccessPackageInfo = ({
   onSelectResource,
 }: AccessPackageInfoProps): React.ReactElement => {
   const { t } = useTranslation();
+
+  const { data: orgData, isLoading } = useGetOrgDataQuery();
+
+  const getProviderLogoUrl = (orgCode: string | null): string | undefined => {
+    if (!orgData || isLoading) {
+      return undefined;
+    }
+    const org = orgData[orgCode ?? ''];
+    return org?.emblem ?? org?.logo ?? undefined;
+  };
 
   return (
     <div className={classes.accessPackages}>
@@ -48,7 +59,8 @@ export const AccessPackageInfo = ({
             id: resource.identifier,
             as: 'button',
             titleAs: 'h3',
-            ownerLogoUrl: resource.resourceOwnerLogoUrl,
+            ownerLogoUrl:
+              getProviderLogoUrl(resource.provider?.code ?? '') ?? resource.resourceOwnerLogoUrl,
             ownerLogoUrlAlt: resource.resourceOwnerName ?? '',
             ownerName: resource.resourceOwnerName ?? '',
             resourceName: resource.title,

--- a/src/features/amUI/systemUser/components/RightsList/AccessPackageInfo.tsx
+++ b/src/features/amUI/systemUser/components/RightsList/AccessPackageInfo.tsx
@@ -4,7 +4,6 @@ import { PackageIcon } from '@navikt/aksel-icons';
 import { useTranslation } from 'react-i18next';
 
 import type { ServiceResource } from '@/rtk/features/singleRights/singleRightsApi';
-import { useGetOrgDataQuery } from '@/rtk/features/altinnCdnApi';
 
 import type { SystemUserAccessPackage } from '../../types';
 
@@ -19,16 +18,6 @@ export const AccessPackageInfo = ({
   onSelectResource,
 }: AccessPackageInfoProps): React.ReactElement => {
   const { t } = useTranslation();
-
-  const { data: orgData, isLoading } = useGetOrgDataQuery();
-
-  const getProviderLogoUrl = (orgCode: string | null): string | undefined => {
-    if (!orgData || isLoading) {
-      return undefined;
-    }
-    const org = orgData[orgCode ?? ''];
-    return org?.emblem ?? org?.logo ?? undefined;
-  };
 
   return (
     <div className={classes.accessPackages}>
@@ -59,8 +48,7 @@ export const AccessPackageInfo = ({
             id: resource.identifier,
             as: 'button',
             titleAs: 'h3',
-            ownerLogoUrl:
-              getProviderLogoUrl(resource.provider?.code ?? '') ?? resource.resourceOwnerLogoUrl,
+            ownerLogoUrl: resource.resourceOwnerLogoUrl,
             ownerLogoUrlAlt: resource.resourceOwnerName ?? '',
             ownerName: resource.resourceOwnerName ?? '',
             resourceName: resource.title,

--- a/src/rtk/app/store.ts
+++ b/src/rtk/app/store.ts
@@ -14,6 +14,7 @@ import { userInfoApi } from '../features/userInfoApi';
 import { roleApi } from '../features/roleApi';
 import { systemUserApi } from '../features/systemUserApi';
 import { consentApi } from '../features/consentApi';
+import { altinnCdnApi } from '../features/altinnCdnApi';
 
 const store = configureStore({
   reducer: {
@@ -30,6 +31,7 @@ const store = configureStore({
     [roleApi.reducerPath]: roleApi.reducer,
     [systemUserApi.reducerPath]: systemUserApi.reducer,
     [consentApi.reducerPath]: consentApi.reducer,
+    [altinnCdnApi.reducerPath]: altinnCdnApi.reducer,
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware().concat(
@@ -43,6 +45,7 @@ const store = configureStore({
       roleApi.middleware,
       systemUserApi.middleware,
       consentApi.middleware,
+      altinnCdnApi.middleware,
     ),
 });
 

--- a/src/rtk/features/accessPackageApi.ts
+++ b/src/rtk/features/accessPackageApi.ts
@@ -21,7 +21,10 @@ export interface PackageResource {
 export interface ResourceProvider {
   id: string;
   name: string;
+  refId: string;
   logoUrl: string;
+  code: string;
+  typeId: string;
 }
 
 export interface AccessPackage {

--- a/src/rtk/features/altinnCdnApi.ts
+++ b/src/rtk/features/altinnCdnApi.ts
@@ -3,7 +3,6 @@ import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 import { getCookie } from '@/resources/Cookie/CookieMethods';
 
 export interface OrgData {
-  orgs: OrgData | Promise<OrgData>;
   name: Record<string, string> | null;
   logo: string | null;
   emblem: string | null;

--- a/src/rtk/features/altinnCdnApi.ts
+++ b/src/rtk/features/altinnCdnApi.ts
@@ -1,0 +1,43 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+
+import { getCookie } from '@/resources/Cookie/CookieMethods';
+
+export interface OrgData {
+  orgs: OrgData | Promise<OrgData>;
+  name: Record<string, string> | null;
+  logo: string | null;
+  emblem: string | null;
+  orgnr: string | null;
+  homepage: string | null;
+  environments: string[] | null;
+  contact: OrgContact | null;
+}
+
+export interface OrgContact {
+  phone: string | null;
+  url: string | null;
+}
+
+const baseUrl = `${import.meta.env.BASE_URL}accessmanagement/api/v1/cdn`;
+
+export const altinnCdnApi = createApi({
+  reducerPath: 'altinnCdnApi',
+  baseQuery: fetchBaseQuery({
+    baseUrl,
+    prepareHeaders: (headers: Headers): Headers => {
+      headers.set('content-type', 'application/json; charset=utf-8');
+      headers.set('X-XSRF-TOKEN', getCookie('XSRF-TOKEN'));
+      return headers;
+    },
+  }),
+  endpoints: (builder) => ({
+    getOrgData: builder.query<Record<string, OrgData>, void>({
+      query: () => `orgdata`,
+      keepUnusedDataFor: 300,
+    }),
+  }),
+});
+
+export const { useGetOrgDataQuery } = altinnCdnApi;
+
+export const { endpoints, reducerPath, reducer, middleware } = altinnCdnApi;

--- a/src/rtk/features/singleRights/singleRightsApi.ts
+++ b/src/rtk/features/singleRights/singleRightsApi.ts
@@ -23,17 +23,8 @@ export interface ServiceResource {
   authorizationReference: IdValuePair[];
   resourceType: string;
   delegable: boolean;
-  provider?: Provider;
 }
 
-export interface Provider {
-  id: string;
-  name: string;
-  refId: string;
-  logoUrl: string;
-  code: string;
-  typeId: string;
-}
 export interface ResourceDelegation {
   resource: ServiceResource;
   delegation: DelegationResult;

--- a/src/rtk/features/singleRights/singleRightsApi.ts
+++ b/src/rtk/features/singleRights/singleRightsApi.ts
@@ -23,8 +23,17 @@ export interface ServiceResource {
   authorizationReference: IdValuePair[];
   resourceType: string;
   delegable: boolean;
+  provider?: Provider;
 }
 
+export interface Provider {
+  id: string;
+  name: string;
+  refId: string;
+  logoUrl: string;
+  code: string;
+  typeId: string;
+}
 export interface ResourceDelegation {
   resource: ServiceResource;
   delegation: DelegationResult;


### PR DESCRIPTION
This pull request introduces service provider emblems (and logos as a fallback) in the package modal. 
To handle CORS, I have added a proxy to the bff to fetch and serve data from Altinn CDN. 
This solution introduces a dual-layer caching strategy, with a 1-hour server-side cache and a 5-minute client-side cache. The UI is updated to show organization emblems with a fallback to logos, enhancing the visual experience. 
(Why use a simple CDN when you can build a distributed, event-driven, blockchain-powered logo delivery platform with AI-enhanced caching strategies?)

## Related Issue(s)
- 906

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving and displaying organization data (names, logos, contact info, environments) from the Altinn CDN in the Access Management UI.
  * Introduced a new API endpoint to fetch organization data with proper authorization and error handling.
  * Integrated organization data into resource provider displays with conditional logo selection.
  * Added a minimizable resource list UI component to handle long lists of package resources with organization logos.

* **Configuration**
  * Added a new configuration flag to enable or disable the Altinn CDN mock client.

* **Bug Fixes**
  * None.

* **Tests**
  * Added comprehensive tests for the organization data API endpoint, covering caching and error scenarios.
  * Introduced test utilities and test data for validating organization data functionality.

* **Chores**
  * Updated Redux store and RTK Query integration to support organization data API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->