### PR TITLE
Disable limited preview launch feature in app settings

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.AT22.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.AT22.json
@@ -32,7 +32,7 @@
   "FeatureFlags": {
     "DisplayConfettiPackage": true,
     "DisplayResourceDelegation": false,
-    "DisplayLimitedPreviewLaunch": true,
+    "DisplayLimitedPreviewLaunch": false,
     "RestrictPrivUse": true
   }
 }


### PR DESCRIPTION

## Description
Disable limited preview launch feature in app settings

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Disabled the limited preview launch display in the AT22 environment. Users will now see the standard interface instead of the limited preview.
  - No changes to core functionality or user workflows outside of the preview visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->