### PR TITLE
Fix broken help pages link

### DIFF
--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -317,7 +317,7 @@
     "user_has_no_packages": "This user has no access packages.",
     "no_packages": "No access packages available.",
     "no_matching_search": "No matches for your search",
-    "info_alert_text": "Access packages will replace today's Altinn roles. They will be filled with more services over time. Read more on the <a href='https://info.altinn.no/en/help/profile/access-packages/'>help page about access packages</a>.",
+    "info_alert_text": "Access packages will replace today's Altinn roles. They will be filled with more services over time. Read more on the <a href='https://info.altinn.no/en/help/ny-tilgangsstyring/'>help pages</a>.",
     "person_info_alert": "Giving powers of attorney to individuals is currently not supported. This will come later.",
     "delegation_check": {
       "delegation_check_error_heading": "Technical error",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -316,7 +316,7 @@
     "user_has_no_packages": "Denne brukeren har ingen tilgangspakker.",
     "no_packages": "Ingen tilgangspakker er tilgjengelige.",
     "no_matching_search": "Ingen treff på søket",
-    "info_alert_text": "Tilgangspakker skal erstatte dagens Altinn-roller. De vil fylles med flere tjenester etterhvert. Les mer om dette på <a href='https://info.altinn.no/hjelp/profil/tilgangspakker/'>hjelpesiden om tilgangspakker</a>.",
+    "info_alert_text": "Tilgangspakker skal erstatte dagens Altinn-roller. De vil fylles med flere tjenester etterhvert. Les mer om dette på <a href='https://info.altinn.no/hjelp/ny-tilgangsstyring/'>hjelpesidene</a>.",
     "person_info_alert": "Det er ikke mulig å gi og fjerne fullmakter til personer helt enda. Dette vil komme senere.",
     "delegation_check": {
       "delegation_check_error_heading": "Teknisk feil",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -313,7 +313,7 @@
     "user_has_no_packages": "Denne brukeren har ingen tilgangspakkar.",
     "no_packages": "Ingen tilgangspakkar tilgjengelege.",
     "no_matching_search": "Ingen treff på søket",
-    "info_alert_text": "Tilgangspakkar skal erstatte dagens Altinn-roller. Dei vil bli fylt med fleire tenester etter kvart. Les meir om dette på <a href='https://info.altinn.no/nn/hjelp/profil/tilgangspakker/'>hjelpesida om tilgangspakkar</a>.",
+    "info_alert_text": "Tilgangspakkar skal erstatte dagens Altinn-roller. Dei vil bli fylt med fleire tenester etter kvart. Les meir om dette på <a href='https://info.altinn.no/nn/hjelp/ny-tilgangsstyring/'>hjelpesidene</a>.",
     "person_info_alert": "Det er ikkje mogleg å gi og fjerne fullmakter til personar heilt enno. Dette vil komme seinare.",
     "delegation_check": {
       "delegation_check_error_heading": "Teknisk feil",
@@ -760,7 +760,7 @@
   "poa_overview_page": {
     "page_title": "Fullmaktsoversikt - Altinn",
     "heading": "Fullmaktsoversikt for {{name}}"
-  },    
+  },
   "poa_status": {
     "no_permissions": "Du må gi fullmakt"
   },
@@ -772,7 +772,6 @@
     "back_to_overview_link": "Gå tilbake til oversikta",
     "package_delegation_success": "{{name}} har no fått fullmakt til {{accessPackage}}.",
     "package_revocation_success": "{{name}} har ikkje lenger fullmakt til {{accessPackage}}.",
-
     "users_tab": {
       "description": "Søk etter brukarar for å gi eller slette fullmakter.",
       "user_search_placeholder": "Søk etter person eller verksemd",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<img width="1347" height="531" alt="image" src="https://github.com/user-attachments/assets/b2b9018b-3ff3-4e6f-b0c8-0e41f9f587ed" />


## Description
<!--- Describe your changes in detail -->
The previous link went to a page that no longer exists in the new info portal.
Changed this link to the existing AM help pages in accordance with this slack thread: https://digdir.slack.com/archives/C079AN12EV8/p1765444915789309

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated help page links and link text labels in access-related information sections across English, Norwegian Bokmål, and Norwegian Nynorsk versions.

* **New Features**
  * Added delegation check error messages with singular and plural form support in Norwegian language versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->