### PR TITLE
Enable access packages for standard system user in AT22

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.AT22.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.AT22.json
@@ -33,7 +33,7 @@
     "DisplayConfettiPackage": true,
     "DisplayResourceDelegation": false,
     "DisplayLimitedPreviewLaunch": false,
-    "StandardSystemUserAccessPackages": false,
+    "StandardSystemUserAccessPackages": true,
     "RestrictPrivUse": true
   }
 }


### PR DESCRIPTION
## Description
- Feature toggle access packages for standard system user ON in AT22

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled Standard System User Access Packages in the AT22 environment.
  * Users in AT22 can now view and select predefined access packages for system users, streamlining access management.
  * No other user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->