### PR TITLE
Navigate to agent page on add new agent

### DIFF
--- a/src/features/amUI/clientAdministration/ClientAdministrationAgentsTab.tsx
+++ b/src/features/amUI/clientAdministration/ClientAdministrationAgentsTab.tsx
@@ -8,10 +8,12 @@ import { useAddAgentMutation, useGetAgentsQuery, type Agent } from '@/rtk/featur
 import { useGetRightHoldersQuery, type Connection } from '@/rtk/features/connectionApi';
 import { usePartyRepresentation } from '../common/PartyRepresentationContext/PartyRepresentationContext';
 import classes from './ClientAdministrationAgentsTab.module.css';
+import { useNavigate } from 'react-router';
 
 export const ClientAdministrationAgentsTab = () => {
   const { t } = useTranslation();
   const { openSnackbar } = useSnackbar();
+  const navigate = useNavigate();
   const { fromParty } = usePartyRepresentation();
   const {
     data: agents,
@@ -92,6 +94,7 @@ export const ClientAdministrationAgentsTab = () => {
         connections={agentConnections}
         indirectConnections={filteredIndirectConnections}
         getUserLink={(user) => `/clientadministration/agent/${user.id}`}
+        onAddNewUser={(user) => navigate(`/clientadministration/agent/${user.id}`)}
         isLoading={isAgentsLoading || isIndirectLoading}
         isActionLoading={isIndirectFetching}
         AddUserButton={AddAgentButton}


### PR DESCRIPTION
On add new user on the clent-admin page, we navigate the user to the page for the new user that was created. 

https://github.com/Altinn/altinn-authorization-tmp/issues/2126

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users are now automatically navigated to a newly created agent's profile page after adding them in client administration. This streamlines the workflow and provides immediate access to manage the new account, eliminating the need for manual navigation after agent creation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->