### PR TITLE
Delete system user button should not be red

### DIFF
--- a/src/features/amUI/systemUser/components/DeleteSystemUserPopover/DeleteSystemUserPopover.tsx
+++ b/src/features/amUI/systemUser/components/DeleteSystemUserPopover/DeleteSystemUserPopover.tsx
@@ -30,7 +30,6 @@ export const DeleteSystemUserPopover = ({
       <DsPopover.TriggerContext>
         <DsPopover.Trigger
           variant='tertiary'
-          data-color='danger'
           onClick={() => setIsPopoverOpen(true)}
         >
           <TrashIcon aria-hidden />


### PR DESCRIPTION
## Description
- Delete system user button should be primary color
<img width="290" height="127" alt="image" src="https://github.com/user-attachments/assets/8815555d-34bc-4f1f-9d75-43aaeb5e0ced" />


## Related Issue(s)
- #1554 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
