### PR TITLE
temp fix: reverse name order in consent and systemuser request header

### DIFF
--- a/src/features/amUI/consent/ConsentRequestPage/ConsentRequestPage.tsx
+++ b/src/features/amUI/consent/ConsentRequestPage/ConsentRequestPage.tsx
@@ -119,7 +119,11 @@ export const ConsentRequestPage = () => {
               groups: {
                 'current-user': {
                   title: t('header.logged_in_as_name', {
-                    name: formatDisplayName({ fullName: userData?.name || '', type: 'person' }),
+                    name: formatDisplayName({
+                      fullName: userData?.name || '',
+                      type: 'person',
+                      reverseNameOrder: true,
+                    }),
                   }),
                 },
               },

--- a/src/features/amUI/systemUser/components/RequestPageBase/RequestPageBase.tsx
+++ b/src/features/amUI/systemUser/components/RequestPageBase/RequestPageBase.tsx
@@ -34,7 +34,13 @@ export const RequestPageBase = ({
           <AltinnLogo />
           {userData && (
             <div>
-              <div>{formatDisplayName({ fullName: userData?.name, type: 'person' })}</div>
+              <div>
+                {formatDisplayName({
+                  fullName: userData?.name,
+                  type: 'person',
+                  reverseNameOrder: true,
+                })}
+              </div>
               <div>for {reporteeName}</div>
             </div>
           )}


### PR DESCRIPTION
## Description
- Reverse name order in consent and systemuser request header while waiting for the new, request specific header design

## Related Issue(s)
- https://github.com/Altinn/altinn-access-management-frontend/issues/1739

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated user name formatting in request and consent pages to display names in reverse order, affecting how names appear in page headers and menu displays across the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->