### PR TITLE
Use yarn to install playwright

### DIFF
--- a/.github/workflows/template-playwright.yml
+++ b/.github/workflows/template-playwright.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install dependencies
         run: yarn --immutable
       - name: Install Playwright Browsers
-        run: npx playwright install --with-deps
+        run: yarn playwright install --with-deps
       - name: Running yarn tests
         working-directory: playwright
         env:

--- a/playwright/package.json
+++ b/playwright/package.json
@@ -17,12 +17,12 @@
   "license": "ISC",
   "devDependencies": {
     "@azure/microsoft-playwright-testing": "^1.0.0-beta.7",
-    "@playwright/test": "^1.43.3",
-    "@types/node": "^22.0.0",
-    "dotenv": "^16.4.5"
+    "@playwright/test": "^1.55.0",
+    "@types/node": "^22.18.0",
+    "dotenv": "^16.6.1"
   },
   "dependencies": {
-    "axios": "^1.6.8",
+    "axios": "^1.11.0",
     "cross-env": "^7.0.3",
     "csv-parse": "^5.6.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1601,17 +1601,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@playwright/test@npm:^1.43.3":
-  version: 1.52.0
-  resolution: "@playwright/test@npm:1.52.0"
-  dependencies:
-    playwright: "npm:1.52.0"
-  bin:
-    playwright: cli.js
-  checksum: 10/e18a4eb626c7bc6cba212ff2e197cf9ae2e4da1c91bfdf08a744d62e27222751173e4b220fa27da72286a89a3b4dea7c09daf384d23708f284b64f98e9a63a88
-  languageName: node
-  linkType: hard
-
 "@playwright/test@npm:^1.55.0":
   version: 1.55.0
   resolution: "@playwright/test@npm:1.55.0"
@@ -2424,7 +2413,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:^22.0.0, @types/node@npm:^22.5.5":
+"@types/node@npm:*, @types/node@npm:^22.5.5":
   version: 22.15.29
   resolution: "@types/node@npm:22.15.29"
   dependencies:
@@ -3582,17 +3571,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.6.8":
-  version: 1.9.0
-  resolution: "axios@npm:1.9.0"
-  dependencies:
-    follow-redirects: "npm:^1.15.6"
-    form-data: "npm:^4.0.0"
-    proxy-from-env: "npm:^1.1.0"
-  checksum: 10/a2f90bba56820883879f32a237e2b9ff25c250365dcafd41cec41b3406a3df334a148f90010182dfdadb4b41dc59f6f0b3e8898ff41b666d1157b5f3f4523497
-  languageName: node
-  linkType: hard
-
 "axobject-query@npm:^4.1.0":
   version: 4.1.0
   resolution: "axobject-query@npm:4.1.0"
@@ -4705,10 +4683,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dotenv@npm:^16.4.2, dotenv@npm:^16.4.5":
+"dotenv@npm:^16.4.2":
   version: 16.5.0
   resolution: "dotenv@npm:16.5.0"
   checksum: 10/e68a16834f1a41cc2dfb01563bc150668ad675e6cd09191211467b5c0806b6ecd6ec438e021aa8e01cd0e72d2b70ef4302bec7cc0fe15b6955f85230b62dc8a9
+  languageName: node
+  linkType: hard
+
+"dotenv@npm:^16.6.1":
+  version: 16.6.1
+  resolution: "dotenv@npm:16.6.1"
+  checksum: 10/1d1897144344447ffe62aa1a6d664f4cd2e0784e0aff787eeeec1940ded32f8e4b5b506d665134fc87157baa086fce07ec6383970a2b6d2e7985beaed6a4cc14
   languageName: node
   linkType: hard
 
@@ -5874,18 +5859,6 @@ __metadata:
   version: 0.6.1
   resolution: "forever-agent@npm:0.6.1"
   checksum: 10/c1e1644d5e074ac063ecbc3fb8582013ef91fff0e3fa41e76db23d2f62bc6d9677aac86db950917deed4fe1fdd772df780cfaa352075f23deec9c015313afb97
-  languageName: node
-  linkType: hard
-
-"form-data@npm:^4.0.0":
-  version: 4.0.2
-  resolution: "form-data@npm:4.0.2"
-  dependencies:
-    asynckit: "npm:^0.4.0"
-    combined-stream: "npm:^1.0.8"
-    es-set-tostringtag: "npm:^2.1.0"
-    mime-types: "npm:^2.1.12"
-  checksum: 10/82c65b426af4a40090e517a1bc9057f76970b4c6043e37aa49859c447d88553e77d4cc5626395079a53d2b0889ba5f2a49f3900db3ad3f3f1bf76613532572fb
   languageName: node
   linkType: hard
 
@@ -8613,36 +8586,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.52.0":
-  version: 1.52.0
-  resolution: "playwright-core@npm:1.52.0"
-  bin:
-    playwright-core: cli.js
-  checksum: 10/42e13f5f98dc25ebc95525fb338a215b9097b2ba39d41e99972a190bf75d79979f163f5bc07b1ca06847ee07acb2c9b487d070fab67e9cd55e33310fc05aca3c
-  languageName: node
-  linkType: hard
-
 "playwright-core@npm:1.55.0":
   version: 1.55.0
   resolution: "playwright-core@npm:1.55.0"
   bin:
     playwright-core: cli.js
   checksum: 10/843376a8e2c1100d3f0625b2c85a69dc4418a0b268bdc7da6cf28252f6dc50c299c734f090a67c7f36cfa9140dacf5b95e817664e69642bcbaf06eea4d216c35
-  languageName: node
-  linkType: hard
-
-"playwright@npm:1.52.0":
-  version: 1.52.0
-  resolution: "playwright@npm:1.52.0"
-  dependencies:
-    fsevents: "npm:2.3.2"
-    playwright-core: "npm:1.52.0"
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  bin:
-    playwright: cli.js
-  checksum: 10/214175446089000c2ac997b925063b95f7d86d129c5d7c74caa5ddcb05bcad598dfd569d2133a10dc82d288bf67e7858877dcd099274b0b928b9c63db7d6ecec
   languageName: node
   linkType: hard
 
@@ -8666,12 +8615,12 @@ __metadata:
   resolution: "playwright@workspace:playwright"
   dependencies:
     "@azure/microsoft-playwright-testing": "npm:^1.0.0-beta.7"
-    "@playwright/test": "npm:^1.43.3"
-    "@types/node": "npm:^22.0.0"
-    axios: "npm:^1.6.8"
+    "@playwright/test": "npm:^1.55.0"
+    "@types/node": "npm:^22.18.0"
+    axios: "npm:^1.11.0"
     cross-env: "npm:^7.0.3"
     csv-parse: "npm:^5.6.0"
-    dotenv: "npm:^16.4.5"
+    dotenv: "npm:^16.6.1"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Playwright tests fail in pipeline after patching. Try using yarn to install instead of npx and update playwright in playwright workspace as well


## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow for end-to-end tests to align browser installation with the repository package manager, improving consistency and reducing environment discrepancies.
  * Upgraded test and tooling dependencies used for Playwright-based testing to more recent versions, streamlining maintenance and improving test reliability.
  * No changes to app functionality or user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->