### PR TITLE
fix: move infomodal component after children (for better tab order)

### DIFF
--- a/src/features/amUI/common/PageLayoutWrapper/PageLayoutWrapper.tsx
+++ b/src/features/amUI/common/PageLayoutWrapper/PageLayoutWrapper.tsx
@@ -262,8 +262,8 @@ export const PageLayoutWrapper = ({ children }: PageLayoutWrapperProps): React.R
           },
         }}
       >
-        <InfoModal />
         {children}
+        <InfoModal />
       </Layout>
       <Snackbar />
     </RootProvider>


### PR DESCRIPTION
## Description
- Move `<InfoModal>` component after children, makes tabbing from menu to children feel more natural

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted Info modal render order to improve overlay stacking and focus handling.
  * Resolves cases where the modal could appear behind page content or capture focus unexpectedly.
  * Enhances keyboard navigation and screen-reader focus flow when opening or closing the Info modal.
  * Provides more consistent behavior across pages without altering layout or introducing new features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->