### PR TITLE
2128 - Remove manual refetch of role metadata

### DIFF
--- a/src/features/amUI/common/UserRoles/useRoleMetadata.ts
+++ b/src/features/amUI/common/UserRoles/useRoleMetadata.ts
@@ -1,10 +1,13 @@
-import { useCallback, useMemo, useEffect } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { useTranslation } from 'react-i18next';
 import { useGetAllRolesQuery, type Role } from '@/rtk/features/roleApi';
 import type { RoleInfo } from '@/rtk/features/connectionApi';
 
-type RoleMetadataMap = Record<string, Role | undefined>;
+type RoleMetadataMap = {
+  byId: Record<string, Role | undefined>;
+  byCode: Record<string, Role | undefined>;
+};
 
 export const ECC_PROVIDER_CODE = 'sys-ccr';
 export const A2_PROVIDER_CODE = 'sys-altinn2';
@@ -20,45 +23,45 @@ export const useRoleMetadata = () => {
     isLoading,
     isError,
     error,
-    refetch,
   } = useGetAllRolesQuery({
     language: i18n.language,
   });
 
-  // Refetch when language changes to ensure fresh translated data
-  useEffect(() => {
-    refetch();
-  }, [i18n.language, refetch]);
-
   const roleMetadataMap = useMemo(() => {
     if (!allRoles) {
-      return {};
+      return { byId: {}, byCode: {} };
     }
 
-    return allRoles.reduce<RoleMetadataMap>((acc, role) => {
-      acc[role.id] = role;
-      return acc;
-    }, {});
+    return allRoles.reduce<RoleMetadataMap>(
+      (acc, role) => {
+        acc.byId[role.id] = role;
+        if (role.code) {
+          acc.byCode[role.code] = role;
+        }
+        return acc;
+      },
+      { byId: {}, byCode: {} },
+    );
   }, [allRoles]);
 
   const getRoleMetadata = useCallback(
     (roleId?: string | null) => {
-      if (!roleId || !roleMetadataMap) {
+      if (!roleId) {
         return undefined;
       }
-      return roleMetadataMap[roleId];
+      return roleMetadataMap.byId[roleId];
     },
     [roleMetadataMap],
   );
 
   const getRoleByCode = useCallback(
     (roleCode?: string | null) => {
-      if (!roleCode || !allRoles) {
+      if (!roleCode) {
         return undefined;
       }
-      return allRoles.find((role) => role.code === roleCode);
+      return roleMetadataMap.byCode[roleCode];
     },
-    [allRoles],
+    [roleMetadataMap],
   );
 
   const mapRoles = useCallback(


### PR DESCRIPTION
useRoleMetadata no longer refetches on load. RTK handles refetches as lang is part of cache-key. Also updates the "get-by-code" to use a dictionary for more efficient lookup.

https://github.com/Altinn/altinn-authorization-tmp/issues/2128

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized role metadata lookups through an improved data structure.
  * Updated automatic language change refresh behavior—automatic refresh on language changes has been removed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->