### PR TITLE
Systemuser: format org and person display names in system user GUI

### DIFF
--- a/src/features/amUI/systemUser/components/RequestPageBase/RequestPageBase.tsx
+++ b/src/features/amUI/systemUser/components/RequestPageBase/RequestPageBase.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { DsHeading, DsParagraph } from '@altinn/altinn-components';
+import { DsHeading, DsParagraph, formatDisplayName } from '@altinn/altinn-components';
 
 import AltinnLogo from '@/assets/AltinnTextLogo.svg?react';
 import { useGetUserInfoQuery } from '@/rtk/features/userInfoApi';
@@ -33,7 +33,7 @@ export const RequestPageBase = ({
           <AltinnLogo />
           {userData && (
             <div>
-              <div>{userData?.name}</div>
+              <div>{formatDisplayName({ fullName: userData?.name, type: 'person' })}</div>
               <div>for {reporteeName}</div>
             </div>
           )}


### PR DESCRIPTION
## Description
- Call `formatDisplayName` from altinn-components to format person and org names in systemuser GUI

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/1627

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Standardized the display formatting of names and company information across system pages and data listings to ensure consistent presentation throughout the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->