### PR TITLE
fix: remove feature toggle for displaying access packages for standard system users

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Configuration/FeatureFlags.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Configuration/FeatureFlags.cs
@@ -25,11 +25,6 @@ namespace Altinn.AccessManagement.UI.Core.Configuration
         /// Whether or not to only display the service/resource delegation feature in the UI
         /// </summary>
         public bool DisplayResourceDelegation { get; set; }
-        
-        /// <summary>
-        /// Whether or not to load access packages for standard system user from API
-        /// </summary>
-        public bool StandardSystemUserAccessPackages { get; set; }
 
         /// <summary>
         /// Whether to show the new AMUI to PRIV users

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.AT22.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.AT22.json
@@ -33,7 +33,6 @@
     "DisplayConfettiPackage": true,
     "DisplayResourceDelegation": false,
     "DisplayLimitedPreviewLaunch": false,
-    "StandardSystemUserAccessPackages": true,
     "RestrictPrivUse": true
   }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.Development.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.Development.json
@@ -36,7 +36,6 @@
     "DisplayConfettiPackage": true,
     "DisplayResourceDelegation": true,
     "DisplayLimitedPreviewLaunch": false,
-    "StandardSystemUserAccessPackages": true,
     "RestrictPrivUse": false
   }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.TT02.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.TT02.json
@@ -20,7 +20,6 @@
     "DisplayConfettiPackage": true,
     "DisplayResourceDelegation": false,
     "DisplayLimitedPreviewLaunch": true,
-    "StandardSystemUserAccessPackages": false,
     "RestrictPrivUse": true
   }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.json
@@ -49,7 +49,6 @@
     "DisplayConfettiPackage": false,
     "DisplayResourceDelegation": false,
     "DisplayLimitedPreviewLaunch": false,
-    "StandardSystemUserAccessPackages": false,
     "RestrictPrivUse": true
   }
 }


### PR DESCRIPTION
## Description
- The API to check which access packages a standard system user has is merged, so feature toggle is not needed anymore

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
