### PR TITLE
Replace yellow warning for persons with text+link

### DIFF
--- a/src/features/amUI/common/NotAvailableForUserTypeAlert/NotAvailableForUserTypeAlert.module.css
+++ b/src/features/amUI/common/NotAvailableForUserTypeAlert/NotAvailableForUserTypeAlert.module.css
@@ -1,0 +1,8 @@
+.notAvailableContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--ds-size-6);
+  margin-top: var(--ds-size-7);
+  max-width: 50rem;
+}

--- a/src/features/amUI/common/NotAvailableForUserTypeAlert/NotAvailableForUserTypeAlert.tsx
+++ b/src/features/amUI/common/NotAvailableForUserTypeAlert/NotAvailableForUserTypeAlert.tsx
@@ -1,11 +1,20 @@
-import { DsAlert, Heading } from '@altinn/altinn-components';
-import { t } from 'i18next';
+import { DsHeading, DsLink, DsParagraph } from '@altinn/altinn-components';
+import { useTranslation } from 'react-i18next';
+import classes from './NotAvailableForUserTypeAlert.module.css';
+import { getHostUrl } from '@/resources/utils/pathUtils';
 
 export const NotAvailableForUserTypeAlert = () => {
+  const { t } = useTranslation();
   return (
-    <DsAlert data-color='warning'>
-      <Heading as='h1'>{t('page_not_available.title')}</Heading>
-      {t('page_not_available.text')}
-    </DsAlert>
+    <div className={classes.notAvailableContainer}>
+      <DsHeading
+        level={1}
+        data-size='sm'
+      >
+        {t('page_not_available.title')}
+      </DsHeading>
+      <DsParagraph>{t('page_not_available.text')}</DsParagraph>
+      <DsLink href={`${getHostUrl()}ui/profile`}>{t('page_not_available.link_text')}</DsLink>
+    </div>
   );
 };

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -677,8 +677,9 @@
     "57_systemuser_failed_to_delete_accesspackage": "Could not delete access package delegation for the system user."
   },
   "page_not_available": {
-    "title": "This page is not available",
-    "text": "The new access management pages are not quite ready for private individuals yet. If you meant to view the accesses for an organization, please switch representation."
+    "title": "Access management for private individuals is still under development",
+    "text": "More content will be added to this page over time. You can still manage access on behalf of yourself as a private individual in the old solution.",
+    "link_text": "Go to old solution"
   },
   "consent_request": {
     "page_title": "Approve consent/power of attorney - Altinn",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -521,7 +521,7 @@
     "oldRolesLinkText": "Gå til gammel løsning",
     "legacyRoleContent": "Denne rollen vil snart fjernes. Bruk heller tilgangspakker."
   },
-"systemuser_overviewpage": {
+  "systemuser_overviewpage": {
     "page_title": "Systemtilganger - Altinn",
     "banner_title": "Systemtilganger",
     "sub_title_text": "Ved å opprette en systemtilgang gir du et fagsystem tilgang til å løse oppgaver i Altinn på vegne av bedriften din.",
@@ -676,8 +676,9 @@
     "57_systemuser_failed_to_delete_accesspackage": "Kunne ikke fjerne tilgangspakke-delegering for systembruker."
   },
   "page_not_available": {
-    "title": "Siden er ikke tilgjengelig",
-    "text": "De nye tilgangsstyringssidene er ikke klare for privatpersoner helt enda. Dersom du mente å se på tilgangene til en virksomhet, vennligst bytt til denne."
+    "title": "Tilgangsstyring for privatpersoner er fortsatt under arbeid",
+    "text": "På denne siden vil det komme mer etterhvert. Du kan fortsatt tilgangsstyre på vegne av deg selv som privatperson i gammel løsning.",
+    "link_text": "Gå til gammel løsning"
   },
   "consent_request": {
     "page_title": "Godkjenn samtykke/fullmakt - Altinn",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -673,8 +673,9 @@
     "57_systemuser_failed_to_delete_accesspackage": "Kunne ikkje fjerne tilgangspakke-delegering for systemtilgangen."
   },
   "page_not_available": {
-    "title": "Sida er ikkje tilgjengeleg",
-    "text": "Dei nye tilgangsstyringssidene er ikkje klare for privatpersonar heilt enno. Dersom du vil sjå tilgangane til ei verksemd, kan du bytte til denne."
+    "title": "Tilgangsstyring for privatpersonar er framleis under arbeid",
+    "text": "På denne sida vil det komme meir etter kvart. Du kan framleis tilgangsstyre på vegne av deg sjølv som privatperson i gammal løysing.",
+    "link_text": "Gå til gammal løysing"
   },
   "consent_request": {
     "page_title": "Godkjenn samtykke/fullmakt - Altinn",


### PR DESCRIPTION
## Description
Replace the warning alert for person with new header, text and link to old solution. Max-width is set to 50rem (instead of 45 rem as per the design sketches) to prevent wrapping the heading in english
<img width="811" height="197" alt="image" src="https://github.com/user-attachments/assets/126f1bbd-fb0f-4186-aacd-dc9f5cbb705e" />


## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/1811

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Redesigned the NotAvailableForUserType alert component with improved layout and messaging structure.
  * Updated messaging to reflect that access management for private individuals is under development, with a link to the legacy solution.
  * Enhanced localization support across English, Norwegian Bokmål, and Norwegian Nynorsk with refined user-facing text and new consent request strings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->