### PR TITLE
Ikke vis knapper Gi fullmakt og Slett alle tilganger på en privatpersons egen side

### DIFF
--- a/src/features/amUI/userRightsPage/AccessPackageSection/AccessPackageSection.tsx
+++ b/src/features/amUI/userRightsPage/AccessPackageSection/AccessPackageSection.tsx
@@ -31,7 +31,9 @@ export const AccessPackageSection = () => {
   } = usePartyRepresentation();
   const { data: isHovedadmin } = useGetIsHovedadminQuery();
   const isCurrentUser = selfParty?.partyUuid === id;
-  const canGiveAccess = !isCurrentUser || (isCurrentUser && isHovedadmin);
+  const canGiveAccess =
+    !isCurrentUser ||
+    (isCurrentUser && isHovedadmin && actingParty?.partyTypeName !== PartyType.Person);
   const shouldDisplayPrivDelegation = displayPrivDelegation();
 
   const { data: accesses, isLoading: loadingAccesses } = useGetUserDelegationsQuery(

--- a/src/features/amUI/userRightsPage/UserRightsPage.tsx
+++ b/src/features/amUI/userRightsPage/UserRightsPage.tsx
@@ -60,7 +60,7 @@ export const UserRightsPage = () => {
           <DelegationModalProvider>
             <PageContainer
               backUrl={`/${amUIPath.Users}`}
-              contentActions={<DeleteUserModal direction='to' />}
+              contentActions={actingPartyUuid !== id && <DeleteUserModal direction='to' />}
             >
               <UserPageHeader
                 direction='to'


### PR DESCRIPTION
## Description
- Det gir ikke mening å ha knappene "Gi fullmakt" og "Slett alle tilganger" på en privatpersons egen side. Det vil ikke være mulig å gi seg selv noe mer (man har allerede alle tilgangspakkene), eller slette en tilgangspakke fra seg selv

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where users could delete access rights from their own user account. The delete action is now unavailable when viewing your own account.
  * Enhanced access delegation security by restricting certain user role types from delegating access permissions to others.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->