### PR TITLE
Use DsButton for better disable state in Package modal

### DIFF
--- a/src/features/amUI/common/AccessPackageList/PackageIsPartiallyDeletableAlert/PackageIsPartiallyDeletableAlert.tsx
+++ b/src/features/amUI/common/AccessPackageList/PackageIsPartiallyDeletableAlert/PackageIsPartiallyDeletableAlert.tsx
@@ -1,5 +1,5 @@
-import type { ButtonProps } from '@altinn/altinn-components';
-import { Button, DsDialog, DsHeading, DsParagraph } from '@altinn/altinn-components';
+import type { DsButtonProps } from '@altinn/altinn-components';
+import { DsButton, DsDialog, DsHeading, DsParagraph } from '@altinn/altinn-components';
 import { t } from 'i18next';
 import { Trans } from 'react-i18next';
 import { useState } from 'react';
@@ -10,7 +10,7 @@ import classes from './PackageIsPartiallyDeletableAlert.module.css';
 
 interface PackageIsPartiallyDeletableAlertProps {
   confirmAction: () => void;
-  triggerButtonProps: ButtonProps;
+  triggerButtonProps: DsButtonProps;
 }
 
 export const PackageIsPartiallyDeletableAlert = ({
@@ -21,12 +21,12 @@ export const PackageIsPartiallyDeletableAlert = ({
   const [open, setOpen] = useState(false);
   return (
     <>
-      <Button
+      <DsButton
         {...triggerButtonProps}
         onClick={() => setOpen(!open)}
       >
         {t('common.delete_poa')}
-      </Button>
+      </DsButton>
       <DsDialog
         open={open}
         closedby='any'
@@ -47,19 +47,19 @@ export const PackageIsPartiallyDeletableAlert = ({
             />
           </div>
           <div className={classes.buttons}>
-            <Button
-              color='danger'
+            <DsButton
+              data-color='danger'
               onClick={confirmAction}
             >
               {t('common.delete')}
-            </Button>
-            <Button
-              color='neutral'
-              variant='text'
+            </DsButton>
+            <DsButton
+              data-color='neutral'
+              variant='tertiary'
               onClick={() => setOpen(false)}
             >
               {t('common.cancel')}
-            </Button>
+            </DsButton>
           </div>
         </div>
       </DsDialog>

--- a/src/features/amUI/common/DelegationModal/AccessPackages/AccessPackageInfo.tsx
+++ b/src/features/amUI/common/DelegationModal/AccessPackages/AccessPackageInfo.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { List, Button, Icon, DsAlert, DsHeading, DsParagraph } from '@altinn/altinn-components';
+import { List, Icon, DsAlert, DsHeading, DsParagraph, DsButton } from '@altinn/altinn-components';
 import { useTranslation } from 'react-i18next';
 import { PackageIcon } from '@navikt/aksel-icons';
 import { useAccessPackageDelegationCheck } from '../../DelegationCheck/AccessPackageDelegationCheckContext';
@@ -188,34 +188,36 @@ export const AccessPackageInfo = ({ accessPackage, availableActions = [] }: Pack
           <div className={classes.actions}>
             {userHasPackage && availableActions.includes(DelegationAction.REVOKE) ? (
               deletableStatus !== DeletableStatus.PartiallyDeletable ? (
-                <Button
+                <DsButton
                   disabled={accessIsInherited || accessPackage.isAssignable === false}
                   onClick={() => onRevoke(accessPackage)}
-                  color='danger'
+                  data-color='danger'
                 >
                   {t('common.delete_poa')}
-                </Button>
+                </DsButton>
               ) : (
                 <PackageIsPartiallyDeletableAlert
                   confirmAction={() => onRevoke(accessPackage)}
                   triggerButtonProps={{
-                    variant: 'solid',
+                    variant: 'primary',
                   }}
                 />
               )
             ) : null}
             {!userHasPackage && availableActions.includes(DelegationAction.DELEGATE) && (
-              <Button
+              <DsButton
                 disabled={accessPackage.isAssignable === false || canDelegate?.result === false}
                 onClick={() => onDelegate(accessPackage)}
               >
                 {t('common.give_poa')}
-              </Button>
+              </DsButton>
             )}
             {!userHasPackage &&
               availableActions.includes(DelegationAction.REQUEST) &&
               // Todo: Implement request access package
-              displayAccessRequestFeature && <Button disabled>{t('common.request_poa')}</Button>}
+              displayAccessRequestFeature && (
+                <DsButton disabled>{t('common.request_poa')}</DsButton>
+              )}
           </div>
         </>
       )}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<img width="1169" height="513" alt="image" src="https://github.com/user-attachments/assets/7327f20f-8ca7-4e91-9809-b3cc1ebfcd63" />


## Description
The disabled state of the altinn-components button is not clearly disabled visually. Use the design system component instead.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated button components across access package management dialogs and modals
  * Adjusted button styling for various actions including package revocation, delegation, and request operations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->