### PR TITLE
add icons to tabs on access-package details page

### DIFF
--- a/src/features/amUI/packagePoaDetailsPage/PackagePoaDetails.tsx
+++ b/src/features/amUI/packagePoaDetailsPage/PackagePoaDetails.tsx
@@ -13,6 +13,7 @@ import { UsersTab } from './UsersTab';
 import { StatusSection } from '../common/StatusSection/StatusSection';
 import { useAccessPackageDelegationCheck } from '../common/DelegationCheck/AccessPackageDelegationCheckContext';
 import { isCriticalAndUndelegated } from '../common/AccessPackageList/UndelegatedPackageWarning';
+import { FilesIcon, PersonGroupIcon } from '@navikt/aksel-icons';
 
 export const PackagePoaDetails = () => {
   const { id } = useParams<{ id: string }>();
@@ -76,8 +77,12 @@ export const PackagePoaDetails = () => {
         onChange={setChosenTab}
       >
         <DsTabs.List>
-          <DsTabs.Tab value='users'>{t('package_poa_details_page.users_tab_title')}</DsTabs.Tab>
+          <DsTabs.Tab value='users'>
+            <PersonGroupIcon aria-hidden='true' />
+            {t('package_poa_details_page.users_tab_title')}
+          </DsTabs.Tab>
           <DsTabs.Tab value='services'>
+            <FilesIcon aria-hidden='true' />
             {t('package_poa_details_page.services_tab_title')}
           </DsTabs.Tab>
         </DsTabs.List>


### PR DESCRIPTION
## Description
- Add icons to tabs on access-package details page
<img width="751" height="468" alt="image" src="https://github.com/user-attachments/assets/9ce02d88-8d81-4567-aa68-b93f45a44e00" />

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/2027

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Added visual icons to the users and services tabs in the Package POA Details page, enhancing visual distinction and navigation within the interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->