### PR TITLE
Change consent menu item label + fix some colors in active consents

### DIFF
--- a/src/features/amUI/consent/ActiveConsentsPage/ActiveConsentsPage.tsx
+++ b/src/features/amUI/consent/ActiveConsentsPage/ActiveConsentsPage.tsx
@@ -116,6 +116,7 @@ export const ActiveConsentsPage = () => {
                   <ConsentListItem
                     key={partyId}
                     title={groupedActiveConsents[partyId][0].toPartyName}
+                    partyType={reportee?.type}
                     subItems={groupedActiveConsents[partyId].map((item) => ({
                       id: item.id,
                       title: item.toPartyName,

--- a/src/features/amUI/consent/ActiveConsentsPage/ConsentListItem.tsx
+++ b/src/features/amUI/consent/ActiveConsentsPage/ConsentListItem.tsx
@@ -9,29 +9,37 @@ import classes from './ActiveConsentsPage.module.css';
 interface ConsentListItemProps {
   title: string;
   subItems: { id: string; title: string; isPoa: boolean }[];
+  partyType?: string;
   isLoading?: boolean;
   onClick?: (consentId: string) => void;
 }
 export const ConsentListItem = ({
   title,
   subItems,
+  partyType,
   isLoading,
   onClick,
 }: ConsentListItemProps): React.ReactNode => {
   const { t } = useTranslation();
 
   const [isExpanded, setIsExpanded] = useState<boolean>(true);
+  const partyColor = partyType === 'Person' ? 'person' : 'company';
+
   return (
     <ListItem
       title={{ as: 'h3', children: title }}
-      icon={{ svgElement: HandshakeIcon, theme: 'surface' }}
+      icon={{
+        svgElement: HandshakeIcon,
+        theme: 'surface',
+        color: partyColor,
+      }}
       as='button'
       size='md'
       loading={isLoading}
       collapsible
       expanded={isExpanded}
       interactive={!!onClick}
-      badge={{ label: subItems.length }}
+      badge={{ label: subItems.length, color: partyColor }}
       onClick={() => setIsExpanded((old) => !old)}
     >
       <List className={classes.expandedListItem}>

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -129,7 +129,7 @@
     "users": "Users",
     "reportees": "Our access to other companies",
     "systemaccess": "API- and system access",
-    "consent": "Consents and powers of attorney",
+    "consent": "Consent and power of attorney agreements",
     "poa_overview": "Power of attorney",
     "settings": "Settings"
   },
@@ -747,7 +747,7 @@
     "already_rejected_poa": "This power of attorney is already rejected"
   },
   "active_consents": {
-    "page_title": "Active consents and powers of attorney - Altinn",
+    "page_title": "Consent and power of attorney agreements - Altinn",
     "heading": "Consents and powers of attorney",
     "sub_heading": "Active agreements",
     "loading_consents": "Loading active agreements...",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -142,7 +142,7 @@
     "users": "Brukere",
     "reportees": "Våre tilganger hos andre",
     "systemaccess": "API- og systemtilganger",
-    "consent": "Samtykker og fullmakter",
+    "consent": "Samtykke- og fullmaktsavtaler",
     "poa_overview": "Fullmakter",
     "settings": "Innstillinger"
   },
@@ -746,7 +746,7 @@
     "already_rejected_poa": "Denne fullmakten er allerede avvist"
   },
   "active_consents": {
-    "page_title": "Aktive samtykker og fullmakter - Altinn",
+    "page_title": "Samtykke- og fullmaktsavtaler - Altinn",
     "heading": "Samtykker og fullmakter",
     "sub_heading": "Aktive avtaler",
     "loading_consents": "Laster aktive avtaler...",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -126,7 +126,7 @@
     "users": "Brukere",
     "reportees": "Våre tilganger hos andre",
     "systemaccess": "API- og systemtilganger",
-    "consent": "Samtykker og fullmakter",
+    "consent": "Samtykke- og fullmaktsavtalar",
     "poa_overview": "Fullmakter",
     "settings": "Innstillingar"
   },
@@ -743,7 +743,7 @@
     "already_rejected_poa": "Denne fullmakten er allereie avvist"
   },
   "active_consents": {
-    "page_title": "Aktive samtykker og fullmakter - Altinn",
+    "page_title": "Samtykke- og fullmaktsavtalar - Altinn",
     "heading": "Samtykker og fullmakter",
     "sub_heading": "Aktive avtalar",
     "loading_consents": "Laster aktive avtalar...",


### PR DESCRIPTION
## Description
- Change consent menu item label after discussion with design
- Change some colors (icon background and badge background) for person on active agreements page

## Related Issue(s)
- this PR

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual indicators to distinguish between individual and company consent holders.

* **Localization Updates**
  * Updated consent and power of attorney agreement labels across English, Norwegian Bokmål, and Norwegian Nynorsk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->