### PR TITLE
Fixed wrong focus on links and disclaimer on person user page

### DIFF
--- a/src/features/amUI/common/List/List.module.css
+++ b/src/features/amUI/common/List/List.module.css
@@ -13,10 +13,6 @@
   --backgroundColor: var(--ds-color-neutral-contrast-1);
 }
 
-a {
-  color: inherit;
-}
-
 .listItem {
   background-color: var(--backgroundColor);
   border-bottom: 1px solid #e1e4e8;

--- a/src/features/amUI/common/PageLayoutWrapper/PageLayoutWrapper.tsx
+++ b/src/features/amUI/common/PageLayoutWrapper/PageLayoutWrapper.tsx
@@ -186,6 +186,9 @@ export const PageLayoutWrapper = ({ children }: PageLayoutWrapperProps): React.R
             menuLabel: t('header.menu-label'),
             backLabel: t('header.back-label'),
             changeLabel: t('header.change-label'),
+            currentEndUserLabel: t('header.logged_in_as_name', {
+              name: userinfo?.name || '',
+            }),
             accountMenu: {
               items: accounts,
               groups: accountGroups,

--- a/src/features/amUI/userRightsPage/AccessPackageSection/AccessPackageSection.tsx
+++ b/src/features/amUI/userRightsPage/AccessPackageSection/AccessPackageSection.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
-import { DsHeading } from '@altinn/altinn-components';
+import { DsAlert, DsHeading } from '@altinn/altinn-components';
 
 import { useGetUserDelegationsQuery } from '@/rtk/features/accessPackageApi';
 import { PartyType } from '@/rtk/features/userInfoApi';
@@ -41,6 +41,7 @@ export const AccessPackageSection = () => {
   return (
     <>
       <AccessPackageInfoAlert />
+      <DsAlert data-color='warning'>{t('access_packages.person_info_alert')}</DsAlert>
       {loadingPartyRepresentation || loadingAccesses ? (
         <TabContentSkeleton />
       ) : (

--- a/src/features/amUI/userRightsPage/AccessPackageSection/AccessPackageSection.tsx
+++ b/src/features/amUI/userRightsPage/AccessPackageSection/AccessPackageSection.tsx
@@ -41,7 +41,9 @@ export const AccessPackageSection = () => {
   return (
     <>
       <AccessPackageInfoAlert />
-      <DsAlert data-color='warning'>{t('access_packages.person_info_alert')}</DsAlert>
+      {toParty?.partyTypeName === PartyType.Person && (
+        <DsAlert data-color='warning'>{t('access_packages.person_info_alert')}</DsAlert>
+      )}
       {loadingPartyRepresentation || loadingAccesses ? (
         <TabContentSkeleton />
       ) : (

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -97,7 +97,8 @@
     "all_services": "All services",
     "chat": "Get help on chat",
     "log_out": "Log out",
-    "locale_title": "Choose language"
+    "locale_title": "Choose language",
+    "logged_in_as_name": "Logged in as {{name}}"
   },
   "footer": {
     "about_altinn": "About Altinn",
@@ -275,6 +276,7 @@
     "user_has_no_packages": "This user has no access packages.",
     "no_matching_search": "No matches for your search",
     "info_alert_text": "Access packages will eventually replace roles in Altinn's access management solution. They may be a bit empty now, but they will soon be filled with services.",
+    "person_info_alert": "Giving powers of attorney to individuals is currently not supported. This will come later.",
     "delegation_check": {
       "delegation_check_error_heading": "Technical error",
       "delegation_check_error_message_singular": "A technical error prevents you from giving the user the access package. Please contact Altinn user service if the problem persists.",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -110,7 +110,8 @@
     "all_services": "Alle tjenester",
     "chat": "Få hjelp på chat",
     "log_out": "Logg ut",
-    "locale_title": "Velg språk"
+    "locale_title": "Velg språk",
+    "logged_in_as_name": "Logget inn som {{name}}"
   },
   "footer": {
     "about_altinn": "Om Altinn",
@@ -274,6 +275,7 @@
     "user_has_no_packages": "Denne brukeren har ingen tilgangspakker.",
     "no_matching_search": "Ingen treff på søket",
     "info_alert_text": "Tilgangspakker vil etterhvert erstatte roller i Altinns tilgangstyringsløsning. De er kanskje litt tomme nå, men de vil snart bli fylt opp med tjenester.",
+    "person_info_alert": "Det er ikke mulig å gi og fjerne fullmakter til personer helt enda. Dette vil komme senere.",
     "delegation_check": {
       "delegation_check_error_heading": "Teknisk feil",
       "delegation_check_error_message_singular": "En teknisk feil sperrer deg fra å gi fullmakt til tilgangspakken. Vennligst kontakt Altinn brukerservice hvis problemet vedvarer.",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -94,7 +94,8 @@
     "all_services": "Alle tjenester",
     "chat": "Få hjelp på chat",
     "log_out": "Logg ut",
-    "locale_title": "Vel språk"
+    "locale_title": "Vel språk",
+    "logged_in_as_name": "Logga inn som {{name}}"
   },
   "footer": {
     "about_altinn": "Om Altinn",
@@ -271,6 +272,7 @@
     "user_has_no_packages": "Denne brukeren har ingen tilgangspakker.",
     "no_matching_search": "Ingen treff på søket",
     "info_alert_text": "Tilgangspakkar vil etter kvart erstatte roller i Altinn si tilgangsstyringsløysing. Dei er kanskje litt tomme nå, men vil snart bli fylte opp med tenester.",
+    "person_info_alert": "Det er ikkje mogleg å gi og fjerne fullmakter til personar heilt enno. Dette vil komme seinare.",
     "delegation_check": {
       "delegation_check_error_heading": "Teknisk feil",
       "delegation_check_error_message_singular": "En teknisk feil sperrer deg fra å gi fullmakt til tilgangspakken. Ver venleg å kontakte Altinn brukarteneste om problemet held fram.",

--- a/src/resources/css/Common.module.css
+++ b/src/resources/css/Common.module.css
@@ -48,6 +48,7 @@ html {
   --ds-color-neutral-surface-default: #fff;
   --ds-body-md-font-size: 1rem;
   --ds-color-text-subtle: #10204a;
+  --ds-link-color-visited: inherit;
 }
 
 /* Overide ds tokens for mobile screens */


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<img width="1612" height="897" alt="image" src="https://github.com/user-attachments/assets/8a66b4e9-35bc-43ba-824d-e106a148a492" />


## Description
<!--- Describe your changes in detail -->
Removed local styling on a tag to allow for the change in focus text color. OBS: The visited link color is overridden.
Added a disclaimer alert on person pages to inform the user that editing accesses on people is currently not supported.

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/1023
- https://github.com/Altinn/altinn-authorization-tmp/issues/923

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
