### PR TITLE
Add interactive to list item on access package page if item can be expanded

### DIFF
--- a/src/features/amUI/common/UserList/UserItem.tsx
+++ b/src/features/amUI/common/UserList/UserItem.tsx
@@ -151,7 +151,7 @@ export const UserItem = ({
       type={type}
       expanded={isExpanded}
       collapsible={!!hasInheritingUsers}
-      interactive={interactive}
+      interactive={!!hasInheritingUsers || interactive}
       shadow={shadow}
       linkIcon={!hasInheritingUsers && !disableLinks}
       onClick={() => {


### PR DESCRIPTION
## Description
- Add interactive to list item on access package page if item can be expanded. Otherwise tabbing to an expandable item shows no focus indicator when expandable list item has focus

## Related Issue(s)
- this PR

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Items containing sub-entities are now properly interactive, enabling user interaction when applicable, while preserving original behavior for items without sub-entities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->