### PR TITLE
Enable client administration page in AT23 and AT24

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.AT23.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.AT23.json
@@ -21,7 +21,7 @@
     "RestrictPrivUse": true,
     "CrossPlatformLinks": true,
     "DisplaySettingsPage": true,
-    "DisplayClientAdministrationPage": false,
+    "DisplayClientAdministrationPage": true,
     "DisplayPoaOverviewPage": true,
     "UseNewActorsList": false,
     "DisplayRequestsPage": false,

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.AT24.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.AT24.json
@@ -21,7 +21,7 @@
     "RestrictPrivUse": true,
     "CrossPlatformLinks": true,
     "DisplaySettingsPage": true,
-    "DisplayClientAdministrationPage": false,
+    "DisplayClientAdministrationPage": true,
     "DisplayPoaOverviewPage": true,
     "UseNewActorsList": false,
     "DisplayRequestsPage": false,


### PR DESCRIPTION
Set 'DisplayClientAdministrationPage' to true in appsettings.AT23.json and appsettings.AT24.json to enable the client administration page for these environments.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Client Administration Page is now enabled across environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->