### PR TITLE
Use logout url feature flag for systemuser and consent

### DIFF
--- a/src/features/amUI/common/PageLayoutWrapper/PageLayoutWrapper.tsx
+++ b/src/features/amUI/common/PageLayoutWrapper/PageLayoutWrapper.tsx
@@ -32,17 +32,13 @@ import {
   getAfUrl,
   getAltinnStartPageUrl,
   getHostUrl,
-  getPlatformUrl,
+  getLogoutUrl,
 } from '@/resources/utils/pathUtils';
 import { useIsTabletOrSmaller } from '@/resources/utils/screensizeUtils';
 
 import { SidebarItems } from './SidebarItems';
 import { InfoModal } from './InfoModal';
-import {
-  crossPlatformLinksEnabled,
-  useNewActorList,
-  useNewLogoutUrl,
-} from '@/resources/utils/featureFlagUtils';
+import { crossPlatformLinksEnabled, useNewActorList } from '@/resources/utils/featureFlagUtils';
 import { useAccounts } from './useAccounts';
 
 interface PageLayoutWrapperProps {
@@ -56,7 +52,6 @@ const getAccountType = (type: string): 'company' | 'person' => {
 export const PageLayoutWrapper = ({ children }: PageLayoutWrapperProps): React.ReactNode => {
   const { t, i18n } = useTranslation();
   const useNewActorListFlag = useNewActorList();
-  const useNewLogoutUrlFlag = useNewLogoutUrl();
   const { data: reportee, isLoading: isLoadingReportee } = useGetReporteeQuery();
   const { data: userinfo } = useGetUserInfoQuery();
   const { data: reporteeList } = useGetReporteeListForAuthorizedUserQuery(undefined, {
@@ -223,11 +218,8 @@ export const PageLayoutWrapper = ({ children }: PageLayoutWrapperProps): React.R
     logoutButton: {
       label: t('header.log_out'),
       onClick: async () => {
-        if (useNewLogoutUrlFlag) {
-          (window as Window).location = `${getPlatformUrl()}authentication/api/v1/logout`;
-        } else {
-          (window as Window).location = `${getHostUrl()}ui/Authentication/Logout?languageID=1044`;
-        }
+        const logoutUrl = getLogoutUrl();
+        window.location.assign(logoutUrl);
       },
     },
 

--- a/src/features/amUI/consent/ConsentRequestPage/ConsentRequestPage.tsx
+++ b/src/features/amUI/consent/ConsentRequestPage/ConsentRequestPage.tsx
@@ -19,7 +19,7 @@ import {
   useGetConsentRequestQuery,
   useRejectConsentRequestMutation,
 } from '@/rtk/features/consentApi';
-import { getAltinnStartPageUrl, getHostUrl, getPlatformUrl } from '@/resources/utils/pathUtils';
+import { getAltinnStartPageUrl, getLogoutUrl } from '@/resources/utils/pathUtils';
 import { useGetUserInfoQuery } from '@/rtk/features/userInfoApi';
 
 import type { ConsentLanguage, ConsentRequest, ProblemDetail } from '../types';
@@ -29,13 +29,11 @@ import { ConsentRights } from '../components/ConsentRights/ConsentRights';
 import classes from './ConsentRequestPage.module.css';
 import { ConsentRequestError } from './ConsentRequestError';
 import { ConsentStatus } from '../components/ConsentStatus/ConsentStatus';
-import { useNewLogoutUrl } from '@/resources/utils/featureFlagUtils';
 
 export const ConsentRequestPage = () => {
   const { t, i18n } = useTranslation();
 
   useDocumentTitle(t('consent_request.page_title'));
-  const useNewLogoutUrlFlag = useNewLogoutUrl();
   const [searchParams] = useSearchParams();
   const requestId = searchParams.get('id') ?? '';
   const language = getLanguage(i18n.language);
@@ -104,9 +102,7 @@ export const ConsentRequestPage = () => {
             logoutButton: {
               label: t('header.log_out'),
               onClick: () => {
-                const logoutUrl = useNewLogoutUrlFlag
-                  ? `${getPlatformUrl()}authentication/api/v1/logout`
-                  : `${getHostUrl()}ui/Authentication/Logout?languageID=1044`;
+                const logoutUrl = getLogoutUrl();
                 window.location.assign(logoutUrl);
               },
             },

--- a/src/features/amUI/systemUser/SystemUserAgentRequestPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserAgentRequestPage.tsx
@@ -15,9 +15,10 @@ import { RequestPageBase } from './components/RequestPageBase/RequestPageBase';
 import type { ProblemDetail } from './types';
 import { ButtonRow } from './components/ButtonRow/ButtonRow';
 import { DelegationCheckError } from './components/DelegationCheckError/DelegationCheckError';
-import { getApiBaseUrl, getLogoutUrl } from './urlUtils';
+import { getApiBaseUrl } from './urlUtils';
 import { CreateSystemUserCheck } from './components/CreateSystemUserCheck/CreateSystemUserCheck';
 import { RightsList } from './components/RightsList/RightsList';
+import { getLogoutUrl } from '@/resources/utils/pathUtils';
 
 export const SystemUserAgentRequestPage = () => {
   const { t } = useTranslation();

--- a/src/features/amUI/systemUser/SystemUserChangeRequestPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserChangeRequestPage.tsx
@@ -16,9 +16,10 @@ import type { ProblemDetail, SystemUserAccessPackage } from './types';
 import { RightsList } from './components/RightsList/RightsList';
 import { ButtonRow } from './components/ButtonRow/ButtonRow';
 import { DelegationCheckError } from './components/DelegationCheckError/DelegationCheckError';
-import { getApiBaseUrl, getLogoutUrl } from './urlUtils';
+import { getApiBaseUrl } from './urlUtils';
 import { CreateSystemUserCheck } from './components/CreateSystemUserCheck/CreateSystemUserCheck';
 import type { ServiceResource } from '@/rtk/features/singleRights/singleRightsApi';
+import { getLogoutUrl } from '@/resources/utils/pathUtils';
 
 export const SystemUserChangeRequestPage = () => {
   const { t } = useTranslation();

--- a/src/features/amUI/systemUser/SystemUserRequestPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserRequestPage.tsx
@@ -16,8 +16,9 @@ import type { ProblemDetail } from './types';
 import { RightsList } from './components/RightsList/RightsList';
 import { ButtonRow } from './components/ButtonRow/ButtonRow';
 import { DelegationCheckError } from './components/DelegationCheckError/DelegationCheckError';
-import { getApiBaseUrl, getLogoutUrl } from './urlUtils';
+import { getApiBaseUrl } from './urlUtils';
 import { CreateSystemUserCheck } from './components/CreateSystemUserCheck/CreateSystemUserCheck';
+import { getLogoutUrl } from '@/resources/utils/pathUtils';
 
 export const SystemUserRequestPage = () => {
   const { t } = useTranslation();

--- a/src/features/amUI/systemUser/urlUtils.ts
+++ b/src/features/amUI/systemUser/urlUtils.ts
@@ -1,13 +1,3 @@
-import { useNewLogoutUrl } from '@/resources/utils/featureFlagUtils';
-import { getHostUrl, getPlatformUrl } from '@/resources/utils/pathUtils';
-
-export const getLogoutUrl = (): string => {
-  const useNewLogoutUrlFlag = useNewLogoutUrl();
-  return useNewLogoutUrlFlag
-    ? `${getPlatformUrl()}authentication/api/v1/logout`
-    : `${getHostUrl()}ui/Authentication/Logout?languageID=1044`;
-};
-
 export const getApiBaseUrl = (): string => {
   return `${import.meta.env.BASE_URL}accessmanagement/api/v1/systemuser`;
 };

--- a/src/resources/utils/pathUtils.tsx
+++ b/src/resources/utils/pathUtils.tsx
@@ -1,3 +1,5 @@
+import { useNewLogoutUrl } from './featureFlagUtils';
+
 enum Environment {
   TT02 = 'tt02',
   PROD = 'prod',
@@ -106,4 +108,11 @@ export const getPlatformUrl = () => {
     default:
       return 'https://platform.altinn.no/';
   }
+};
+
+export const getLogoutUrl = (): string => {
+  const useNewLogoutUrlFlag = useNewLogoutUrl();
+  return useNewLogoutUrlFlag
+    ? `${getPlatformUrl()}authentication/api/v1/logout`
+    : `${getHostUrl()}ui/Authentication/Logout?languageID=1044`;
 };


### PR DESCRIPTION
## Description
- Use new logout url feature flag for systemuser and consent logout urls
- Add new utils function for getLogoutUrl, which will read the feature flag

## Related Issue(s)
- this PR

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized logout URL logic into a single utility and updated pages to use it.
  * Simplified logout flow by always delegating to the unified logout URL function.

* **Bug Fixes**
  * Fixed inconsistent logout redirects by ensuring the app computes and navigates to the correct logout URL, respecting the configured rollout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->