### PR TITLE
add option to disable guardianship packages in person access package list

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/AccessPackage/Frontend/AccessAreaFE.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/AccessPackage/Frontend/AccessAreaFE.cs
@@ -11,6 +11,11 @@
         public string Id { get; set; }
 
         /// <summary>
+        /// Urn of the AccessArea
+        /// </summary>
+        public string Urn { get; set; }
+
+        /// <summary>
         /// Name
         /// </summary>
         public string Name { get; set; }
@@ -36,6 +41,7 @@
         public AccessAreaFE(AccessArea area, List<AccessPackage> packages)
         {
             Id = area.Id;
+            Urn = area.Urn;
             Name = area.Name;
             Description = area.Description;
             IconUrl = area.IconUrl;

--- a/src/features/amUI/common/AccessPackageList/AccessPackageList.tsx
+++ b/src/features/amUI/common/AccessPackageList/AccessPackageList.tsx
@@ -20,6 +20,7 @@ import { createErrorDetails } from '../TechnicalErrorParagraphs/TechnicalErrorPa
 interface AccessPackageListProps {
   showAllPackages?: boolean;
   showAllAreas?: boolean;
+  showGuardianships?: boolean;
   minimizeAvailablePackages?: boolean;
   isLoading?: boolean;
   availableActions?: DelegationAction[];
@@ -39,6 +40,7 @@ interface AccessPackageListProps {
 export const AccessPackageList = ({
   showAllAreas,
   showAllPackages,
+  showGuardianships,
   minimizeAvailablePackages,
   isLoading,
   availableActions,
@@ -69,6 +71,7 @@ export const AccessPackageList = ({
   } = useAreaPackageList({
     showAllAreas,
     showAllPackages,
+    showGuardianships,
     searchString,
   });
 

--- a/src/features/amUI/common/AccessPackageList/useAreaPackageList.ts
+++ b/src/features/amUI/common/AccessPackageList/useAreaPackageList.ts
@@ -31,6 +31,7 @@ export interface ExtendedAccessPackage extends AccessPackage {
 interface useAreaPackagesProps {
   showAllAreas?: boolean;
   showAllPackages?: boolean;
+  showGuardianships?: boolean;
   searchString?: string;
 }
 
@@ -44,6 +45,7 @@ export const useAreaPackageList = ({
   searchString,
   showAllAreas,
   showAllPackages,
+  showGuardianships,
 }: useAreaPackagesProps) => {
   const { i18n } = useTranslation();
   const { fromParty, toParty, actingParty } = usePartyRepresentation();
@@ -136,10 +138,13 @@ export const useAreaPackageList = ({
 
           acc.assignedAreas.push({ ...area, packages: pkgs });
         } else if (showAllAreas) {
-          acc.availableAreas.push({
-            ...area,
-            packages: { assigned: [], available: area.accessPackages },
-          });
+          const isGuardianshipArea = area.urn.startsWith('accesspackage:area:vergemal');
+          if (!isGuardianshipArea || showGuardianships) {
+            acc.availableAreas.push({
+              ...area,
+              packages: { assigned: [], available: area.accessPackages },
+            });
+          }
         }
 
         return acc;
@@ -156,6 +161,7 @@ export const useAreaPackageList = ({
     fromParty,
     showAllAreas,
     showAllPackages,
+    showGuardianships,
     toParty,
   ]);
 

--- a/src/features/amUI/common/DelegationModal/AccessPackages/PackageSearch.tsx
+++ b/src/features/amUI/common/DelegationModal/AccessPackages/PackageSearch.tsx
@@ -1,6 +1,6 @@
 import { Trans, useTranslation } from 'react-i18next';
 import { useCallback, useState } from 'react';
-import { DsSearch, DsHeading } from '@altinn/altinn-components';
+import { DsSearch, DsHeading, formatDisplayName } from '@altinn/altinn-components';
 
 import { debounce } from '@/resources/utils';
 import type { AccessPackage } from '@/rtk/features/accessPackageApi';
@@ -11,6 +11,7 @@ import { useDelegationModalContext } from '../DelegationModalContext';
 import type { DelegationAction } from '../EditModal';
 
 import classes from './PackageSearch.module.css';
+import { PartyType } from '@/rtk/features/userInfoApi';
 
 export interface PackageSearchProps {
   onSelection: (pack: AccessPackage) => void;
@@ -47,7 +48,12 @@ export const PackageSearch = ({
         >
           <Trans
             i18nKey='delegation_modal.give_package_to_name'
-            values={{ name: toParty.name }}
+            values={{
+              name: formatDisplayName({
+                fullName: toParty.name,
+                type: toParty.partyTypeName === PartyType.Person ? 'person' : 'company',
+              }),
+            }}
             components={{ strong: <strong /> }}
           />
         </DsHeading>
@@ -78,6 +84,7 @@ export const PackageSearch = ({
             <AccessPackageList
               showAllAreas={true}
               showAllPackages={true}
+              showGuardianships={false}
               showPackagesCount={true}
               onSelect={onSelection}
               searchString={debouncedSearchString}

--- a/src/features/amUI/poaOverview/AccessPackagePermissions.tsx
+++ b/src/features/amUI/poaOverview/AccessPackagePermissions.tsx
@@ -47,6 +47,7 @@ export const AccessPackagePermissions = () => {
         showPermissions
         showAllPackages
         showAllAreas
+        showGuardianships
         showPackagesCount={false}
         packageAs={(props) => (
           <Link

--- a/src/rtk/features/accessPackageApi.ts
+++ b/src/rtk/features/accessPackageApi.ts
@@ -5,6 +5,7 @@ import type { CompactPackage, Permissions } from '@/dataObjects/dtos/accessPacka
 
 export interface AccessArea {
   id: string;
+  urn: string;
   name: string;
   description: string;
   iconUrl: string;


### PR DESCRIPTION
## Description
- Display of guardianship access package areas when displaying all access packages is not opt-in. (`showGuardianships` prop)

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/2178

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added conditional filtering for guardianship areas in access package displays
  * Improved display name formatting for delegation recipients based on party type
  * Enhanced delegation workflows with error handling and action callbacks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->