### PR TITLE
Fix: compare service owner org code by lowercasing both values

### DIFF
--- a/src/features/amUI/common/ResourceList/useFilteredResources.ts
+++ b/src/features/amUI/common/ResourceList/useFilteredResources.ts
@@ -30,7 +30,9 @@ export const useFilteredResources = <TResource>({
       const description = getDescription?.(resource)?.toLowerCase() ?? '';
       const serviceOwnerMatch =
         serviceOwnerFilter && serviceOwnerFilter.length > 0
-          ? serviceOwnerFilter.includes(getOwnerOrgCode(resource).toLowerCase())
+          ? serviceOwnerFilter
+              .map((owner) => owner.toLowerCase())
+              .includes(getOwnerOrgCode(resource).toLowerCase())
           : true;
       return (
         (nameOrTitle.includes(normalizedSearch) ||


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Service owner filter matching is now case-insensitive, ensuring consistent filtering results regardless of capitalization in resource owner codes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->