### PR TITLE
Use the partytype of fromParty for fetching accessPackages

### DIFF
--- a/src/features/amUI/common/AccessPackageList/useAreaPackageList.ts
+++ b/src/features/amUI/common/AccessPackageList/useAreaPackageList.ts
@@ -47,8 +47,8 @@ export const useAreaPackageList = ({
 }: useAreaPackagesProps) => {
   const { i18n } = useTranslation();
   const { fromParty, toParty, actingParty } = usePartyRepresentation();
-  const typeName = actingParty
-    ? actingParty.partyTypeName === PartyType.Organization
+  const typeName = fromParty
+    ? fromParty?.partyTypeName === PartyType.Organization
       ? 'organisasjon'
       : 'person'
     : undefined;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The content that is delegated belongs to the fromParty (it is their inbox we give access to), thus, the packages and other such delegated content should always reflect their partyType _not_ the actingParty.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed party type detection in access package searches by correcting the source data used for determining organization versus individual classification, improving search result accuracy and filtering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->