### PR TITLE
Display GUI in prod

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.Prod.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.Prod.json
@@ -16,6 +16,10 @@
     "SecretUri": "https://altinn-prod-am-kv.vault.azure.net/"
   },
   "FeatureFlags": {
-    "DisplayPopularSingleRightsServices": true
+    "DisplayPopularSingleRightsServices": true,
+    "DisplayConfettiPackage": true,
+    "DisplayResourceDelegation": false,
+    "DisplayLimitedPreviewLaunch": true,
+    "RestrictPrivUse": true
   }
 }

--- a/src/features/amUI/common/CurrentUserPageHeader/CurrentUserPageHeader.tsx
+++ b/src/features/amUI/common/CurrentUserPageHeader/CurrentUserPageHeader.tsx
@@ -17,6 +17,7 @@ interface CurrentUserPageHeaderProps {
 export const CurrentUserPageHeader = ({ currentUser, as, loading }: CurrentUserPageHeaderProps) => {
   const { t } = useTranslation();
   const roles = currentUser?.roles ? getRoleCodesForKeyRoles(currentUser.roles) : [];
+  const formattedBirthDate = formatDateToNorwegian(currentUser?.party?.keyValues?.DateOfBirth);
 
   return (
     <div className={classes.currentUser}>
@@ -24,8 +25,7 @@ export const CurrentUserPageHeader = ({ currentUser, as, loading }: CurrentUserP
         id={currentUser?.party?.id || ''}
         name={currentUser?.party?.name || ''}
         description={
-          t('common.date_of_birth') +
-          ` ${formatDateToNorwegian(currentUser?.party?.keyValues?.DateOfBirth)}`
+          formattedBirthDate ? t('common.date_of_birth') + ` ${formattedBirthDate}` : undefined
         }
         roleNames={roles.map((r) => t(`${r}`))}
         type='person'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR changes feature flags in prod to display the access management interface in production as in TT02

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enabled confetti visuals in relevant package flows.
  - Enabled limited preview launch indicators.
  - Applied usage restrictions for private users where applicable.
  - Temporarily hid resource delegation features in production.

- Bug Fixes
  - User header now displays birth date only when available, formatted in Norwegian, avoiding empty or misleading labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->