### PR TITLE
Add Power of Attorney overview page and update sidebar items

### DIFF
--- a/src/features/amUI/common/PageLayoutWrapper/SidebarItems.tsx
+++ b/src/features/amUI/common/PageLayoutWrapper/SidebarItems.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { MenuItemProps, MenuItemSize } from '@altinn/altinn-components';
-import { InboxIcon, PersonGroupIcon, TenancyIcon } from '@navikt/aksel-icons';
+import { InboxIcon, PersonGroupIcon, TenancyIcon, PadlockUnlockedIcon } from '@navikt/aksel-icons';
 import { t } from 'i18next';
 import { Link } from 'react-router';
 
@@ -19,7 +19,8 @@ export const SidebarItems = (
   accountName: string,
   accountType: 'company' | 'person',
 ) => {
-  const displayConfettiPackage = window.featureFlags?.displayConfettiPackage;
+  const { displayConfettiPackage, displayLimitedPreviewLaunch } = window.featureFlags;
+
   const heading: MenuItemProps = {
     id: '1',
     groupId: 1,
@@ -31,46 +32,64 @@ export const SidebarItems = (
     title: t('sidebar.access_management'),
   };
 
-  const confettiPackage: MenuItemProps[] = [
-    {
-      groupId: 2,
-      id: '2',
-      size: 'md' as MenuItemSize,
-      title: t('sidebar.users'),
-      selected: pathname?.includes(`/${amUIPath.Users}`),
-      icon: PersonGroupIcon,
-      as: (props) => (
-        <Link
-          to={`/${amUIPath.Users}`}
-          {...props}
-        />
-      ),
-    },
-    {
-      groupId: 3,
-      id: '3',
-      size: 'md' as MenuItemSize,
-      title: t('sidebar.reportees'),
-      selected: pathname?.includes(`/${amUIPath.Reportees}`),
-      icon: InboxIcon,
-      as: (props) => (
-        <Link
-          to={`/${amUIPath.Reportees}`}
-          {...props}
-        />
-      ),
-    },
-  ].slice(0, isAdmin ? 2 : 1);
+  const users: MenuItemProps = {
+    groupId: 2,
+    id: '2',
+    size: 'md' as MenuItemSize,
+    title: t('sidebar.users'),
+    selected: pathname?.includes(`/${amUIPath.Users}`),
+    icon: PersonGroupIcon,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    as: (props: any) => (
+      <Link
+        to={`/${amUIPath.Users}`}
+        {...props}
+      />
+    ),
+  };
+
+  const poaOverview: MenuItemProps = {
+    groupId: 2,
+    id: '2.1',
+    size: 'md',
+    title: t('sidebar.poa_overview'),
+    icon: PadlockUnlockedIcon,
+    selected: pathname?.includes(`/${amUIPath.PoaOverview}`),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    as: (props: any) => (
+      <Link
+        to={`/${amUIPath.PoaOverview}`}
+        {...props}
+      />
+    ),
+  };
+
+  const reportees: MenuItemProps = {
+    groupId: 4,
+    id: '4',
+    size: 'md' as MenuItemSize,
+    title: t('sidebar.reportees'),
+    selected: pathname?.includes(`/${amUIPath.Reportees}`),
+    icon: InboxIcon,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    as: (props: any) => (
+      <Link
+        to={`/${amUIPath.Reportees}`}
+        {...props}
+      />
+    ),
+  };
 
   const systemUserPath = `/${SystemUserPath.SystemUser}/${SystemUserPath.Overview}`;
   const systemUser: MenuItemProps = {
-    groupId: 4,
-    id: '4',
+    groupId: 5,
+    id: '5',
     size: 'md',
     title: t('sidebar.systemaccess'),
     icon: TenancyIcon,
     selected: pathname?.includes(systemUserPath),
-    as: (props) => (
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    as: (props: any) => (
       <Link
         to={systemUserPath}
         {...props}
@@ -78,14 +97,30 @@ export const SidebarItems = (
     ),
   };
 
+  const items: MenuItemProps[] = [];
+
+  if (!isSmall && displayConfettiPackage) {
+    items.push(heading);
+  }
+
   if (displayConfettiPackage) {
-    if (isSmall) {
-      return [...confettiPackage, systemUser];
+    items.push(users);
+    if (isAdmin) {
+      items.push(reportees);
     }
-    return [heading, ...confettiPackage, systemUser];
   }
-  if (isSmall) {
-    return [systemUser];
+
+  if (displayLimitedPreviewLaunch) {
+    if (isAdmin) {
+      items.push(poaOverview);
+    }
   }
-  return [heading, systemUser];
+
+  items.push(systemUser);
+
+  if (!displayConfettiPackage && !isSmall) {
+    items.unshift(heading);
+  }
+
+  return items;
 };

--- a/src/features/amUI/common/PageLayoutWrapper/SidebarItems.tsx
+++ b/src/features/amUI/common/PageLayoutWrapper/SidebarItems.tsx
@@ -111,7 +111,7 @@ export const SidebarItems = (
     }
   }
 
-  if (displayLimitedPreviewLaunch) {
+  if (!displayLimitedPreviewLaunch) {
     if (isAdmin) {
       items.push(poaOverview);
     }

--- a/src/features/amUI/common/PageLayoutWrapper/SidebarItems.tsx
+++ b/src/features/amUI/common/PageLayoutWrapper/SidebarItems.tsx
@@ -19,7 +19,8 @@ export const SidebarItems = (
   accountName: string,
   accountType: 'company' | 'person',
 ) => {
-  const { displayConfettiPackage, displayLimitedPreviewLaunch } = window.featureFlags;
+  const displayConfettiPackage = window.featureFlags.displayConfettiPackage;
+  const displayLimitedPreviewLaunch = window.featureFlags.displayLimitedPreviewLaunch;
 
   const heading: MenuItemProps = {
     id: '1',

--- a/src/features/amUI/common/PageLayoutWrapper/SidebarItems.tsx
+++ b/src/features/amUI/common/PageLayoutWrapper/SidebarItems.tsx
@@ -100,7 +100,7 @@ export const SidebarItems = (
 
   const items: MenuItemProps[] = [];
 
-  if (!isSmall && displayConfettiPackage) {
+  if (!isSmall) {
     items.push(heading);
   }
 
@@ -118,10 +118,6 @@ export const SidebarItems = (
   }
 
   items.push(systemUser);
-
-  if (!displayConfettiPackage && !isSmall) {
-    items.unshift(heading);
-  }
 
   return items;
 };

--- a/src/features/amUI/common/PageLayoutWrapper/SidebarItems.tsx
+++ b/src/features/amUI/common/PageLayoutWrapper/SidebarItems.tsx
@@ -19,8 +19,8 @@ export const SidebarItems = (
   accountName: string,
   accountType: 'company' | 'person',
 ) => {
-  const displayConfettiPackage = window.featureFlags.displayConfettiPackage;
-  const displayLimitedPreviewLaunch = window.featureFlags.displayLimitedPreviewLaunch;
+  const displayConfettiPackage = window.featureFlags?.displayConfettiPackage;
+  const displayLimitedPreviewLaunch = window.featureFlags?.displayLimitedPreviewLaunch;
 
   const heading: MenuItemProps = {
     id: '1',

--- a/src/features/amUI/poaOverview/PoaOverviewPage.tsx
+++ b/src/features/amUI/poaOverview/PoaOverviewPage.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { DsHeading } from '@altinn/altinn-components';
+import { useTranslation } from 'react-i18next';
+
+import { useDocumentTitle } from '@/resources/hooks/useDocumentTitle';
+import { PageWrapper } from '@/components';
+import { useGetReporteeQuery } from '@/rtk/features/userInfoApi';
+import { getCookie } from '@/resources/Cookie/CookieMethods';
+
+import { PageLayoutWrapper } from '../common/PageLayoutWrapper';
+import { PartyRepresentationProvider } from '../common/PartyRepresentationContext/PartyRepresentationContext';
+
+export const PoaOverviewPage = () => {
+  const { t } = useTranslation();
+  const { data: reportee } = useGetReporteeQuery();
+
+  useDocumentTitle(t('poa_overview_page.page_title'));
+
+  return (
+    <PageWrapper>
+      <PartyRepresentationProvider
+        fromPartyUuid={getCookie('AltinnPartyUuid')}
+        actingPartyUuid={getCookie('AltinnPartyUuid')}
+      >
+        <PageLayoutWrapper>
+          <DsHeading
+            level={1}
+            data-size='lg'
+          >
+            {t('poa_overview_page.heading', { fromparty: reportee?.name || '' })}
+          </DsHeading>
+        </PageLayoutWrapper>
+      </PartyRepresentationProvider>
+    </PageWrapper>
+  );
+};

--- a/src/features/amUI/poaOverview/PoaOverviewPage.tsx
+++ b/src/features/amUI/poaOverview/PoaOverviewPage.tsx
@@ -6,6 +6,7 @@ import { useDocumentTitle } from '@/resources/hooks/useDocumentTitle';
 import { PageWrapper } from '@/components';
 import { useGetReporteeQuery } from '@/rtk/features/userInfoApi';
 import { getCookie } from '@/resources/Cookie/CookieMethods';
+import { rerouteIfNotLimitedPreview } from '@/resources/utils/featureFlagUtils';
 
 import { PageLayoutWrapper } from '../common/PageLayoutWrapper';
 import { PartyRepresentationProvider } from '../common/PartyRepresentationContext/PartyRepresentationContext';
@@ -13,8 +14,9 @@ import { PartyRepresentationProvider } from '../common/PartyRepresentationContex
 export const PoaOverviewPage = () => {
   const { t } = useTranslation();
   const { data: reportee } = useGetReporteeQuery();
-
   useDocumentTitle(t('poa_overview_page.page_title'));
+
+  rerouteIfNotLimitedPreview();
 
   return (
     <PageWrapper>

--- a/src/features/amUI/poaOverview/index.ts
+++ b/src/features/amUI/poaOverview/index.ts
@@ -1,0 +1,1 @@
+export { PoaOverviewPage } from './PoaOverviewPage';

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -104,7 +104,8 @@
     "access_management": "Access management",
     "users": "Users",
     "reportees": "Our access to other companies",
-    "systemaccess": "API- and system access"
+    "systemaccess": "API- and system access",
+    "poa_overview": "Power of attorney"
   },
   "error_page": {
     "not_found_site_type": "Error 404",
@@ -653,5 +654,9 @@
     "consent_is_revoked": "Consent/power of attorney is revoked",
     "consent_is_expired": "Consent/power of attorney has expired",
     "consent_is_not_accepted": "Consent/power of attorney is not approved"
+  },
+  "poa_overview_page": {
+    "page_title": "Power of attorney overview",
+    "heading": "Power of attorney overview for {{fromparty}}"
   }
 }

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -117,7 +117,8 @@
     "access_management": "Tilgangsstyring",
     "users": "Brukere",
     "reportees": "Våre tilganger hos andre",
-    "systemaccess": "API- og systemtilganger"
+    "systemaccess": "API- og systemtilganger",
+    "poa_overview": "Fullmakter"
   },
   "profile": {
     "received": "Mottatte",
@@ -651,5 +652,9 @@
     "consent_is_revoked": "Samtykket/fullmakten er trukket",
     "consent_is_expired": "Samtykket/fullmakten har utløpt",
     "consent_is_not_accepted": "Samtykket/fullmakten er ikke godkjent"
+  },
+  "poa_overview_page": {
+    "page_title": "Fullmaktsoversikt",
+    "heading": "Fullmaktsoversikt for {{fromparty}}"
   }
 }

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -101,7 +101,8 @@
     "access_management": "Tilgangsstyring",
     "users": "Brukere",
     "reportees": "Våre tilganger hos andre",
-    "systemaccess": "API- og systemtilganger"
+    "systemaccess": "API- og systemtilganger",
+    "poa_overview": "Fullmakter"
   },
   "error_page": {
     "not_found_site_error_type": "Feil 404",
@@ -648,5 +649,9 @@
     "consent_is_revoked": "Samtykket/fullmakten er trukket",
     "consent_is_expired": "Samtykket/fullmakten har utløpt",
     "consent_is_not_accepted": "Samtykket/fullmakten er ikkje godkjent"
+  },
+  "poa_overview_page": {
+    "page_title": "Fullmaktsoversikt",
+    "heading": "Fullmaktsoversikt for {{fromparty}}"
   }
 }

--- a/src/resources/utils/featureFlagUtils.tsx
+++ b/src/resources/utils/featureFlagUtils.tsx
@@ -7,6 +7,13 @@ export const rerouteIfNotConfetti = () => {
   }
 };
 
+export const rerouteIfNotLimitedPreview = () => {
+  const navigate = useNavigate();
+  if (window.featureFlags.displayLimitedPreviewLaunch === false) {
+    navigate('/not-found');
+  }
+};
+
 export const availableForUserTypeCheck = (userType?: string) => {
   if ((userType && userType === 'Organization') || window.featureFlags?.restrictPrivUse === false) {
     return true;

--- a/src/routes/Router/Router.tsx
+++ b/src/routes/Router/Router.tsx
@@ -23,6 +23,7 @@ import { ReporteeRightsPage } from '@/features/amUI/reporteeRightsPage/ReporteeR
 import { SystemUserAgentRequestPage } from '@/features/amUI/systemUser/SystemUserAgentRequestPage';
 import { SystemUserAgentDelegationPage } from '@/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPage';
 import { ConsentRequestPage } from '@/features/amUI/consent/ConsentRequestPage/ConsentRequestPage';
+import { PoaOverviewPage } from '@/features/amUI/poaOverview/PoaOverviewPage';
 
 import {
   GeneralPath,
@@ -110,6 +111,10 @@ export const Router = createBrowserRouter(
       <Route
         path={amUIPath.ReporteeRights}
         element={<ReporteeRightsPage />}
+      />
+      <Route
+        path={amUIPath.PoaOverview}
+        element={<PoaOverviewPage />}
       />
       <Route
         path={SystemUserPath.SystemUser}

--- a/src/routes/paths/amUIPath.tsx
+++ b/src/routes/paths/amUIPath.tsx
@@ -3,4 +3,5 @@ export enum amUIPath {
   UserRights = 'users/:id',
   Reportees = 'received-from',
   ReporteeRights = 'received-from/:id',
+  PoaOverview = 'poa-overview',
 }


### PR DESCRIPTION
# Add PoA Overview Page
This PR introduces a new Power of Attorney overview page and adds it to the sidebar navigation.

## Changes:
- New PoA Overview Page component: Created a basic overview page for Power of Attorney functionality.
- Updated sidebar navigation: Added PoA Overview menu item, visible only for administrator users and controlled by a feature flag (e.g., display-limited-preview-launch).
- Refactored SidebarItems: Simplified logic and improved conditional rendering of menu items.

## Related Issue(s)
- [809](https://github.com/Altinn/altinn-authorization-tmp/issues/809)

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a "Power of Attorney Overview" page accessible from the sidebar for eligible users.
  * Added a new sidebar menu item for the Power of Attorney overview, with support for feature flag-based visibility.
  * Enabled navigation to the new overview page via a dedicated route.

* **Localization**
  * Added translations for the Power of Attorney overview feature in English, Norwegian Bokmål, and Norwegian Nynorsk.

* **Style**
  * Updated sidebar icons and menu item ordering to accommodate the new feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->