### PR TITLE
When authorization times out, redirect to A3 landing page after new login

### DIFF
--- a/src/resources/Token/RefreshToken.tsx
+++ b/src/resources/Token/RefreshToken.tsx
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/no-misused-promises */
 import axios from 'axios';
 import * as React from 'react';
+import { getAmStartPageUrl } from '../utils/pathUtils';
 
 export const RefreshToken = () => {
   const lastRefreshTokenTimestamp = React.useRef(0);
@@ -35,18 +36,14 @@ export const RefreshToken = () => {
     const domainSplitted: string[] = window.location.host.split('.');
     let encodedGoToUrl = '';
     if (domainSplitted.length === 5) {
-      encodedGoToUrl = encodeURIComponent(
-        `https://${domainSplitted[2]}.${domainSplitted[3]}.${domainSplitted[4]}/ui/Profile`,
-      ); // Return user to Profile after login
+      encodedGoToUrl = encodeURIComponent(getAmStartPageUrl()); // Go to landing page after login
       return (
         `https://platform.${domainSplitted[2]}.${domainSplitted[3]}.${domainSplitted[4]}` +
         `/authentication/api/v1/authentication?goto=${encodedGoToUrl}`
       );
     }
     if (domainSplitted.length === 4) {
-      encodedGoToUrl = encodeURIComponent(
-        `https://${domainSplitted[2]}.${domainSplitted[3]}/ui/Profile`,
-      ); // Return user to Profile after login
+      encodedGoToUrl = encodeURIComponent(getAmStartPageUrl()); // Go to landing page after login
       return (
         `https://platform.${domainSplitted[2]}.${domainSplitted[3]}` +
         `/authentication/api/v1/authentication?goto=${encodedGoToUrl}`

--- a/src/resources/utils/pathUtils.tsx
+++ b/src/resources/utils/pathUtils.tsx
@@ -33,6 +33,26 @@ export const getEnv = () => {
   return Environment.PROD;
 };
 
+export const getAmStartPageUrl = () => {
+  const env = getEnv();
+  switch (env) {
+    case Environment.TT02:
+      return 'https://am.ui.tt02.altinn.no/accessmanagement/ui/';
+    case Environment.AT21:
+      return 'https://am.ui.at21.altinn.cloud/accessmanagement/ui/';
+    case Environment.AT22:
+      return 'https://am.ui.at22.altinn.cloud/accessmanagement/ui/';
+    case Environment.AT23:
+      return 'https://am.ui.at23.altinn.cloud/accessmanagement/ui/';
+    case Environment.AT24:
+      return 'https://am.ui.at24.altinn.cloud/accessmanagement/ui/';
+    case Environment.PROD:
+      return 'https://am.ui.altinn.no/accessmanagement/ui/';
+    default:
+      return 'https://am.ui.altinn.no/accessmanagement/ui/';
+  }
+};
+
 export const getAltinnStartPageUrl = (languageOverride?: string) => {
   const env = getEnv();
   const lang = languageOverride ?? getCookie('selectedLanguage');


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
As the title says - before, we redirected to the A2 profile page after re-login, but since A3 is the new main solution, we now redirect to the A3 UI instead.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Updated authentication redirect behavior to use environment-specific landing page URLs instead of hardcoded paths, ensuring users are directed to the correct destination after login across all supported environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->