### PR TITLE
Display single rights page with disclaimer text when feature flag is off

### DIFF
--- a/src/features/amUI/common/RightsTabs/RightsTabs.tsx
+++ b/src/features/amUI/common/RightsTabs/RightsTabs.tsx
@@ -20,7 +20,7 @@ export const RightsTabs = ({
   const { t } = useTranslation();
   const [chosenTab, setChosenTab] = useState('packages');
 
-  const { displayResourceDelegation, displayRoles } = window.featureFlags;
+  const { displayRoles } = window.featureFlags;
 
   return (
     <DsTabs
@@ -41,7 +41,7 @@ export const RightsTabs = ({
           )}
           {t('user_rights_page.access_packages_title')}
         </DsTabs.Tab>
-        {displayResourceDelegation && singleRightsPanel && (
+        {singleRightsPanel && (
           <DsTabs.Tab value='singleRights'>
             {tabBadge && (
               <DsBadge
@@ -74,7 +74,7 @@ export const RightsTabs = ({
       >
         {packagesPanel}
       </DsTabs.Panel>
-      {displayResourceDelegation && singleRightsPanel && (
+      {singleRightsPanel && (
         <DsTabs.Panel
           className={classes.tabContent}
           value='singleRights'

--- a/src/features/amUI/reporteeRightsPage/ReporteeRightsPage.tsx
+++ b/src/features/amUI/reporteeRightsPage/ReporteeRightsPage.tsx
@@ -24,6 +24,7 @@ import { ReporteeRoleSection } from './ReporteeRoleSection';
 import { Breadcrumbs } from '../common/Breadcrumbs/Breadcrumbs';
 import { formatDisplayName } from '@altinn/altinn-components';
 import { PartyType } from '@/rtk/features/userInfoApi';
+import { SingleRightsSection } from '../userRightsPage/SingleRightsSection/SingleRightsSection';
 
 export const ReporteeRightsPage = () => {
   const { t } = useTranslation();
@@ -56,7 +57,7 @@ export const ReporteeRightsPage = () => {
               />
               <RightsTabs
                 packagesPanel={<ReporteeAccessPackageSection />}
-                singleRightsPanel={<div>SingleRightsSection</div>}
+                singleRightsPanel={<SingleRightsSection />}
                 roleAssignmentsPanel={<ReporteeRoleSection />}
               />
             </PageContainer>

--- a/src/features/amUI/userRightsPage/SingleRightsSection/SingleRightsSection.module.css
+++ b/src/features/amUI/userRightsPage/SingleRightsSection/SingleRightsSection.module.css
@@ -67,3 +67,9 @@
   display: flex;
   gap: 1rem;
 }
+
+.wipMessage {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}

--- a/src/features/amUI/userRightsPage/SingleRightsSection/SingleRightsSection.tsx
+++ b/src/features/amUI/userRightsPage/SingleRightsSection/SingleRightsSection.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams } from 'react-router';
-import { DsHeading } from '@altinn/altinn-components';
+import { Link, useParams } from 'react-router';
+import { DsHeading, DsLink, DsParagraph } from '@altinn/altinn-components';
 
 import { useGetSingleRightsForRightholderQuery } from '@/rtk/features/singleRights/singleRightsApi';
 import { getCookie } from '@/resources/Cookie/CookieMethods';
@@ -14,6 +14,7 @@ import { usePartyRepresentation } from '../../common/PartyRepresentationContext/
 
 import classes from './SingleRightsSection.module.css';
 import SingleRightItem from './SingleRightItem';
+import { getRedirectToA2UsersListSectionUrl } from '@/resources/utils';
 
 export const SingleRightsSection = () => {
   const { t } = useTranslation();
@@ -28,8 +29,32 @@ export const SingleRightsSection = () => {
     userId: id || '',
   });
 
-  const { toParty } = usePartyRepresentation();
+  const { toParty, fromParty, actingParty } = usePartyRepresentation();
   const { paginatedData, totalPages, currentPage, goToPage } = usePagination(singleRights ?? [], 5);
+
+  const { displayResourceDelegation } = window.featureFlags;
+  const sectionId = fromParty?.partyUuid === actingParty?.partyUuid ? 9 : 8; // Section for "Users (A2)" in Profile is 9, for "Accesses for others (A2)" it is 8
+  const A2url = getRedirectToA2UsersListSectionUrl(sectionId);
+
+  if (!displayResourceDelegation) {
+    return (
+      <div className={classes.singleRightsSectionContainer}>
+        <DsHeading
+          level={2}
+          data-size='xs'
+          id='single_rights_title'
+        >
+          {t('single_rights.wip_title')}
+        </DsHeading>
+        <div className={classes.wipMessage}>
+          <DsParagraph>{t('single_rights.wip_message')}</DsParagraph>
+          <DsLink asChild>
+            <Link to={A2url}>{t('single_rights.wip_link_text')}</Link>
+          </DsLink>
+        </div>
+      </div>
+    );
+  }
 
   return (
     toParty && (

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -289,7 +289,10 @@
     "give_new_single_right": "Give power of attorney to new service",
     "current_services_title": "Power of attorney to {{count}} services",
     "delete_singleRight_success_message": "Deleted access to ",
-    "delete_singleRight_error_message": "Failed to delete access to "
+    "delete_singleRight_error_message": "Failed to delete access to ",
+    "wip_title": "Power of attorney to services",
+    "wip_message": "We are still working on this page! To manage services, please go to the old solution.",
+    "wip_link_text": "Go to old solution"
   },
   "access_packages": {
     "helptext_button": "What are access packages?",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -288,7 +288,10 @@
     "give_new_single_right": "Gi fullmakt",
     "current_services_title": "Fullmakt til {{count}} tjenester",
     "delete_singleRight_success_message": "Slettet tilgang til ",
-    "delete_singleRight_error_message": "Kunne ikke slette tilgang til "
+    "delete_singleRight_error_message": "Kunne ikke slette tilgang til ",
+    "wip_title": "Fullmakter til enkelttjenester",
+    "wip_message": "Denne siden jobber vi fremdeles med! For å administrere enkelttjenester, må du gå til den gamle løsningen.",
+    "wip_link_text": "Gå til gammel løsning"
   },
   "access_packages": {
     "helptext_button": "Hva er tilgangspakker?",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -285,7 +285,10 @@
     "give_new_single_right": "Gi fullmakt til ny teneste",
     "current_services_title": "Fullmakt til {{count}} tenester",
     "delete_singleRight_success_message": "Slettet tilgang til ",
-    "delete_singleRight_error_message": "Kunne ikke slette tilgang til "
+    "delete_singleRight_error_message": "Kunne ikke slette tilgang til ",
+    "wip_title": "Fullmakter til enkelttenester",
+    "wip_message": "Denne sida jobbar vi framleis med! For å administrere enkelttenester, må du gå til den gamle løysinga.",
+    "wip_link_text": "Gå til gammal løsning"
   },
   "access_packages": {
     "helptext_button": "Kva er tilgangspakkar?",


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

<img width="1473" height="691" alt="image" src="https://github.com/user-attachments/assets/5a931420-8489-448b-a581-b2292365463d" />


## Description
<!--- Describe your changes in detail -->

As the title says, we display the tab but with a message explaining that this page isn't ready yet and offer the user a link back to A2

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/1809

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Single rights section now properly displays instead of placeholder content.
  * Added work-in-progress messaging with link to legacy solution when the service delegation feature is unavailable.

* **Chores**
  * Added localization strings in English, Norwegian Bokmål, and Norwegian Nynorsk for new UI messaging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->