### PR TITLE
Add language to Altinn start page URLs

### DIFF
--- a/src/resources/utils/pathUtils.tsx
+++ b/src/resources/utils/pathUtils.tsx
@@ -41,19 +41,19 @@ export const getAltinnStartPageUrl = () => {
 
   switch (env) {
     case Environment.TT02:
-      return `https://info.tt02.altinn.no/${langKey}`;
+      return `https://info.tt02.altinn.no/${langKey}/`;
     case Environment.AT21:
-      return `https://info.at21.altinn.cloud/${langKey}`;
+      return `https://info.at21.altinn.cloud/${langKey}/`;
     case Environment.AT22:
-      return `https://info.at22.altinn.cloud/${langKey}`;
+      return `https://info.at22.altinn.cloud/${langKey}/`;
     case Environment.AT23:
-      return `https://info.at23.altinn.cloud/${langKey}`;
+      return `https://info.at23.altinn.cloud/${langKey}/`;
     case Environment.AT24:
-      return `https://info.at24.altinn.cloud/${langKey}`;
+      return `https://info.at24.altinn.cloud/${langKey}/`;
     case Environment.PROD:
-      return `https://info.altinn.no/${langKey}`;
+      return `https://info.altinn.no/${langKey}/`;
     default:
-      return `https://info.altinn.no/${langKey}`;
+      return `https://info.altinn.no/${langKey}/`;
   }
 };
 


### PR DESCRIPTION
The getAltinnStartPageUrl function now appends a language key to the URL based on the 'selectedLanguage' cookie. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Start page URLs now include a language-specific segment based on your stored language preference (supports English, Norwegian Nynorsk, and default Norwegian).

* **Chores**
  * Expanded environment support so start page links behave correctly across additional deployment hosts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->