### PR TITLE
fix: remove ActionBarHeader header data-size, since it conflicts the child paragraph data-size

### DIFF
--- a/src/components/ActionBar/ActionBarHeader.tsx
+++ b/src/components/ActionBar/ActionBarHeader.tsx
@@ -21,28 +21,23 @@ export const ActionBarHeader = forwardRef<HTMLHeadingElement, ActionBarHeaderPro
     const { open, toggleOpen, contentId, headerId, color, size } = useActionBarContext();
 
     let paragraphSize: 'sm' | 'md' | 'lg' | 'xs';
-    let headingSize: 'sm' | 'md' | 'lg';
     switch (size) {
       case 'large':
         headingLevel = headingLevel || 3;
         paragraphSize = 'lg';
-        headingSize = 'lg';
         break;
       case 'medium':
         headingLevel = headingLevel || 4;
         paragraphSize = 'sm';
-        headingSize = 'md';
         break;
       case 'small':
         headingLevel = headingLevel || 5;
         paragraphSize = 'xs';
-        headingSize = 'sm';
         break;
     }
     return (
       <DsHeading
         level={headingLevel}
-        data-size={headingSize}
         ref={ref}
         className={cn(classes.actionBar, classes[color], classes[size], {
           [classes.subtitle]: subtitle,


### PR DESCRIPTION
## Description
- Prepare for upgrade of designsystemet package (through altinn-components). Setting `data-size` on a `<DsHeading>` element, and putting `<DsParagraph>` children in this header, will result in the heading data-size overriding the data-size set on paragraph with designsystemet 1.5.0. There is already a slight discrepancy with designsystemet 1.0.6, as seen below

**Current look (with designsystemet 1.0.6):**
<img width="490" height="150" alt="image" src="https://github.com/user-attachments/assets/dbf13100-1584-429b-a37a-a55f513f373c" />

**With data-size removed from DsHeading wrapper**
<img width="485" height="146" alt="image" src="https://github.com/user-attachments/assets/99fbc7ae-0c2a-4b9f-8a5b-72c8548a7dd3" />



## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
