### PR TITLE
Handle role metadata errors in user-pages

### DIFF
--- a/src/features/amUI/common/UserPageHeader/UserPageHeader.tsx
+++ b/src/features/amUI/common/UserPageHeader/UserPageHeader.tsx
@@ -14,7 +14,7 @@ import { UserRoles } from '../UserRoles/UserRoles';
 
 import classes from './UserPageHeader.module.css';
 import { UserPageHeaderSkeleton } from './UserPageHeaderSkeleton';
-import { isSubUnit, isSubUnitByType } from '@/resources/utils/reporteeUtils';
+import { isSubUnitByType } from '@/resources/utils/reporteeUtils';
 
 interface UserPageHeaderProps {
   direction: 'to' | 'from';

--- a/src/features/amUI/common/UserRoles/UserRoles.tsx
+++ b/src/features/amUI/common/UserRoles/UserRoles.tsx
@@ -31,7 +31,7 @@ export const UserRoles = ({ className, ...props }: React.HTMLAttributes<HTMLDivE
     permissions,
   });
 
-  const { getRoleMetadata } = useRoleMetadata();
+  const { getRoleMetadata, isError: roleMetadataIsError } = useRoleMetadata();
 
   const roleForModal = selectedRoleId
     ? (getRoleMetadata(selectedRoleId) ??
@@ -48,7 +48,9 @@ export const UserRoles = ({ className, ...props }: React.HTMLAttributes<HTMLDivE
   const onModalClose = () => {
     setSelectedRoleId(null);
   };
-
+  if (!userRoles || roleMetadataIsError) {
+    return null;
+  }
   return (
     <>
       <div

--- a/src/features/amUI/common/UserRoles/useRoleMapper.ts
+++ b/src/features/amUI/common/UserRoles/useRoleMapper.ts
@@ -7,11 +7,15 @@ import { useRoleMetadata } from './useRoleMetadata';
 const ECC_PROVIDER_CODE = 'sys-ccr';
 
 export const useRoleMapper = () => {
-  const { getRoleMetadata, isLoading: loadingRoleMetadata } = useRoleMetadata();
+  const {
+    getRoleMetadata,
+    isLoading: loadingRoleMetadata,
+    isError: roleMetadataIsError,
+  } = useRoleMetadata();
 
   const mapRoles = useCallback(
     (roles?: Connection['roles']) => {
-      if (loadingRoleMetadata) {
+      if (loadingRoleMetadata || roleMetadataIsError) {
         return [];
       }
 
@@ -31,8 +35,8 @@ export const useRoleMapper = () => {
           .filter((role): role is NonNullable<typeof role> => role !== null) ?? []
       );
     },
-    [getRoleMetadata, loadingRoleMetadata],
+    [getRoleMetadata, loadingRoleMetadata, roleMetadataIsError],
   );
 
-  return { mapRoles, loadingRoleMetadata };
+  return { mapRoles, loadingRoleMetadata, roleMetadataIsError };
 };

--- a/src/features/amUI/common/UserRoles/useRoleMetadata.ts
+++ b/src/features/amUI/common/UserRoles/useRoleMetadata.ts
@@ -10,7 +10,12 @@ type RoleMetadataMap = Record<string, Role | undefined>;
  */
 export const useRoleMetadata = () => {
   const { i18n } = useTranslation();
-  const { data: allRoles, isFetching, refetch } = useGetAllRolesQuery({ language: i18n.language });
+  const {
+    data: allRoles,
+    isFetching,
+    isError,
+    refetch,
+  } = useGetAllRolesQuery({ language: i18n.language });
 
   // Refetch when language changes to ensure fresh translated data
   useEffect(() => {
@@ -30,7 +35,7 @@ export const useRoleMetadata = () => {
 
   const getRoleMetadata = useCallback(
     (roleId?: string | null) => {
-      if (!roleId) {
+      if (!roleId || !roleMetadataMap) {
         return undefined;
       }
       return roleMetadataMap[roleId];
@@ -38,5 +43,5 @@ export const useRoleMetadata = () => {
     [roleMetadataMap],
   );
 
-  return { getRoleMetadata, isLoading: isFetching };
+  return { getRoleMetadata, isLoading: isFetching, isError };
 };

--- a/src/features/amUI/userRightsPage/UserRightsPage.tsx
+++ b/src/features/amUI/userRightsPage/UserRightsPage.tsx
@@ -26,12 +26,14 @@ import { useGetPartyFromLoggedInUserQuery } from '@/rtk/features/lookupApi';
 import { UserRightsPageSkeleton } from './UserRightsPageSkeleton';
 import { Breadcrumbs } from '../common/Breadcrumbs/Breadcrumbs';
 import { formatDisplayName } from '@altinn/altinn-components';
+import { useRoleMetadata } from '../common/UserRoles/useRoleMetadata';
 
 export const UserRightsPage = () => {
   const { t } = useTranslation();
   const { id } = useParams();
   const { data: isHovedadmin, isLoading: isHovedadminLoading } = useGetIsHovedadminQuery();
   const { data: currentUser, isLoading: currentUserIsLoading } = useGetPartyFromLoggedInUserQuery();
+  const { isError: roleMetadataIsError } = useRoleMetadata();
 
   const actingPartyUuid =
     !isHovedadminLoading && !isHovedadmin && !currentUserIsLoading && currentUser?.partyUuid === id
@@ -41,6 +43,7 @@ export const UserRightsPage = () => {
   useRerouteIfNotConfetti();
 
   const { displayRoles } = window.featureFlags;
+  const shouldDisplayRoles = displayRoles && !roleMetadataIsError;
 
   return (
     <PageWrapper>
@@ -61,12 +64,12 @@ export const UserRightsPage = () => {
             >
               <UserPageHeader
                 direction='to'
-                displayRoles={displayRoles}
+                displayRoles={shouldDisplayRoles}
               />
               <RightsTabs
                 packagesPanel={<AccessPackageSection />}
                 singleRightsPanel={<SingleRightsSection />}
-                roleAssignmentsPanel={<RoleSection />}
+                roleAssignmentsPanel={shouldDisplayRoles ? <RoleSection /> : null}
               />
             </PageContainer>
           </DelegationModalProvider>


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when role metadata retrieval fails, preventing broken UI display
  * Role sections now gracefully hide during errors instead of showing incomplete data


<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Related gh issue: https://github.com/Altinn/altinn-authorization-tmp/issues/1816