### PR TITLE
Remove specialized sizing and hide search fields for empty lists

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "vitest:ci": "vitest --coverage"
   },
   "dependencies": {
-    "@altinn/altinn-components": "0.45.4",
+    "@altinn/altinn-components": "0.46.1",
     "@navikt/aksel-icons": "^7.12.2",
     "@reduxjs/toolkit": "^2.8.2",
     "@tanstack/react-query": "^5.85.5",

--- a/src/features/amUI/userRightsPage/AccessPackageSection/AccessPackageSection.tsx
+++ b/src/features/amUI/userRightsPage/AccessPackageSection/AccessPackageSection.tsx
@@ -89,27 +89,29 @@ export const AccessPackageSection = () => {
             </DsPopover.TriggerContext>
           </div>
           <div className={classes.inputs}>
-            <div className={classes.searchField}>
-              <DsSearch data-size='sm'>
-                <DsSearch.Input
-                  aria-label={t('access_packages.search_label')}
-                  placeholder={t('access_packages.search_label')}
-                  value={searchString}
-                  onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                    const value = event.target.value;
-                    setSearchString(value);
-                    debouncedUpdate(value);
-                  }}
-                />
-                <DsSearch.Clear
-                  onClick={() => {
-                    debouncedUpdate.cancel();
-                    setSearchString('');
-                    setDebouncedSearchString('');
-                  }}
-                />
-              </DsSearch>
-            </div>
+            {numberOfAccesses > 0 && (
+              <div className={classes.searchField}>
+                <DsSearch data-size='sm'>
+                  <DsSearch.Input
+                    aria-label={t('access_packages.search_label')}
+                    placeholder={t('access_packages.search_label')}
+                    value={searchString}
+                    onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                      const value = event.target.value;
+                      setSearchString(value);
+                      debouncedUpdate(value);
+                    }}
+                  />
+                  <DsSearch.Clear
+                    onClick={() => {
+                      debouncedUpdate.cancel();
+                      setSearchString('');
+                      setDebouncedSearchString('');
+                    }}
+                  />
+                </DsSearch>
+              </div>
+            )}
             <div className={classes.delegateButton}>
               {(toParty?.partyTypeName === PartyType.Organization ||
                 !displayLimitedPreviewLaunch) && (

--- a/src/features/amUI/users/UsersList.tsx
+++ b/src/features/amUI/users/UsersList.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useNavigate } from 'react-router';
-import { DsHeading, DsSearch } from '@altinn/altinn-components';
+import { DsHeading, DsParagraph, DsSearch } from '@altinn/altinn-components';
 
 import type { User } from '@/rtk/features/userInfoApi';
 import { useGetIsAdminQuery, useGetUserInfoQuery } from '@/rtk/features/userInfoApi';
@@ -97,40 +97,48 @@ export const UsersList = () => {
               )
             }
           />
-          <DsHeading
-            level={2}
-            data-size='sm'
-            id='user_list_heading_id'
-            className={classes.usersListHeading}
-          >
-            {t('users_page.user_list_heading')}
-          </DsHeading>
+          {isAdmin && (
+            <DsHeading
+              level={2}
+              data-size='sm'
+              id='user_list_heading_id'
+              className={classes.usersListHeading}
+            >
+              {t('users_page.user_list_heading')}
+            </DsHeading>
+          )}
         </>
       )}
-      <div className={classes.searchAndAddUser}>
-        <DsSearch className={classes.searchBar}>
-          <DsSearch.Input
-            aria-label={t('users_page.user_search_placeholder')}
-            placeholder={t('users_page.user_search_placeholder')}
-            onChange={(event: React.ChangeEvent<HTMLInputElement>) => onSearch(event.target.value)}
+      {isAdmin ? (
+        <>
+          <div className={classes.searchAndAddUser}>
+            <DsSearch className={classes.searchBar}>
+              <DsSearch.Input
+                aria-label={t('users_page.user_search_placeholder')}
+                placeholder={t('users_page.user_search_placeholder')}
+                onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+                  onSearch(event.target.value)
+                }
+              />
+              <DsSearch.Clear
+                onClick={() => {
+                  setSearchString('');
+                }}
+              />
+            </DsSearch>
+            {isAdmin && <NewUserButton onComplete={handleNewUser} />}
+          </div>
+          <UserList
+            connections={userList ?? undefined}
+            searchString={searchString}
+            isLoading={!userList || loadingRightHolders || loadingPartyRepresentation}
+            listItemTitleAs='h2'
+            interactive={isAdmin}
+            onAddNewUser={handleNewUser}
           />
-          <DsSearch.Clear
-            onClick={() => {
-              setSearchString('');
-            }}
-          />
-        </DsSearch>
-        {isAdmin && <NewUserButton onComplete={handleNewUser} />}
-      </div>
-      {isAdmin && (
-        <UserList
-          connections={userList ?? undefined}
-          searchString={searchString}
-          isLoading={!userList || loadingRightHolders || loadingPartyRepresentation}
-          listItemTitleAs='h2'
-          interactive={isAdmin}
-          onAddNewUser={handleNewUser}
-        />
+        </>
+      ) : (
+        <DsParagraph>{t('users_page.no_access_to_users_message')}</DsParagraph>
       )}
     </div>
   );

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -331,7 +331,8 @@
     "only_you_have_access": "Only you have access here. Do you want to change this?",
     "user_no_search_result": "No matches for the search \"{{searchTerm}}\".",
     "user_no_search_result_with_add_suggestion": "No matches for the search \"{{searchTerm}}\". Is this someone you want to give access to?",
-    "indirect_connections": "Users without power of attorney"
+    "indirect_connections": "Users without power of attorney",
+    "no_access_to_users_message": "Only access managers can see the full list of users with powers of attorney in the organization."
   },
   "advanced_user_search": {
     "add_user_button": "Add user",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -330,7 +330,8 @@
     "only_you_have_access": "Ingen andre enn deg har fullmakt. Ønsker du å endre dette?",
     "user_no_search_result": "Ingen treff på søket \"{{searchTerm}}\".",
     "user_no_search_result_with_add_suggestion": "Ingen treff på søket \"{{searchTerm}}\". Er dette en ny bruker du ønsker å gi fullmakt til?",
-    "indirect_connections": "Brukere uten fullmakt"
+    "indirect_connections": "Brukere uten fullmakt",
+    "no_access_to_users_message": "Kun tilgangsstyrerere kan se full liste av brukere med fullmakter i virksomheten."
   },
   "advanced_user_search": {
     "add_user_button": "Ny bruker",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -327,7 +327,8 @@
     "only_you_have_access": "Ingen andre enn deg har fullmakt. Ønskjer du å endre dette?",
     "user_no_search_result": "Ingen treff på søket \"{{searchTerm}}\".",
     "user_no_search_result_with_add_suggestion": "Ingen treff på søket \"{{searchTerm}}\". Er dette ein ny brukar du ønsker å gi fullmakt til?",
-    "indirect_connections": "Brukarar utan fullmakt"
+    "indirect_connections": "Brukarar utan fullmakt",
+    "no_access_to_users_message": "Kun tilgangsstyrarar kan se full liste av brukarar med fullmakter i virksemden."
   },
   "advanced_user_search": {
     "add_user_button": "Ny brukar",

--- a/src/resources/css/Common.module.css
+++ b/src/resources/css/Common.module.css
@@ -2,13 +2,6 @@ body {
   margin: 0;
 }
 
-html {
-  scrollbar-gutter: stable;
-  scrollbar-width: thin;
-  background-color: var(--ds-color-background-subtle);
-  scrollbar-color: var(--ds-color-neutral-border-subtle) rgba(0, 0, 0, 0);
-}
-
 :root {
   font-family: 'Inter', sans-serif;
   --backgroundColorA2: #1eadf7;
@@ -46,23 +39,10 @@ html {
 
   /* Overide tokens from designSystem & altinn-components */
   --ds-color-neutral-surface-default: #fff;
-  --ds-body-md-font-size: 1rem;
   --ds-color-text-subtle: #10204a;
   --ds-link-color-visited: inherit;
 }
 
-/* Overide ds tokens for mobile screens */
-@media screen and (max-width: 768px) {
-  :root {
-    --ds-heading-2xl-font-size: 3.25rem;
-    --ds-heading-xl-font-size: 2.75rem;
-    --ds-heading-lg-font-size: 2rem;
-    --ds-heading-md-font-size: 1.5rem;
-    --ds-heading-sm-font-size: 1.25rem;
-    --ds-heading-xs-font-size: 1.2rem;
-    --ds-heading-2xs-font-size: 1.1rem;
-  }
-}
 body {
   margin: 0;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,9 +19,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@altinn/altinn-components@npm:0.45.4":
-  version: 0.45.4
-  resolution: "@altinn/altinn-components@npm:0.45.4"
+"@altinn/altinn-components@npm:0.46.1":
+  version: 0.46.1
+  resolution: "@altinn/altinn-components@npm:0.46.1"
   dependencies:
     "@digdir/designsystemet-css": "npm:^1.0.6"
     "@digdir/designsystemet-react": "npm:^1.0.6"
@@ -34,7 +34,7 @@ __metadata:
   peerDependencies:
     react: ">=18.3.1 || ^19.0.0"
     react-dom: ">=18.3.1 || ^19.0.0"
-  checksum: 10/089bf41ba7ecab74b181ed9f1537118d248acc4a695e8c3594ce98d80d3890991e7d24eeac6db1c7907962e7a3146d10534e8a993ae408f1e2af48ec9873701b
+  checksum: 10/fe8e8c2bfa6297ad0a0ffb2e66038f61e577fc64d18863d3a658c43575154ce43c119412c38518fbe967057da4dcc54e7b8794f08f831c6cac8d41778aa086ef
   languageName: node
   linkType: hard
 
@@ -3373,7 +3373,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "access-management@workspace:."
   dependencies:
-    "@altinn/altinn-components": "npm:0.45.4"
+    "@altinn/altinn-components": "npm:0.46.1"
     "@axe-core/playwright": "npm:^4.10.2"
     "@navikt/aksel-icons": "npm:^7.12.2"
     "@playwright/test": "npm:^1.55.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<img width="1490" height="691" alt="image" src="https://github.com/user-attachments/assets/4ad69980-c5d4-48f7-8024-91c0d2279338" />

## Description
<!--- Describe your changes in detail -->
This PR removes css overrides that made our text and components appear smaller than in InfoPortal and Inbox. With these gone, the header now looks identical across the solutions.

In addition to this, the PR hides unnecessary search fields on the Users page (for when the logged-in user is not an admin) and on a specific users page (when the list of access packages they have access to is empty). This will hopefully cause less confusion about what these search bars are for.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved access control for user management—search and add user functions now restricted to administrators only.
  * Search field in access list now displays only when items are available.

* **Localization**
  * Added user-facing message for non-administrators indicating access restrictions.

* **Style**
  * Removed scrollbar and mobile font styling overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->