### PR TITLE
fix: remove unused translation strings

### DIFF
--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -614,7 +614,6 @@
     "update_systemuser_error": "Failed to update system access",
     "systemuser_deleted": "System access deleted",
     "save_systemuser": "Save changes",
-    "name_too_long": "Name of system access cannot be longer than 255 characters, you have entered {{ nameLength }} characters.",
     "created_by": "System access created {{created}}",
     "accesspackage_resources_list_singular": "1 service",
     "accesspackage_resources_list_plural": "{{resourcesCount}} services",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -585,7 +585,6 @@
     "confirm_button": "Gå vidare",
     "choose": "Velg ...",
     "load_vendors_error": "Kunne ikkje laste systemleverandørar",
-    "name_too_long": "Namn på systemtilgang kan berre vere 255 teikn, du har skrive inn {{ nameLength }} teikn.",
     "loading_systems": "Lastar leverandørar og system..."
   },
   "systemuser_includedrightspage": {
@@ -611,7 +610,6 @@
     "update_systemuser_error": "Kunne ikkje oppdatere systemtilgang",
     "systemuser_deleted": "Systemtilgang sletta",
     "save_systemuser": "Lagre endringar",
-    "name_too_long": "Namn på systemtilgang kan berre vere 255 teikn, du har skrive inn {{ nameLength }} teikn.",
     "created_by": "Systemtilgang oppretta {{created}}",
     "accesspackage_resources_list_singular": "1 teneste",
     "accesspackage_resources_list_plural": "{{resourcesCount}} tenester",


### PR DESCRIPTION
## Description
- Remove some dead translation strings

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
