### PR TITLE
fix: change header menu in consent request page after changes in altinn-components

### DIFF
--- a/src/features/amUI/consent/ConsentRequestPage/ConsentRequestPage.tsx
+++ b/src/features/amUI/consent/ConsentRequestPage/ConsentRequestPage.tsx
@@ -1,4 +1,4 @@
-import type { ChangeEvent, ReactElement } from 'react';
+import type { ReactElement } from 'react';
 import React from 'react';
 import cn from 'classnames';
 import { useTranslation } from 'react-i18next';
@@ -19,7 +19,7 @@ import {
   useGetConsentRequestQuery,
   useRejectConsentRequestMutation,
 } from '@/rtk/features/consentApi';
-import { getAltinnStartPageUrl } from '@/resources/utils/pathUtils';
+import { getAltinnStartPageUrl, getHostUrl } from '@/resources/utils/pathUtils';
 import { useGetUserInfoQuery } from '@/rtk/features/userInfoApi';
 
 import type { ConsentLanguage, ConsentRequest, ProblemDetail } from '../types';
@@ -50,8 +50,7 @@ export const ConsentRequestPage = () => {
     },
   );
 
-  const onChangeLocale = (event: ChangeEvent<HTMLInputElement>) => {
-    const newLocale = event.target.value;
+  const onChangeLocale = (newLocale: string) => {
     i18n.changeLanguage(newLocale);
     document.cookie = `selectedLanguage=${newLocale}; path=/; SameSite=Strict`;
   };
@@ -62,9 +61,6 @@ export const ConsentRequestPage = () => {
         color='neutral'
         theme='subtle'
         header={{
-          menu: {
-            items: [],
-          },
           locale: {
             title: t('header.locale_title'),
             options: [
@@ -72,7 +68,7 @@ export const ConsentRequestPage = () => {
               { label: 'Norsk (nynorsk)', value: 'no_nn', checked: i18n.language === 'no_nn' },
               { label: 'English', value: 'en', checked: i18n.language === 'en' },
             ],
-            onChange: onChangeLocale,
+            onSelect: onChangeLocale,
           },
           logo: {
             href: getAltinnStartPageUrl(),
@@ -82,6 +78,21 @@ export const ConsentRequestPage = () => {
             name: request?.fromPartyName ?? (userData?.name || ''),
             type: request?.fromPartyName ? 'company' : 'person',
             id: '',
+          },
+          globalMenu: {
+            logoutButton: {
+              label: t('header.log_out'),
+              onClick: () => {
+                (window as Window).location =
+                  `${getHostUrl()}ui/Authentication/Logout?languageID=1044`;
+              },
+            },
+            menuLabel: t('header.menu-label'),
+            backLabel: t('header.back-label'),
+            changeLabel: t('header.change-label'),
+            currentEndUserLabel: t('header.logged_in_as_name', {
+              name: userData?.name || '',
+            }),
           },
         }}
       >


### PR DESCRIPTION
## Description
- Fix language selector in consent request page
- Show logged in user name and logout button in menu
<img width="361" height="305" alt="image" src="https://github.com/user-attachments/assets/25d710cf-a97a-4f2a-9e8e-8cacbf72db12" />


## Related Issue(s)
- #1600 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a global menu in the header with a logout button and clearer labels (menu, back, change).
  - Display of the current end-user now shows the user’s name in the header.
  - Locale switching updated to a more direct selection flow for smoother language changes.
  - Logout now performs a full redirect to the host’s logout endpoint for a more reliable sign-out experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->