### PR TITLE
Add client access info modal for agent users

### DIFF
--- a/src/features/amUI/common/RoleList/useGroupedRoleListEntries.ts
+++ b/src/features/amUI/common/RoleList/useGroupedRoleListEntries.ts
@@ -1,7 +1,11 @@
 import { useMemo } from 'react';
 
 import type { RolePermission } from '@/rtk/features/roleApi';
-import { A2_PROVIDER_CODE, ECC_PROVIDER_CODE } from '../UserRoles/useRoleMetadata';
+import {
+  A2_PROVIDER_CODE,
+  ECC_PROVIDER_CODE,
+  A3_PROVIDER_CODE,
+} from '../UserRoles/useRoleMetadata';
 
 type UseGroupedRoleListEntriesParams = {
   permissions?: RolePermission[];
@@ -9,16 +13,18 @@ type UseGroupedRoleListEntriesParams = {
 
 type UseGroupedRoleListEntriesResult = {
   altinn2Roles: RolePermission[];
+  altinn3Roles: RolePermission[];
   userRoles: RolePermission[];
 };
 
 export const useGroupedRoleListEntries = ({
   permissions,
 }: UseGroupedRoleListEntriesParams): UseGroupedRoleListEntriesResult => {
-  const { altinn2Roles, userRoles } = useMemo(() => {
+  const { altinn2Roles, altinn3Roles, userRoles } = useMemo(() => {
     if (!permissions) {
       return {
         altinn2Roles: [],
+        altinn3Roles: [],
         userRoles: [],
       };
     }
@@ -26,6 +32,7 @@ export const useGroupedRoleListEntries = ({
     const collator = new Intl.Collator(undefined, { sensitivity: 'base' });
     const groups = {
       altinn2Roles: [] as RolePermission[],
+      altinn3Roles: [] as RolePermission[],
       userRoles: [] as RolePermission[],
     };
 
@@ -38,10 +45,13 @@ export const useGroupedRoleListEntries = ({
         groups.altinn2Roles.push(connection);
       } else if (providerCode === ECC_PROVIDER_CODE) {
         groups.userRoles.push(connection);
+      } else if (providerCode === A3_PROVIDER_CODE) {
+        groups.altinn3Roles.push(connection);
       }
     });
 
     groups.altinn2Roles.sort((a, b) => collator.compare(a.role.name, b.role.name));
+    groups.altinn3Roles.sort((a, b) => collator.compare(a.role.name, b.role.name));
     groups.userRoles.sort((a, b) => collator.compare(a.role.name, b.role.name));
 
     return groups;
@@ -49,6 +59,7 @@ export const useGroupedRoleListEntries = ({
 
   return {
     altinn2Roles,
+    altinn3Roles,
     userRoles,
   };
 };

--- a/src/features/amUI/common/UserRoles/ClientAccessInfoModal.tsx
+++ b/src/features/amUI/common/UserRoles/ClientAccessInfoModal.tsx
@@ -1,0 +1,41 @@
+import { DsDialog, DsHeading, DsParagraph } from '@altinn/altinn-components';
+import { Trans, useTranslation } from 'react-i18next';
+import { Link } from 'react-router';
+
+import classes from './clientAccessInfoModal.module.css';
+import { amUIPath } from '@/routes/paths';
+
+interface ClientAccessInfoModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export const ClientAccessInfoModal = ({ open, onClose }: ClientAccessInfoModalProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <DsDialog
+      open={open}
+      closedby='any'
+      closeButton={t('common.close')}
+      onClose={onClose}
+    >
+      <div className={classes.modalContent}>
+        <DsHeading
+          level={2}
+          data-size='xs'
+        >
+          {t('user_roles.has_client_access')}
+        </DsHeading>
+        <DsParagraph data-size='sm'>
+          <Trans
+            i18nKey='user_roles.has_client_access_description'
+            components={{
+              a: <Link to={`/${amUIPath.ClientAdministration}`} />,
+            }}
+          />
+        </DsParagraph>
+      </div>
+    </DsDialog>
+  );
+};

--- a/src/features/amUI/common/UserRoles/UserRoles.tsx
+++ b/src/features/amUI/common/UserRoles/UserRoles.tsx
@@ -1,4 +1,5 @@
 import { DsChip } from '@altinn/altinn-components';
+import { useTranslation } from 'react-i18next';
 
 import cn from 'classnames';
 
@@ -9,11 +10,13 @@ import { useRef, useState } from 'react';
 import { RoleInfoModal } from '../DelegationModal/RoleInfoModal';
 import { useGroupedRoleListEntries } from '../RoleList/useGroupedRoleListEntries';
 import { useRoleMetadata } from './useRoleMetadata';
-import { RoleInfo } from '@/rtk/features/connectionApi';
+import { ClientAccessInfoModal } from './ClientAccessInfoModal';
 
 export const UserRoles = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => {
+  const { t } = useTranslation();
   const modalRef = useRef<HTMLDialogElement>(null);
   const [selectedRole, setSelectedRole] = useState<Role | null>(null);
+  const [isClientAccessModalOpen, setIsClientAccessModalOpen] = useState(false);
 
   const { toParty, fromParty, actingParty } = usePartyRepresentation();
 
@@ -28,7 +31,7 @@ export const UserRoles = ({ className, ...props }: React.HTMLAttributes<HTMLDivE
     },
   );
 
-  const { userRoles } = useGroupedRoleListEntries({
+  const { userRoles, altinn3Roles } = useGroupedRoleListEntries({
     permissions,
   });
 
@@ -50,6 +53,7 @@ export const UserRoles = ({ className, ...props }: React.HTMLAttributes<HTMLDivE
   };
 
   const roles = mapRoles(userRoles?.map(({ role }) => role) ?? []);
+  const isAgent = altinn3Roles.some((rolePermission) => rolePermission.role.code === 'agent');
 
   return (
     <>
@@ -57,6 +61,11 @@ export const UserRoles = ({ className, ...props }: React.HTMLAttributes<HTMLDivE
         className={cn(classes.userRoles, className)}
         {...props}
       >
+        {isAgent && (
+          <DsChip.Button onClick={() => setIsClientAccessModalOpen(true)}>
+            {t('user_roles.has_client_access')}
+          </DsChip.Button>
+        )}
         {roles.map((role) => {
           return (
             <DsChip.Button
@@ -73,6 +82,12 @@ export const UserRoles = ({ className, ...props }: React.HTMLAttributes<HTMLDivE
         role={selectedRole || undefined}
         onClose={onModalClose}
       />
+      {isAgent && (
+        <ClientAccessInfoModal
+          open={isClientAccessModalOpen}
+          onClose={() => setIsClientAccessModalOpen(false)}
+        />
+      )}
     </>
   );
 };

--- a/src/features/amUI/common/UserRoles/clientAccessInfoModal.module.css
+++ b/src/features/amUI/common/UserRoles/clientAccessInfoModal.module.css
@@ -1,0 +1,6 @@
+.modalContent {
+  white-space: normal;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}

--- a/src/features/amUI/common/UserRoles/useRoleMetadata.ts
+++ b/src/features/amUI/common/UserRoles/useRoleMetadata.ts
@@ -8,6 +8,7 @@ type RoleMetadataMap = Record<string, Role | undefined>;
 
 export const ECC_PROVIDER_CODE = 'sys-ccr';
 export const A2_PROVIDER_CODE = 'sys-altinn2';
+export const A3_PROVIDER_CODE = 'sys-altinn3';
 
 /**
  * Fetches all role metadata once and provides helpers to look up and map metadata by role id.

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -348,6 +348,10 @@
       "via_keyrole": "{{user_name}} has access to this through their role in {{via_name}}."
     }
   },
+  "user_roles": {
+    "has_client_access": "Has client access",
+    "has_client_access_description": "This user has access to one or more of the organization's clients. This does not necessarily mean they have access to the organization's own content, but that they can perform work on behalf of one or more of their clients/customers. Which clients they have access to can be managed under <a>client administration</a>."
+  },
   "users_page": {
     "page_title": "Users and groups - Altinn",
     "main_page_heading": "Users with power of attorney in {{name}}",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -345,6 +345,10 @@
       "via_keyrole": "{{user_name}} har tilgang til dette gjennom rollen de har i {{via_name}}."
     }
   },
+  "user_roles": {
+    "has_client_access": "Har klienttilgang",
+    "has_client_access_description": "Denne brukeren har tilgang til en eller flere av virksomhetens klienter. Dette betyr ikke nødvendigvis at de har tilgang til virksomhetens eget innhold, men at de kan utføre arbeid på vegne av en eller flere av deres klienter/kunder. Hvilke klienter de har tilgang til kan administreres under <a>klientadministrasjon</a>."
+  },
   "users_page": {
     "page_title": "Brukere og grupper - Altinn",
     "main_page_heading": "Brukere med fullmakter i {{name}}",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -345,6 +345,10 @@
       "via_keyrole": "{{user_name}} har tilgang til dette gjennom rolla dei har i {{via_name}}."
     }
   },
+  "user_roles": {
+    "has_client_access": "Har klienttilgang",
+    "has_client_access_description": "Denne brukaren har tilgang til ein eller fleire av verksemda sine klientar. Dette betyr ikkje nødvendigvis at dei har tilgang til verksemda sitt eige innhald, men at dei kan utføre arbeid på vegner av ein eller fleire av kundane deira. Kva klientar dei har tilgang til kan administrerast under <a>klientadministrasjon</a>."
+  },
   "users_page": {
     "page_title": "Brukarar og grupper - Altinn",
     "main_page_heading": "Brukarar med fullmakter i {{name}}",


### PR DESCRIPTION
Legger til en chip der brukeren har agentrolle. Et klikk på chipen åpner en modal med beskrivelse av hva det innbærer og hvordan man administrerer disse.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Altinn 3 role grouping support to categorize roles alongside existing role types.
  * Introduced a new modal dialog providing information about client access permissions.
  * Added a UI control for users with agent roles to view client access details.
  * Added multi-language support for client access messaging in English, Norwegian Bokmål, and Norwegian Nynorsk.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->