### PR TITLE
fix: use feature toggle for requests page on landing page

### DIFF
--- a/src/features/amUI/landingPage/LandingPage.tsx
+++ b/src/features/amUI/landingPage/LandingPage.tsx
@@ -144,7 +144,7 @@ export const LandingPage = () => {
 
   const getOtherItems = (): MenuItemProps[] => {
     const displaySettingsPage = window.featureFlags?.displaySettingsPage;
-    const displayRequestsPage = true;
+    const displayRequestsPage = window.featureFlags?.displayRequestsPage;
     const requestCount = 0;
     const items: MenuItemProps[] = [];
 


### PR DESCRIPTION
## Description
- Read value of `displayRequestsPage` feature toggle in landing page

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated landing page configuration to conditionally display the Requests item based on feature flag settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->