### PR TITLE
Fjernet delen av aktørvalgtesten som tester på tvers

### DIFF
--- a/playwright/e2eTests/headertest.spec.ts
+++ b/playwright/e2eTests/headertest.spec.ts
@@ -34,26 +34,6 @@ test.describe('Aktørvalg, valg og visning av avgiver', () => {
       await aktorvalgHeader.selectActor('Kunnskapsrik Kry Ape');
     });
 
-    await test.step('Chosen actor persists on infoportal', async () => {
-      await aktorvalgHeader.goToInfoportal();
-      await aktorvalgHeader.currentlySelectedActor('Kunnskapsrik Kry Ape');
-    });
-
-    await test.step('Chosen actor persists on inbox', async () => {
-      await aktorvalgHeader.goToInbox();
-      await aktorvalgHeader.currentlySelectedActor('Kunnskapsrik Kry Ape');
-    });
-
-    await test.step('Chosen actor persists on access management', async () => {
-      await aktorvalgHeader.goToAccessManagement();
-      await aktorvalgHeader.currentlySelectedActor('Kunnskapsrik Kry Ape');
-    });
-
-    await test.step('Chosen actor persists on profile', async () => {
-      await aktorvalgHeader.goToProfile();
-      await aktorvalgHeader.currentlySelectedActor('Kunnskapsrik Kry Ape');
-    });
-
     //sett favoritt
     await test.step('Add actor as favorites', async () => {
       await aktorvalgHeader.goToSelectActor('Kunnskapsrik Kry Ape');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fjernet delen av aktørvalgtesten som tester på tvers. Passer bedre å teste på tvers i [altinn-platform-validation-tests](https://github.com/Altinn/altinn-platform-validation-tests)

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified test coverage by removing redundant validation steps, streamlining the test flow while maintaining core functionality checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->