### PR TITLE
Set A2 language cookie as not url-ecoded

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/SettingsControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/SettingsControllerTest.cs
@@ -60,7 +60,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             string altinnCookie = cookieHeaders.FirstOrDefault(cookie => cookie.StartsWith("altinnPersistentContext=", StringComparison.OrdinalIgnoreCase));
             Assert.NotNull(altinnCookie);
             SetCookieHeaderValue parsedCookie = SetCookieHeaderValue.Parse(altinnCookie!);
-            string cookieValue = Uri.UnescapeDataString(parsedCookie.Value.ToString());
+            string cookieValue = parsedCookie.Value.ToString();
             Assert.Equal(expectedCookieValue, cookieValue);
             Assert.Equal("/", parsedCookie.Path.ToString());
             Assert.True(parsedCookie.HttpOnly);

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/SettingsController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/SettingsController.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.Options;
+using Microsoft.Net.Http.Headers;
 
 namespace Altinn.AccessManagement.UI.Controllers
 {
@@ -70,7 +71,7 @@ namespace Altinn.AccessManagement.UI.Controllers
                 return BadRequest("Unsupported language code.");
             }
 
-            CookieOptions cookieOptions = new CookieOptions
+            SetCookieHeaderValue cookie = new SetCookieHeaderValue("altinnPersistentContext", altinnStandardLanguage)
             {
                 Expires = DateTimeOffset.UtcNow.AddDays(1),
                 HttpOnly = true,
@@ -80,13 +81,10 @@ namespace Altinn.AccessManagement.UI.Controllers
 
             if (!string.IsNullOrWhiteSpace(_generalSettings?.Hostname))
             {
-                cookieOptions.Domain = _generalSettings.Hostname;
+                cookie.Domain = _generalSettings.Hostname;
             }
 
-            Response.Cookies.Append(
-                "altinnPersistentContext",
-                altinnStandardLanguage,
-                cookieOptions);
+            Response.Headers.Append(HeaderNames.SetCookie, cookie.ToString());
 
             return Ok();
         }


### PR DESCRIPTION
This PR changes the language-cookie to set the selected language, not URL-encoded. 

## Related Issue(s)
https://github.com/Altinn/altinn-tests/issues/223

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated cookie management implementation for improved handling.

* **Tests**
  * Modified cookie value handling in test assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->