### PR TITLE
Add cascade=true to agent removal request

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/ClientDelegationClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/ClientDelegationClient.cs
@@ -195,7 +195,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
         /// <inheritdoc />
         public async Task RemoveAgent(Guid party, Guid to, CancellationToken cancellationToken = default)
         {
-            string endpointUrl = $"enduser/clientdelegations/agents?party={party}&to={to}";
+            string endpointUrl = $"enduser/clientdelegations/agents?party={party}&to={to}&cascade=true";
             string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
 
             HttpResponseMessage response = await _client.DeleteAsync(token, endpointUrl);


### PR DESCRIPTION
We need to set `cascade=true` to be allowed to delete agents with connections. 
We have no cases where this should be set to false, so we can safely set it here. 

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the agent removal process to ensure all associated data is properly cleaned up when an agent is removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->