### PR TITLE
Show date of birth for person clients in list

### DIFF
--- a/src/features/amUI/clientAdministrationAgentDetails/ClientAdministrationAgentClientsList.tsx
+++ b/src/features/amUI/clientAdministrationAgentDetails/ClientAdministrationAgentClientsList.tsx
@@ -5,6 +5,7 @@ import {
   Button,
   type UserListItemProps,
   type Color,
+  formatDate,
 } from '@altinn/altinn-components';
 
 import type {
@@ -149,9 +150,14 @@ export const ClientAdministrationAgentClientsList = ({
       collapsible: true,
       as: Button,
       children: <AccessPackageListItems items={nodes} />,
-      description: t('client_administration_page.organization_identifier', {
-        orgnr: client.client.organizationIdentifier,
-      }),
+      description:
+        userType === 'company'
+          ? t('client_administration_page.organization_identifier', {
+              orgnr: client.client.organizationIdentifier,
+            })
+          : userType === 'person'
+            ? `${t('common.date_of_birth')} ${formatDate(client.client.dateOfBirth ?? '')}`
+            : undefined,
     };
   });
 


### PR DESCRIPTION
Updated the client list to display date of birth for person-type clients using the formatDate utility, while retaining organization identifier for company-type clients.


To test: 
login: 22877497392
go to:  client-admin > agent > clients tab > search for "liggestol". 

<img width="622" height="364" alt="Skjermbilde 2026-01-28 kl  12 42 24" src="https://github.com/user-attachments/assets/c7f62cad-cb1a-4959-844e-67cc9720cd5b" />
btitle 

 
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated user information display in client administration to correctly show date of birth for individual users and organization identifiers for company users based on user type.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->