### PR TITLE
refactor request tabs badge + show 0 in badge on sent requests tab

### DIFF
--- a/src/features/amUI/requestPage/RequestsPage.tsx
+++ b/src/features/amUI/requestPage/RequestsPage.tsx
@@ -1,8 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Link } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import {
   Badge,
+  BadgeVariant,
+  Color,
   DsAlert,
   DsTabs,
   formatDisplayName,
@@ -21,8 +23,21 @@ import { useRequests } from '@/resources/hooks/useRequests';
 import classes from './RequestPage.module.css';
 import { Request } from './types';
 
+const selectedTabProps = {
+  'data-size': 'sm',
+  variant: 'base' as BadgeVariant,
+};
+
+const unselectedTabProps = {
+  'data-size': 'sm',
+  color: 'neutral' as Color,
+};
+const INCOMING_REQUESTS_TAB = 'incomingRequests';
+const SENT_REQUESTS_TAB = 'sentRequests';
+
 export const RequestPage = () => {
   const { t } = useTranslation();
+  const [selectedTab, setSelectedTab] = useState<string>(INCOMING_REQUESTS_TAB);
 
   useRerouteIfRequestPageDisabled();
 
@@ -48,26 +63,37 @@ export const RequestPage = () => {
           isLoading={isLoadingReportee}
         />
         <DsTabs
-          defaultValue='incomingRequests'
+          value={selectedTab}
+          onChange={setSelectedTab}
           data-size='sm'
         >
           <DsTabs.List className={classes.requestPageTabs}>
             <DsTabs.Tab
-              value='incomingRequests'
+              value={INCOMING_REQUESTS_TAB}
               className={classes.requestTab}
             >
               {!!totalRequests && (
                 <Badge
-                  data-size='sm'
-                  variant='base'
+                  {...(selectedTab === INCOMING_REQUESTS_TAB
+                    ? selectedTabProps
+                    : unselectedTabProps)}
                   label={totalRequests}
                 />
               )}
               {t('request_page.incoming_requests')}
             </DsTabs.Tab>
-            <DsTabs.Tab value='sentRequests'>{t('request_page.sent_requests')}</DsTabs.Tab>
+            <DsTabs.Tab
+              value={SENT_REQUESTS_TAB}
+              className={classes.requestTab}
+            >
+              <Badge
+                {...(selectedTab === SENT_REQUESTS_TAB ? selectedTabProps : unselectedTabProps)}
+                label={'0'} // endre tall her når "Be om tilgang" implementeres
+              />
+              {t('request_page.sent_requests')}
+            </DsTabs.Tab>
           </DsTabs.List>
-          <DsTabs.Panel value='incomingRequests'>
+          <DsTabs.Panel value={INCOMING_REQUESTS_TAB}>
             <List>
               {isLoadingRequests ? (
                 <>
@@ -87,7 +113,7 @@ export const RequestPage = () => {
               <DsAlert data-color='danger'>{t('request_page.error_loading_requests')}</DsAlert>
             )}
           </DsTabs.Panel>
-          <DsTabs.Panel value='sentRequests'>
+          <DsTabs.Panel value={SENT_REQUESTS_TAB}>
             <div>{t('request_page.no_sent_requests')}</div>
           </DsTabs.Panel>
         </DsTabs>


### PR DESCRIPTION
## Description
- Refactor tab badge on request page (to show grey-ish tab when tab is not active)
- Show 0 in badge on sent requests tab
<img width="475" height="272" alt="image" src="https://github.com/user-attachments/assets/25f379f8-90c7-4225-81bc-f4dff8adf1ff" />


## Related Issue(s)
- this PR

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Enhanced tab state management for more reliable interaction handling.
  * Improved badge styling to dynamically reflect active and inactive tab states.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->