### PR TITLE
dont run the slow playwrighttests as part of deploy

### DIFF
--- a/.github/workflows/scheduled-slow-playwright-tests.yml
+++ b/.github/workflows/scheduled-slow-playwright-tests.yml
@@ -1,0 +1,65 @@
+name: Scheduled Slow Playwright Tests
+
+on:
+  schedule:
+    # Run daily at 06:00 AM UTC (08:00 AM CET, 09:00 AM CEST)
+    - cron: '0 6 * * *'
+  workflow_dispatch: # Allow manual triggering for testing
+
+jobs:
+  slow-e2e-tests:
+    name: Slow Playwright Tests - ${{ matrix.environment }} - ${{ matrix.project }}
+    permissions:
+      id-token: write
+      contents: read
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        environment: [AT24, TT02]
+        project: [e2e-tests]
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: lts/*
+      - name: Install dependencies
+        run: yarn --immutable
+      - name: Install Playwright Browsers
+        run: yarn playwright install --with-deps
+      - name: Running slow Playwright tests
+        working-directory: playwright
+        env:
+          USERNAME_TEST_API: ${{ secrets.USERNAME_TEST_API }}
+          PASSWORD_TEST_API: ${{ secrets.PASSWORD_TEST_API }}
+        run: |
+          yarn run env:${{ matrix.environment }} --project ${{ matrix.project }} --grep @slow
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        if: always()
+        with:
+          name: slow-playwright-report-${{ matrix.environment }}-${{ matrix.project }}
+          path: playwright/playwright-report/${{ matrix.environment }}
+          retention-days: 30
+
+      - name: Azure CLI Login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZCOPY_SPA_APPLICATION_ID }}
+          tenant-id: ${{ secrets.AZCOPY_TENANT_ID }}
+          subscription-id: ${{ secrets.AZCOPY_SUBSCRIPTION_ID }}
+
+      - name: Upload HTML report to Azure
+        uses: azure/cli@v2
+        with:
+          azcliversion: latest
+          inlineScript: |
+            REPORT_NAME=${{ matrix.environment }}-slow
+            REPORT_ID=${{ github.sha }}-${{ matrix.project }}
+            ACCOUNT_NAME=playwrightreporting
+            az storage blob upload-batch \
+                --account-name "$ACCOUNT_NAME" \
+                --destination "\$web" \
+                --destination-path "$REPORT_ID" \
+                --source "playwright/playwright-report/$REPORT_NAME" \
+                --overwrite \
+                --auth-mode login
+            echo "::Link to Slow Playwright test results: title=HTML report url::https://playwrightreporting.z1.web.core.windows.net/$REPORT_ID/$REPORT_NAME/index.html"

--- a/.github/workflows/scheduled-slow-playwright-tests.yml
+++ b/.github/workflows/scheduled-slow-playwright-tests.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           azcliversion: latest
           inlineScript: |
-            REPORT_NAME=${{ matrix.environment }}-slow
+            REPORT_NAME=${{ matrix.environment }} -slow
             REPORT_ID=${{ github.sha }}-${{ matrix.project }}
             ACCOUNT_NAME=playwrightreporting
             az storage blob upload-batch \

--- a/.github/workflows/scheduled-slow-playwright-tests.yml
+++ b/.github/workflows/scheduled-slow-playwright-tests.yml
@@ -2,8 +2,8 @@ name: Scheduled Slow Playwright Tests
 
 on:
   schedule:
-    # Run daily at 06:00 AM UTC (08:00 AM CET, 09:00 AM CEST)
-    - cron: '0 6 * * *'
+    # Run daily a 04:00 AM UTC (06 norsk tid)
+    - cron: '0 4 * * *'
   workflow_dispatch: # Allow manual triggering for testing
 
 jobs:

--- a/.github/workflows/scheduled-slow-playwright-tests.yml
+++ b/.github/workflows/scheduled-slow-playwright-tests.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           azcliversion: latest
           inlineScript: |
-            REPORT_NAME=${{ matrix.environment }} -slow
+            REPORT_NAME=${{ github.run_id }}
             REPORT_ID=${{ github.sha }}-${{ matrix.project }}
             ACCOUNT_NAME=playwrightreporting
             az storage blob upload-batch \

--- a/.github/workflows/template-playwright.yml
+++ b/.github/workflows/template-playwright.yml
@@ -51,7 +51,7 @@ jobs:
           USERNAME_TEST_API: ${{ secrets.USERNAME_TEST_API }}
           PASSWORD_TEST_API: ${{ secrets.PASSWORD_TEST_API }}
         run: |
-          yarn run env:${{ inputs.environment }} --retries=2 --project ${{ inputs.project }} --workers=4
+          yarn run env:${{ inputs.environment }} --project ${{ inputs.project }} --workers=4 --grep-invert @slow
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:

--- a/playwright/config/.env.at24
+++ b/playwright/config/.env.at24
@@ -1,19 +1,19 @@
 ENV_NAME="at24"
 BASE_URL="https://at24.altinn.cloud"
 APP_URL="https://ttd.apps.at24.altinn.cloud/ttd/autorisasjon-autotest-app-2"
-PLATFORM_URL= "https://platform.at24.altinn.cloud/accessmanagement/api/"
+PLATFORM_URL="https://platform.at24.altinn.cloud/accessmanagement/api/"
 
 ##Rettighetshaver configs 
-PARTY_ID = "09f9fa4c-01a9-42c1-bed7-a1829969cc85"
-FROM_ORG = "09f9fa4c-01a9-42c1-bed7-a1829969cc85"
-TO_ORG = "743dd977-55ea-4bac-84d2-3007ceb63b46"
+PARTY_ID="09f9fa4c-01a9-42c1-bed7-a1829969cc85"
+FROM_ORG="09f9fa4c-01a9-42c1-bed7-a1829969cc85"
+TO_ORG="743dd977-55ea-4bac-84d2-3007ceb63b46"
 DAGL_PARTY_ID="51155461"
 DAGL_USER_ID="20879211"
 DAGL_PID="23926299794"
-DAGL_PARTY_UUID = "BC5FBEA9-465A-4C37-80B9-CD0B28939591"
-BYGG_PACKAGE_URN = "urn:altinn:accesspackage:byggesoknad"
-OPPVEKST_PACKAGE_URN = "urn:altinn:accesspackage:godkjenning-av-personell"
-VEI_PACKAGE_URN = "urn:altinn:accesspackage:veitransport"
+DAGL_PARTY_UUID="BC5FBEA9-465A-4C37-80B9-CD0B28939591"
+BYGG_PACKAGE_URN="urn:altinn:accesspackage:byggesoknad"
+OPPVEKST_PACKAGE_URN="urn:altinn:accesspackage:godkjenning-av-personell"
+VEI_PACKAGE_URN="urn:altinn:accesspackage:veitransport"
 
 
 ## System user configs

--- a/playwright/e2eTests/accesspkgdelegation/accesspkgDirectdelegatation.spec.ts
+++ b/playwright/e2eTests/accesspkgdelegation/accesspkgDirectdelegatation.spec.ts
@@ -44,7 +44,9 @@ test.describe('Delegate access pacakge from Org-A(Avgiver) to Org-B(Rettighetsha
     await delegation.verifyDelegatedPacakge('Oppvekst og utdanning', 'Godkjenning av personell');
   });
 
-  test('Org-A revokes all delegated access package rights from Org-2', async ({ delegation }) => {
+  test.skip('Org-A revokes all delegated access package rights from Org-2', async ({
+    delegation,
+  }) => {
     await DelegationApiUtil.addOrgToDelegate();
     await DelegationApiUtil.delegateAccessPacakage();
 

--- a/playwright/e2eTests/api-delegering.spec.ts
+++ b/playwright/e2eTests/api-delegering.spec.ts
@@ -9,7 +9,7 @@ const standardApiDetails = {
 
 test.describe.configure({ mode: 'parallel' });
 
-test.describe('API-Delegations to organization user', () => {
+test.describe('@slow API-Delegations to organization user', () => {
   test('Delegate api to an organization', async ({ apiDelegations, login }) => {
     const userThatDelegates = {
       id: '12917198150',

--- a/playwright/e2eTests/api-delegering.spec.ts
+++ b/playwright/e2eTests/api-delegering.spec.ts
@@ -7,8 +7,6 @@ const standardApiDetails = {
   department: 'Testdepartement',
 };
 
-test.describe.configure({ mode: 'parallel' });
-
 test.describe('@slow API-Delegations to organization user', () => {
   test('Delegate api to an organization', async ({ apiDelegations, login }) => {
     const userThatDelegates = {

--- a/playwright/e2eTests/idPortenLogin.spec.ts
+++ b/playwright/e2eTests/idPortenLogin.spec.ts
@@ -4,7 +4,7 @@ import { test } from '@playwright/test';
 
 import { LoginPage } from 'playwright/pages/LoginPage';
 
-test.skip('Login with TestID', async ({ page }) => {
+test('Login with TestID', async ({ page }) => {
   const login = new LoginPage(page);
   await login.loginWithUser('02828698497');
 });

--- a/playwright/e2eTests/idPortenLogin.spec.ts
+++ b/playwright/e2eTests/idPortenLogin.spec.ts
@@ -4,7 +4,7 @@ import { test } from '@playwright/test';
 
 import { LoginPage } from 'playwright/pages/LoginPage';
 
-test('Login with TestID', async ({ page }) => {
+test('@skip Login with TestID', async ({ page }) => {
   const login = new LoginPage(page);
   await login.loginWithUser('02828698497');
 });

--- a/playwright/e2eTests/idPortenLogin.spec.ts
+++ b/playwright/e2eTests/idPortenLogin.spec.ts
@@ -4,7 +4,7 @@ import { test } from '@playwright/test';
 
 import { LoginPage } from 'playwright/pages/LoginPage';
 
-test('@skip Login with TestID', async ({ page }) => {
+test.skip('Login with TestID', async ({ page }) => {
   const login = new LoginPage(page);
   await login.loginWithUser('02828698497');
 });

--- a/playwright/e2eTests/singleRightsDelegering.spec.ts
+++ b/playwright/e2eTests/singleRightsDelegering.spec.ts
@@ -2,7 +2,7 @@
 /* eslint-disable import/no-named-as-default-member */
 import { test } from './../fixture/pomFixture';
 
-test.describe('User with DAGL/HADM role without having resource access themselves', () => {
+test.describe('@slow User with DAGL/HADM role without having resource access themselves', () => {
   test('User A who is DAGL/HADM for org delegates resources/Altinn 3 app/Altinn 2 services to User B', async ({
     login,
     delegate,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Labeled selected end-to-end suites as slow and excluded them from standard runs.
  - Disabled parallel execution for one suite to improve stability.
  - Temporarily skipped a failing test to reduce noise in CI.

- Chores
  - Introduced a scheduled nightly workflow to run slow end-to-end tests and publish reports.
  - Updated CI commands to stop retrying failed runs and filter out slow tests.
  - Standardized environment variable formatting for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->