### PR TITLE
Add onchange-update to Altinn start page URLs

### DIFF
--- a/src/features/amUI/common/PageLayoutWrapper/useFooter.tsx
+++ b/src/features/amUI/common/PageLayoutWrapper/useFooter.tsx
@@ -1,20 +1,19 @@
 import { getAltinnStartPageUrl } from '@/resources/utils/pathUtils';
 import { useTranslation } from 'react-i18next';
 
-const infoPortalUrl = getAltinnStartPageUrl();
-
-const footerLinks = [
-  { href: infoPortalUrl + 'hjelp/', resourceId: 'footer.help' },
-  {
-    href: infoPortalUrl + 'om-altinn/',
-    resourceId: 'footer.about_altinn',
-  },
-  { href: infoPortalUrl + 'om-altinn/personvern/', resourceId: 'footer.privacy_policy' },
-  { href: infoPortalUrl + 'om-altinn/tilgjengelighet/', resourceId: 'footer.accessibility' },
-];
-
 export const useFooter = () => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const infoPortalUrl = getAltinnStartPageUrl(i18n.language);
+
+  const footerLinks = [
+    { href: infoPortalUrl + 'hjelp/', resourceId: 'footer.help' },
+    {
+      href: infoPortalUrl + 'om-altinn/',
+      resourceId: 'footer.about_altinn',
+    },
+    { href: infoPortalUrl + 'om-altinn/personvern/', resourceId: 'footer.privacy_policy' },
+    { href: infoPortalUrl + 'om-altinn/tilgjengelighet/', resourceId: 'footer.accessibility' },
+  ];
 
   const footer = {
     address: t('common.digdir') + ',',

--- a/src/features/amUI/common/PageLayoutWrapper/useHeader.tsx
+++ b/src/features/amUI/common/PageLayoutWrapper/useHeader.tsx
@@ -5,13 +5,11 @@ import { AccountSelectorProps } from '@altinn/altinn-components/dist/types/lib/c
 import { GlobalSearchProps } from '@altinn/altinn-components/dist/types/lib/components/GlobalHeader/GlobalSearch';
 import { useGlobalMenu } from './useGlobalMenu';
 import { useTranslation } from 'react-i18next';
-import { useNewActorList, useNewHeader } from '@/resources/utils/featureFlagUtils';
-import { useIsTabletOrSmaller } from '@/resources/utils/screensizeUtils';
+import { useNewHeader } from '@/resources/utils/featureFlagUtils';
 import {
   useGetReporteeQuery,
   useGetUserInfoQuery,
   useGetReporteeListForAuthorizedUserQuery,
-  useGetActorListForAuthorizedUserQuery,
   useGetFavoriteActorUuidsQuery,
   useAddFavoriteActorUuidMutation,
   useRemoveFavoriteActorUuidMutation,
@@ -111,7 +109,7 @@ export const useHeader = () => {
         ],
         onSelect: onChangeLocale,
       },
-      logo: { href: getAltinnStartPageUrl(), title: 'Altinn' },
+      logo: { href: getAltinnStartPageUrl(i18n.language), title: 'Altinn' },
       globalMenu: globalMenu,
       desktopMenu: desktopMenu,
       mobileMenu: mobileMenu,
@@ -164,7 +162,7 @@ export const useHeader = () => {
         ],
         onSelect: onChangeLocale,
       },
-      logo: { href: getAltinnStartPageUrl(), title: 'Altinn' },
+      logo: { href: getAltinnStartPageUrl(i18n.language), title: 'Altinn' },
       currentAccount: {
         name: currentAccountName,
         type: getAccountType(reportee?.type ?? ''),

--- a/src/features/amUI/consent/ConsentRequestPage/ConsentRequestPage.tsx
+++ b/src/features/amUI/consent/ConsentRequestPage/ConsentRequestPage.tsx
@@ -94,7 +94,7 @@ export const ConsentRequestPage = () => {
             onSelect: onChangeLocale,
           },
           logo: {
-            href: getAltinnStartPageUrl(),
+            href: getAltinnStartPageUrl(i18n.language),
             title: 'Altinn',
           },
           currentAccount: {

--- a/src/resources/utils/pathUtils.tsx
+++ b/src/resources/utils/pathUtils.tsx
@@ -33,27 +33,26 @@ export const getEnv = () => {
   return Environment.PROD;
 };
 
-export const getAltinnStartPageUrl = () => {
+export const getAltinnStartPageUrl = (languageOverride?: string) => {
   const env = getEnv();
-
-  const lang = getCookie('selectedLanguage') || 'nb';
-  const langKey = lang === 'en' ? 'en' : lang === 'no_nn' ? 'nn' : '';
+  const lang = languageOverride ?? getCookie('selectedLanguage');
+  const langKey = lang === 'en' ? 'en/' : lang === 'no_nn' ? 'nn/' : '';
 
   switch (env) {
     case Environment.TT02:
-      return `https://info.tt02.altinn.no/${langKey}/`;
+      return `https://info.tt02.altinn.no/${langKey}`;
     case Environment.AT21:
-      return `https://info.at21.altinn.cloud/${langKey}/`;
+      return `https://info.at21.altinn.cloud/${langKey}`;
     case Environment.AT22:
-      return `https://info.at22.altinn.cloud/${langKey}/`;
+      return `https://info.at22.altinn.cloud/${langKey}`;
     case Environment.AT23:
-      return `https://info.at23.altinn.cloud/${langKey}/`;
+      return `https://info.at23.altinn.cloud/${langKey}`;
     case Environment.AT24:
-      return `https://info.at24.altinn.cloud/${langKey}/`;
+      return `https://info.at24.altinn.cloud/${langKey}`;
     case Environment.PROD:
-      return `https://info.altinn.no/${langKey}/`;
+      return `https://info.altinn.no/${langKey}`;
     default:
-      return `https://info.altinn.no/${langKey}/`;
+      return `https://info.altinn.no/${langKey}`;
   }
 };
 


### PR DESCRIPTION
Updated getAltinnStartPageUrl to accept an optional language parameter and adjusted its usage in header, footer, and consent request page components. This ensures that links to the Altinn info portal are generated with the correct language context based on the current i18n language.

ref denne: https://digdir.slack.com/archives/C079AN12EV8/p1763374867858369

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Footer links and header logo now dynamically respond to your language selection for a consistent localized experience.
  * Start page URLs are now language-aware, ensuring seamless navigation between localized versions of the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->