### PR TITLE
Invalidate connection cache when adding new user

### DIFF
--- a/src/rtk/features/connectionApi.ts
+++ b/src/rtk/features/connectionApi.ts
@@ -64,6 +64,7 @@ export const connectionApi = createApi({
       }): { status: string | number; data: string } => {
         return { status: response.status, data: new Date().toISOString() };
       },
+      invalidatesTags: ['Connections'],
     }),
     getRightHolders: builder.query<
       Connection[],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

To be sure that newly added people show up in the user list, we invalidate cache after adding them.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the connections list wouldn't refresh after adding a right holder.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->