### PR TITLE
Hide systemuser agent customer paging if there are less than 2 pages

### DIFF
--- a/src/features/amUI/systemUser/SystemUserAgentDelegationPage/CustomerList.tsx
+++ b/src/features/amUI/systemUser/SystemUserAgentDelegationPage/CustomerList.tsx
@@ -146,7 +146,7 @@ export const CustomerList = ({
           />
         ))}
       </List>
-      {list.length > 0 && (
+      {totalPages > 1 && (
         <AmPagination
           totalPages={totalPages}
           showPages={showPages}


### PR DESCRIPTION
## Description
- Input from design: hide paging if there are less than 2 pages

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pagination control no longer displays when results fit on a single page.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->