### PR TITLE
Add icons to tabs on user page

### DIFF
--- a/src/features/amUI/common/RightsTabs/RightsTabs.tsx
+++ b/src/features/amUI/common/RightsTabs/RightsTabs.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { DsBadge, DsTabs } from '@altinn/altinn-components';
 
 import classes from './RightsTabs.module.css';
+import { FilesIcon, FolderIcon, PackageIcon } from '@navikt/aksel-icons';
 interface RightsTabsProps {
   tabBadge?: { accessPackages: number; services: number; roles: number };
   packagesPanel: ReactNode;
@@ -39,6 +40,7 @@ export const RightsTabs = ({
               maxCount={99}
             />
           )}
+          <PackageIcon aria-hidden='true' />
           {t('user_rights_page.access_packages_title')}
         </DsTabs.Tab>
         {singleRightsPanel && (
@@ -51,6 +53,7 @@ export const RightsTabs = ({
                 maxCount={99}
               />
             )}
+            <FilesIcon aria-hidden='true' />
             {t('user_rights_page.single_rights_title')}
           </DsTabs.Tab>
         )}
@@ -64,9 +67,11 @@ export const RightsTabs = ({
                 maxCount={99}
               />
             )}
+            <FolderIcon aria-hidden='true' />
             {t('user_rights_page.roles_title')}
           </DsTabs.Tab>
         )}
+        {/* Bruk <EnvelopeClosedIcon aria-hidden='true' /> for delt fra innboks tab*/}
       </DsTabs.List>
       <DsTabs.Panel
         className={classes.tabContent}


### PR DESCRIPTION
## Description
<img width="508" height="297" alt="image" src="https://github.com/user-attachments/assets/503d094d-9d64-4f0c-a98e-0c3b014e3df0" />

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/2027

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual icons to tabs for improved navigation clarity. Users now see distinct icons next to access packages, single rights, and roles tabs, making it easier to identify and navigate between different sections.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->