### PR TITLE
Update info alert text for access packages

### DIFF
--- a/src/features/amUI/userRightsPage/AccessPackageSection/AccessPackageInfoAlert.tsx
+++ b/src/features/amUI/userRightsPage/AccessPackageSection/AccessPackageInfoAlert.tsx
@@ -1,15 +1,26 @@
 import { DsAlert, DsParagraph } from '@altinn/altinn-components';
-import { useTranslation } from 'react-i18next';
+import { Trans } from 'react-i18next';
 
 export const AccessPackageInfoAlert = () => {
-  const { t } = useTranslation();
-
   return (
     <DsAlert
       data-color='info'
       data-size='sm'
     >
-      <DsParagraph>{t('access_packages.info_alert_text')}</DsParagraph>
+      <DsParagraph>
+        <Trans
+          i18nKey='access_packages.info_alert_text'
+          components={{
+            link: (
+              <a
+                href='https://info.altinn.no/hjelp/profil/tilgangspakker/'
+                target='_blank'
+                rel='noopener noreferrer'
+              />
+            ),
+          }}
+        />
+      </DsParagraph>
     </DsAlert>
   );
 };

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -287,7 +287,7 @@
     "package_number_of_resources": "{{count}} services",
     "user_has_no_packages": "This user has no access packages.",
     "no_matching_search": "No matches for your search",
-    "info_alert_text": "Access packages will eventually replace the traditional Altinn roles. They may be a bit empty now, but they will soon be filled with services.",
+    "info_alert_text": "Access packages will replace today's Altinn roles. They will be filled with more services over time. Read more on our help pages: <link>altinn.no/help</link>.",
     "person_info_alert": "Giving powers of attorney to individuals is currently not supported. This will come later.",
     "delegation_check": {
       "delegation_check_error_heading": "Technical error",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -286,7 +286,7 @@
     "package_number_of_resources": "{{count}} tjenester",
     "user_has_no_packages": "Denne brukeren har ingen tilgangspakker.",
     "no_matching_search": "Ingen treff på søket",
-    "info_alert_text": "Tilgangspakker vil etter hvert erstatte de tradisjonelle Altinn-rollene. De er kanskje litt tomme nå, men de vil snart bli fylt opp med tjenester.",
+    "info_alert_text": "Tilgangspakker skal erstatte dagens altinn-roller. De vil fylles med flere tjenester etterhvert. Les mer om dette på våre hjelpesider: <link>altinn.no/hjelpesider</link>.",
     "person_info_alert": "Det er ikke mulig å gi og fjerne fullmakter til personer helt enda. Dette vil komme senere.",
     "delegation_check": {
       "delegation_check_error_heading": "Teknisk feil",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -283,7 +283,7 @@
     "package_number_of_resources": "{{count}} tenester",
     "user_has_no_packages": "Denne brukeren har ingen tilgangspakkar.",
     "no_matching_search": "Ingen treff på søket",
-    "info_alert_text": "Tilgangspakkar vil etter kvart erstatte dei tradisjonelle Altinn-rollene. Dei er kanskje litt tomme nå, men vil snart bli fylte opp med tenester.",
+    "info_alert_text": "Tilgangspakkar skal erstatte dagens Altinn-roller. Dei vil bli fylt med fleire tenester etter kvart. Les meir om dette på hjelpesidene våre: <link>altinn.no/hjelpesider</link>.",
     "person_info_alert": "Det er ikkje mogleg å gi og fjerne fullmakter til personar heilt enno. Dette vil komme seinare.",
     "delegation_check": {
       "delegation_check_error_heading": "Teknisk feil",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Updates the warning text on the user page to `"Tilgangspakker skal erstatte dagens altinn-roller. De vil fylles med flere tjenester etterhvert. Les mer om dette på våre hjelpesider: altinn.no/hjelpesider."`


## Related Issue(s)
[1094](https://github.com/Altinn/altinn-authorization-tmp/issues/1094)

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
