### PR TITLE
Display key roles as chips on user's page

### DIFF
--- a/src/features/amUI/common/UserList/UserList.module.css
+++ b/src/features/amUI/common/UserList/UserList.module.css
@@ -22,3 +22,7 @@
 .showMoreButton {
   width: 100%;
 }
+
+.inheritingUsersContainer {
+  padding: 0.5rem 1rem;
+}

--- a/src/features/amUI/common/UserPageHeader/UserPageHeader.module.css
+++ b/src/features/amUI/common/UserPageHeader/UserPageHeader.module.css
@@ -9,7 +9,16 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  position: relative;
 }
+
+.secondaryAvatar {
+  position: absolute;
+  bottom: -6px;
+  right: -6px;
+  z-index: 1;
+}
+
 .name {
   grid-area: name;
 }

--- a/src/features/amUI/common/UserPageHeader/UserPageHeader.tsx
+++ b/src/features/amUI/common/UserPageHeader/UserPageHeader.tsx
@@ -1,4 +1,4 @@
-import { DsParagraph, DsHeading, MenuItemIcon } from '@altinn/altinn-components';
+import { DsParagraph, DsHeading, MenuItemIcon, Avatar } from '@altinn/altinn-components';
 import { ArrowRightIcon } from '@navikt/aksel-icons';
 import { t } from 'i18next';
 
@@ -58,13 +58,11 @@ export const UserPageHeader = ({
             }}
             size={'lg'}
           />
-          <ArrowRightIcon style={{ fontSize: '1.5rem' }} />
-          <MenuItemIcon
-            icon={{
-              name: secondaryParty?.name ?? '',
-              type: secondaryParty?.partyTypeName === PartyType.Organization ? 'company' : 'person',
-            }}
+          <Avatar
+            name={secondaryParty?.name ?? ''}
+            type={secondaryParty?.partyTypeName === PartyType.Organization ? 'company' : 'person'}
             size={'lg'}
+            className={classes.secondaryAvatar}
           />
         </div>
       );

--- a/src/features/amUI/common/UserPageHeader/UserPageHeader.tsx
+++ b/src/features/amUI/common/UserPageHeader/UserPageHeader.tsx
@@ -2,7 +2,7 @@ import { DsParagraph, DsHeading, MenuItemIcon } from '@altinn/altinn-components'
 import { ArrowRightIcon } from '@navikt/aksel-icons';
 import { t } from 'i18next';
 
-import { PartyType } from '@/rtk/features/userInfoApi';
+import { PartyType, useGetRightHoldersQuery } from '@/rtk/features/userInfoApi';
 
 import { usePartyRepresentation } from '../PartyRepresentationContext/PartyRepresentationContext';
 import { UserRoles } from '../UserRoles/UserRoles';
@@ -21,7 +21,12 @@ export const UserPageHeader = ({
   displayDirection = false,
   displayRoles = true,
 }: UserPageHeaderProps) => {
-  const { toParty, fromParty, isLoading: loadingPartyRepresentation } = usePartyRepresentation();
+  const {
+    toParty,
+    fromParty,
+    actingParty,
+    isLoading: loadingPartyRepresentation,
+  } = usePartyRepresentation();
 
   if (!toParty && !fromParty && !loadingPartyRepresentation) {
     return null;

--- a/src/features/amUI/common/UserRoles/UserRoles.tsx
+++ b/src/features/amUI/common/UserRoles/UserRoles.tsx
@@ -8,6 +8,7 @@ import { usePartyRepresentation } from '../PartyRepresentationContext/PartyRepre
 import { useGetRightHoldersQuery } from '@/rtk/features/userInfoApi';
 import { useMemo } from 'react';
 import { t } from 'i18next';
+import { getRoleCodesForKeyRoles } from './roleUtils';
 
 interface UserRulesProps extends React.HTMLAttributes<HTMLDivElement> {
   rightOwnerUuid: string;
@@ -34,11 +35,11 @@ export const UserRoles = ({
     },
     { skip: !actingParty || (!toParty && !fromParty) },
   );
-  const roles = useMemo(() => {
+  const roleTextKeys = useMemo(() => {
     if (isConnectionLoading || loadingPartyRepresentation || connectionData === undefined) {
       return [];
     }
-    return connectionData[0].roles.map((role) => role.code) ?? [];
+    return getRoleCodesForKeyRoles(connectionData[0].roles) ?? [];
   }, [connectionData, isConnectionLoading, loadingPartyRepresentation]);
 
   return (
@@ -46,12 +47,12 @@ export const UserRoles = ({
       className={cn(classes.userRoles, className)}
       {...props}
     >
-      {roles?.map((role) => {
+      {roleTextKeys?.map((roleTextKey) => {
         return (
           <Badge
             color={'company'}
-            label={t(`user_role.${role}`)}
-            key={role}
+            label={t(roleTextKey)}
+            key={roleTextKey}
           />
         );
       })}

--- a/src/features/amUI/common/UserRoles/UserRoles.tsx
+++ b/src/features/amUI/common/UserRoles/UserRoles.tsx
@@ -4,6 +4,10 @@ import cn from 'classnames';
 import { useGetRolesForUserQuery } from '@/rtk/features/roleApi';
 
 import classes from './userRoles.module.css';
+import { usePartyRepresentation } from '../PartyRepresentationContext/PartyRepresentationContext';
+import { useGetRightHoldersQuery } from '@/rtk/features/userInfoApi';
+import { useMemo } from 'react';
+import { t } from 'i18next';
 
 interface UserRulesProps extends React.HTMLAttributes<HTMLDivElement> {
   rightOwnerUuid: string;
@@ -16,23 +20,38 @@ export const UserRoles = ({
   className,
   ...props
 }: UserRulesProps) => {
-  const { data } = useGetRolesForUserQuery({
-    from: rightOwnerUuid,
-    to: rightHolderUuid,
-  });
+  const {
+    toParty,
+    fromParty,
+    actingParty,
+    isLoading: loadingPartyRepresentation,
+  } = usePartyRepresentation();
+  const { data: connectionData, isLoading: isConnectionLoading } = useGetRightHoldersQuery(
+    {
+      partyUuid: actingParty?.partyUuid ?? '',
+      toUuid: toParty?.partyUuid ?? '',
+      fromUuid: fromParty?.partyUuid ?? '',
+    },
+    { skip: !actingParty || (!toParty && !fromParty) },
+  );
+  const roles = useMemo(() => {
+    if (isConnectionLoading || loadingPartyRepresentation || connectionData === undefined) {
+      return [];
+    }
+    return connectionData[0].roles.map((role) => role.code) ?? [];
+  }, [connectionData, isConnectionLoading, loadingPartyRepresentation]);
+
   return (
     <div
       className={cn(classes.userRoles, className)}
       {...props}
     >
-      {data?.map((assignment) => {
-        const isER = assignment?.role?.urn?.includes('brreg:');
+      {roles?.map((role) => {
         return (
           <Badge
-            color={isER ? 'info' : 'company'}
-            label={assignment.role.name}
-            key={assignment.id}
-            theme={isER ? 'base' : 'subtle'}
+            color={'company'}
+            label={t(`user_role.${role}`)}
+            key={role}
           />
         );
       })}

--- a/src/features/amUI/common/UserRoles/UserRoles.tsx
+++ b/src/features/amUI/common/UserRoles/UserRoles.tsx
@@ -1,7 +1,6 @@
-import { Badge } from '@altinn/altinn-components';
-import cn from 'classnames';
+import { Badge, DsChip } from '@altinn/altinn-components';
 
-import { useGetRolesForUserQuery } from '@/rtk/features/roleApi';
+import cn from 'classnames';
 
 import classes from './userRoles.module.css';
 import { usePartyRepresentation } from '../PartyRepresentationContext/PartyRepresentationContext';
@@ -48,13 +47,7 @@ export const UserRoles = ({
       {...props}
     >
       {roleTextKeys?.map((roleTextKey) => {
-        return (
-          <Badge
-            color={'company'}
-            label={t(roleTextKey)}
-            key={roleTextKey}
-          />
-        );
+        return <DsChip.Button key={roleTextKey}>{t(roleTextKey)}</DsChip.Button>;
       })}
     </div>
   );

--- a/src/features/amUI/packagePoaDetailsPage/PackagePoaDetails.tsx
+++ b/src/features/amUI/packagePoaDetailsPage/PackagePoaDetails.tsx
@@ -91,8 +91,6 @@ export const PackagePoaDetails = () => {
           isLoading={isLoading}
           packageName={accessPackage?.name}
           packageDescription={accessPackage?.description}
-          fromPartyName={fromParty?.name}
-          fromPartyTypeName={fromParty?.partyTypeName}
         />
       </div>
       <DsTabs

--- a/src/features/amUI/packagePoaDetailsPage/PackagePoaDetailsHeader.module.css
+++ b/src/features/amUI/packagePoaDetailsPage/PackagePoaDetailsHeader.module.css
@@ -9,27 +9,14 @@
   align-items: center;
 }
 
-.packageIconContainer {
-  grid-area: icon;
-  position: relative;
-}
-
 @media screen and (max-width: 768px) {
 }
 
 .packageIcon {
-  height: 2.35rem;
-  width: 2.35rem;
+  grid-area: icon;
+  height: 2.6rem;
+  width: 2.6rem;
   margin: auto;
-}
-
-.packageAvatar {
-  position: absolute;
-  bottom: 0;
-  right: 0;
-  height: 1rem;
-  width: 1rem;
-  z-index: 100;
 }
 
 .pageHeading {

--- a/src/features/amUI/packagePoaDetailsPage/PackagePoaDetailsHeader.tsx
+++ b/src/features/amUI/packagePoaDetailsPage/PackagePoaDetailsHeader.tsx
@@ -8,32 +8,19 @@ import { PackagePoaDetailsHeaderSkeleton } from './PackagePoaDetailsHeaderSkelet
 interface PackagePoaDetailsHeaderProps {
   packageName?: string;
   packageDescription?: string;
-  fromPartyName?: string;
-  fromPartyTypeName?: PartyType | string;
   isLoading?: boolean;
 }
 
 export const PackagePoaDetailsHeader: React.FC<PackagePoaDetailsHeaderProps> = ({
   packageName = '',
   packageDescription = '',
-  fromPartyName = '',
-  fromPartyTypeName,
   isLoading = false,
 }) => {
-  const avatarType = fromPartyTypeName === PartyType.Organization ? 'company' : 'person';
   return isLoading ? (
     <PackagePoaDetailsHeaderSkeleton />
   ) : (
     <>
-      <div className={classes.packageIconContainer}>
-        <PackageIcon className={classes.packageIcon} />
-        <Avatar
-          name={fromPartyName}
-          type={avatarType}
-          className={classes.packageAvatar}
-          size='xs'
-        />
-      </div>
+      <PackageIcon className={classes.packageIcon} />
       <DsHeading
         level={1}
         data-size='lg'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<img width="1215" height="775" alt="image" src="https://github.com/user-attachments/assets/3b458147-1d96-4aad-a025-abc31db7a489" />

This PR displays all key roles a user might have, on their page. They are displayed as chip buttons, so that they can later be used to open modals with more information about the role.

In addition to this, several minor fixes have been made:
- Display a small avatar in the corner of the avatar of the user page in the Reportee overview flow
- Remove the small avatar on the package page of the Poa overview flow
- Fix the hierarchical display of users with sub-connections so that main units appear together with their children and thus, can be accessed

<img width="1211" height="657" alt="image" src="https://github.com/user-attachments/assets/3ab0e397-4c59-470b-aa50-369c35789190" />
<img width="1193" height="486" alt="image" src="https://github.com/user-attachments/assets/f4b34ab5-1547-4a93-b109-7bf29e43c3b5" />
<img width="1001" height="204" alt="image" src="https://github.com/user-attachments/assets/0f40fcb5-36a8-4d27-94dd-8deda0a9393e" />


## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/1118

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
