### PR TITLE
fix: use system resource to check if user has permission to create system user

### DIFF
--- a/src/features/amUI/common/PageLayoutWrapper/useSidebarItems.tsx
+++ b/src/features/amUI/common/PageLayoutWrapper/useSidebarItems.tsx
@@ -66,7 +66,7 @@ export const useSidebarItems = ({ isSmall }: { isSmall?: boolean }) => {
   }
 
   if (
-    hasCreateSystemUserPermission(reportee) ||
+    hasCreateSystemUserPermission(reportee, isAdmin) ||
     hasSystemUserClientAdminPermission(reportee, isClientAdmin)
   ) {
     items.push(getSystemUserMenuItem(pathname, isLoading, isSmall));

--- a/src/features/amUI/landingPage/LandingPage.tsx
+++ b/src/features/amUI/landingPage/LandingPage.tsx
@@ -126,7 +126,7 @@ export const LandingPage = () => {
     }
 
     if (
-      hasCreateSystemUserPermission(reportee) ||
+      hasCreateSystemUserPermission(reportee, isAdmin) ||
       hasSystemUserClientAdminPermission(reportee, isClientAdmin)
     ) {
       items.push({

--- a/src/features/amUI/systemUser/CreateSystemUserPage/SelectRegisteredSystem.tsx
+++ b/src/features/amUI/systemUser/CreateSystemUserPage/SelectRegisteredSystem.tsx
@@ -23,6 +23,7 @@ import type { RegisteredSystem } from '../types';
 import { CreateSystemUserCheck } from '../components/CreateSystemUserCheck/CreateSystemUserCheck';
 
 import classes from './CreateSystemUser.module.css';
+import { useGetIsAdminQuery } from '@/rtk/features/userInfoApi';
 
 const isStringMatch = (inputString: string, matchString = ''): boolean => {
   return matchString.toLowerCase().indexOf(inputString.toLowerCase()) >= 0;
@@ -50,6 +51,7 @@ export const SelectRegisteredSystem = ({
     isLoading: isLoadingRegisteredSystems,
     isError: isLoadRegisteredSystemsError,
   } = useGetRegisteredSystemsQuery();
+  const { data: isAdmin } = useGetIsAdminQuery();
 
   const onSelectSystem = (newValue: string[]) => {
     setSelectedSystem(registeredSystems?.find((system) => system.systemId === newValue[0]));
@@ -69,7 +71,10 @@ export const SelectRegisteredSystem = ({
         {isLoadingReportee && (
           <DsSpinner aria-label={t('systemuser_creationpage.loading_systems')} />
         )}
-        <CreateSystemUserCheck reporteeData={reporteeData}>
+        <CreateSystemUserCheck
+          reporteeData={reporteeData}
+          isAdmin={isAdmin}
+        >
           <DsParagraph
             data-size='sm'
             className={classes.systemDescription}

--- a/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPage.tsx
@@ -24,6 +24,7 @@ import { PageContainer } from '../../common/PageContainer/PageContainer';
 import { SystemUserPath } from '@/routes/paths';
 import { hasCreateSystemUserPermission } from '@/resources/utils/permissionUtils';
 import { DeleteSystemUserPopover } from '../components/DeleteSystemUserPopover/DeleteSystemUserPopover';
+import { useGetIsAdminQuery } from '@/rtk/features/userInfoApi';
 
 export const SystemUserAgentDelegationPage = (): React.ReactNode => {
   const { id } = useParams();
@@ -56,6 +57,7 @@ export const SystemUserAgentDelegationPage = (): React.ReactNode => {
     partyUuid,
   });
   const { data: reporteeData } = useGetSystemUserReporteeQuery(partyId);
+  const { data: isAdmin } = useGetIsAdminQuery();
 
   const [deleteAgentSystemUser, { isError: isDeleteError, isLoading: isDeletingSystemUser }] =
     useDeleteAgentSystemuserMutation();
@@ -83,7 +85,7 @@ export const SystemUserAgentDelegationPage = (): React.ReactNode => {
           onNavigateBack={handleNavigateBack}
           pageActions={
             systemUser &&
-            hasCreateSystemUserPermission(reporteeData) && (
+            hasCreateSystemUserPermission(reporteeData, isAdmin) && (
               <DeleteSystemUserPopover
                 integrationTitle={systemUser.integrationTitle}
                 isDeleteError={isDeleteError}

--- a/src/features/amUI/systemUser/SystemUserAgentRequestPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserAgentRequestPage.tsx
@@ -22,6 +22,7 @@ import { SystemUserPath } from '@/routes/paths';
 import { RightsList } from './components/RightsList/RightsList';
 import { getLogoutUrl } from '@/resources/utils/pathUtils';
 import { SystemUserRequestLoadError } from './components/SystemUserRequestLoadError/SystemUserRequestLoadError';
+import { useGetIsAdminQuery } from '@/rtk/features/userInfoApi';
 
 export const SystemUserAgentRequestPage = () => {
   const { t } = useTranslation();
@@ -48,6 +49,7 @@ export const SystemUserAgentRequestPage = () => {
   } = useGetSystemUserReporteeQuery(request?.partyId ?? '', {
     skip: !request?.partyId,
   });
+  const { data: isAdmin } = useGetIsAdminQuery();
 
   const [
     postAcceptCreationRequest,
@@ -167,7 +169,7 @@ export const SystemUserAgentRequestPage = () => {
                 {t('systemuser_request.reject_error')}
               </DsAlert>
             )}
-            {hasCreateSystemUserPermission(reporteeData) && (
+            {hasCreateSystemUserPermission(reporteeData, isAdmin) && (
               <ButtonRow>
                 <DsButton
                   variant='primary'
@@ -191,12 +193,13 @@ export const SystemUserAgentRequestPage = () => {
                 </DsButton>
               </ButtonRow>
             )}
-            {hasCreateSystemUserPermission(reporteeData) === false && request.status === 'New' && (
-              <EscalateRequest
-                request={request}
-                isAgentRequest
-              />
-            )}
+            {hasCreateSystemUserPermission(reporteeData, isAdmin) === false &&
+              request.status === 'New' && (
+                <EscalateRequest
+                  request={request}
+                  isAgentRequest
+                />
+              )}
           </div>
         </>
       )}

--- a/src/features/amUI/systemUser/SystemUserChangeRequestPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserChangeRequestPage.tsx
@@ -21,6 +21,7 @@ import { CreateSystemUserCheck } from './components/CreateSystemUserCheck/Create
 import type { ServiceResource } from '@/rtk/features/singleRights/singleRightsApi';
 import { getLogoutUrl } from '@/resources/utils/pathUtils';
 import { SystemUserRequestLoadError } from './components/SystemUserRequestLoadError/SystemUserRequestLoadError';
+import { useGetIsAdminQuery } from '@/rtk/features/userInfoApi';
 
 export const SystemUserChangeRequestPage = () => {
   const { t } = useTranslation();
@@ -45,6 +46,7 @@ export const SystemUserChangeRequestPage = () => {
   } = useGetSystemUserReporteeQuery(changeRequest?.partyId ?? '', {
     skip: !changeRequest?.partyId,
   });
+  const { data: isAdmin } = useGetIsAdminQuery();
 
   const [
     postAcceptChangeRequest,
@@ -165,7 +167,10 @@ export const SystemUserChangeRequestPage = () => {
                 {t('systemuser_change_request.reject_error')}
               </DsAlert>
             )}
-            <CreateSystemUserCheck reporteeData={reporteeData}>
+            <CreateSystemUserCheck
+              reporteeData={reporteeData}
+              isAdmin={isAdmin}
+            >
               <ButtonRow>
                 <DsButton
                   variant='primary'

--- a/src/features/amUI/systemUser/SystemUserDetailPage/SystemUserDetailsPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserDetailPage/SystemUserDetailsPage.tsx
@@ -22,6 +22,7 @@ import { RightsList } from '../components/RightsList/RightsList';
 import classes from './SystemUserDetailsPage.module.css';
 import { hasCreateSystemUserPermission } from '@/resources/utils/permissionUtils';
 import { Breadcrumbs } from '../../common/Breadcrumbs/Breadcrumbs';
+import { useGetIsAdminQuery } from '@/rtk/features/userInfoApi';
 
 export const SystemUserDetailsPage = (): React.ReactNode => {
   const { t } = useTranslation();
@@ -31,6 +32,7 @@ export const SystemUserDetailsPage = (): React.ReactNode => {
   const partyId = getCookie('AltinnPartyId');
 
   const { data: reporteeData } = useGetSystemUserReporteeQuery(partyId);
+  const { data: isAdmin } = useGetIsAdminQuery();
 
   const {
     data: systemUser,
@@ -63,7 +65,7 @@ export const SystemUserDetailsPage = (): React.ReactNode => {
         <PageContainer
           onNavigateBack={handleNavigateBack}
           pageActions={
-            hasCreateSystemUserPermission(reporteeData) &&
+            hasCreateSystemUserPermission(reporteeData, isAdmin) &&
             systemUser && (
               <DeleteSystemUserPopover
                 integrationTitle={systemUser?.integrationTitle ?? ''}

--- a/src/features/amUI/systemUser/SystemUserRequestPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserRequestPage.tsx
@@ -22,6 +22,7 @@ import { SystemUserPath } from '@/routes/paths';
 import { getApiBaseUrl } from './urlUtils';
 import { getLogoutUrl } from '@/resources/utils/pathUtils';
 import { SystemUserRequestLoadError } from './components/SystemUserRequestLoadError/SystemUserRequestLoadError';
+import { useGetIsAdminQuery } from '@/rtk/features/userInfoApi';
 
 export const SystemUserRequestPage = () => {
   const { t } = useTranslation();
@@ -48,6 +49,7 @@ export const SystemUserRequestPage = () => {
   } = useGetSystemUserReporteeQuery(request?.partyId ?? '', {
     skip: !request?.partyId,
   });
+  const { data: isAdmin } = useGetIsAdminQuery();
 
   const [
     postAcceptCreationRequest,
@@ -169,7 +171,7 @@ export const SystemUserRequestPage = () => {
                 {t('systemuser_request.reject_error')}
               </DsAlert>
             )}
-            {hasCreateSystemUserPermission(reporteeData) && (
+            {hasCreateSystemUserPermission(reporteeData, isAdmin) && (
               <ButtonRow>
                 <DsButton
                   variant='primary'
@@ -193,9 +195,8 @@ export const SystemUserRequestPage = () => {
                 </DsButton>
               </ButtonRow>
             )}
-            {hasCreateSystemUserPermission(reporteeData) === false && request.status === 'New' && (
-              <EscalateRequest request={request} />
-            )}
+            {hasCreateSystemUserPermission(reporteeData, isAdmin) === false &&
+              request.status === 'New' && <EscalateRequest request={request} />}
           </div>
         </>
       )}

--- a/src/features/amUI/systemUser/SystemUsersOverviewPage/SystemUserOverviewPage.tsx
+++ b/src/features/amUI/systemUser/SystemUsersOverviewPage/SystemUserOverviewPage.tsx
@@ -65,7 +65,7 @@ export const SystemUserOverviewPage = () => {
     isLoading: isLoadingPendingSystemUsers,
     isError: isLoadPendingSystemUsersError,
   } = useGetPendingSystemUserRequestsQuery(partyUuid, {
-    skip: !hasCreateSystemUserPermission(reporteeData),
+    skip: !hasCreateSystemUserPermission(reporteeData, isAdmin),
   });
 
   const isLoading =
@@ -111,14 +111,15 @@ export const SystemUserOverviewPage = () => {
           )}
           {!isLoading && (
             <>
-              {isClientAdmin === false && hasCreateSystemUserPermission(reporteeData) === false && (
-                <DsAlert
-                  data-color='warning'
-                  className={classes.noPermissionsWarning}
-                >
-                  {t('systemuser_overviewpage.no_permissions_warning')}
-                </DsAlert>
-              )}
+              {isClientAdmin === false &&
+                hasCreateSystemUserPermission(reporteeData, isAdmin) === false && (
+                  <DsAlert
+                    data-color='warning'
+                    className={classes.noPermissionsWarning}
+                  >
+                    {t('systemuser_overviewpage.no_permissions_warning')}
+                  </DsAlert>
+                )}
               {pendingSystemUsers && pendingSystemUsers.length > 0 && (
                 <SystemUserList
                   systemUsers={pendingSystemUsers}
@@ -136,7 +137,9 @@ export const SystemUserOverviewPage = () => {
                   systemUsers={systemUsers}
                   listHeading={t('systemuser_overviewpage.existing_system_users_title')}
                   headerContent={
-                    hasCreateSystemUserPermission(reporteeData) && <CreateSystemUserButton />
+                    hasCreateSystemUserPermission(reporteeData, isAdmin) && (
+                      <CreateSystemUserButton />
+                    )
                   }
                 />
               )}

--- a/src/features/amUI/systemUser/components/CreateSystemUserCheck/CreateSystemUserCheck.tsx
+++ b/src/features/amUI/systemUser/components/CreateSystemUserCheck/CreateSystemUserCheck.tsx
@@ -8,15 +8,17 @@ import { hasCreateSystemUserPermission } from '@/resources/utils/permissionUtils
 
 interface CreateSystemUserCheckProps {
   reporteeData: ReporteeInfo | undefined;
+  isAdmin: boolean | undefined;
   children: React.ReactNode;
 }
 export const CreateSystemUserCheck = ({
   reporteeData,
+  isAdmin,
   children,
 }: CreateSystemUserCheckProps): React.ReactNode => {
   const { t } = useTranslation();
 
-  const canCreate = hasCreateSystemUserPermission(reporteeData);
+  const canCreate = hasCreateSystemUserPermission(reporteeData, isAdmin);
 
   return (
     <>

--- a/src/resources/utils/permissionUtils.ts
+++ b/src/resources/utils/permissionUtils.ts
@@ -4,15 +4,15 @@ export const hasConsentPermission = (isAdmin: boolean = false): boolean => {
   return isAdmin;
 };
 
-export const hasCreateSystemUserPermission = (reporteeInfo?: ReporteeInfo): boolean | undefined => {
+export const hasCreateSystemUserPermission = (
+  reporteeInfo?: ReporteeInfo,
+  isAdmin: boolean = false,
+): boolean | undefined => {
   if (!reporteeInfo) {
     return undefined;
   }
   const isOrganization = reporteeInfo.type === 'Organization';
-  const hasCorrectRole = reporteeInfo.authorizedRoles.some((role) =>
-    ['DAGL', 'HADM', 'ADMAI'].includes(role),
-  );
-  return isOrganization && hasCorrectRole;
+  return isOrganization && isAdmin;
 };
 
 export const hasSystemUserClientAdminPermission = (


### PR DESCRIPTION
## Description
- The old permission check for create system user permission checked if user has either of the roles 'DAGL', 'HADM', 'ADMAI'. Change this to instead check if user is admin by calling `useGetIsAdminQuery`

## Related Issue(s)
- https://digdir-samarbeid.slack.com/archives/C068V9FJQTD/p1767706319340719

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced System User management permission checks to incorporate admin status verification alongside existing role-based access control
  * Permission updates now affect visibility and availability of system user operations—including creation, modification, and deletion—across the application interface

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->