### PR TITLE
fix: show spesific avatar and description for subunits on landing page

### DIFF
--- a/src/features/amUI/landingPage/LandingPage.tsx
+++ b/src/features/amUI/landingPage/LandingPage.tsx
@@ -171,7 +171,7 @@ export const LandingPage = () => {
     if (reportee?.type === 'Organization') {
       const orgNrString = `${t('common.org_nr')} ${reportee?.organizationNumber?.match(/.{1,3}/g)?.join(' ') || ''}`;
       if (isSubunit) {
-        return `↳ ${t('common.org_nr')} ${orgNrString}, ${t('common.subunit').toLowerCase()}`;
+        return `↳ ${orgNrString}, ${t('common.subunit').toLowerCase()}`;
       }
       return orgNrString;
     }


### PR DESCRIPTION
## Description
- Show subunit avatar and description for subunit on landing page
<img width="758" height="110" alt="image" src="https://github.com/user-attachments/assets/26c40750-4d10-4f3e-89f0-1c5d5714317e" />


## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/1787

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced reportee list item display logic to more accurately reflect organizational hierarchy and reportee information. List items now display appropriate icons and descriptions based on reportee type—organization numbers with subunit indicators for organizations, and formatted dates for other reportee types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->