### PR TITLE
Update footer links with new service announcement link

### DIFF
--- a/src/features/amUI/common/PageLayoutWrapper/useFooter.tsx
+++ b/src/features/amUI/common/PageLayoutWrapper/useFooter.tsx
@@ -4,15 +4,17 @@ import { useTranslation } from 'react-i18next';
 export const useFooter = () => {
   const { t, i18n } = useTranslation();
   const infoPortalUrl = getAltinnStartPageUrl(i18n.language);
+  const langSpecificUrls = getLangSpecificUrls(i18n.language, infoPortalUrl);
 
   const footerLinks = [
-    { href: infoPortalUrl + 'hjelp/', resourceId: 'footer.help' },
+    { href: langSpecificUrls.help, resourceId: 'footer.help' },
     {
-      href: infoPortalUrl + 'om-altinn/',
+      href: langSpecificUrls.about,
       resourceId: 'footer.about_altinn',
     },
-    { href: infoPortalUrl + 'om-altinn/personvern/', resourceId: 'footer.privacy_policy' },
-    { href: infoPortalUrl + 'om-altinn/tilgjengelighet/', resourceId: 'footer.accessibility' },
+    { href: langSpecificUrls.serviceAnnouncements, resourceId: 'footer.service_announcement' },
+    { href: langSpecificUrls.privacy, resourceId: 'footer.privacy_policy' },
+    { href: langSpecificUrls.accessibility, resourceId: 'footer.accessibility' },
   ];
 
   const footer = {
@@ -28,4 +30,34 @@ export const useFooter = () => {
   };
 
   return footer;
+};
+
+const getLangSpecificUrls = (languageCode: string, baseUrl: string) => {
+  switch (languageCode) {
+    case 'en':
+      return {
+        help: baseUrl + 'help/',
+        about: baseUrl + 'about-altinn/',
+        serviceAnnouncements: baseUrl + 'about-altinn/service-announcements/',
+        privacy: baseUrl + 'about-altinn/privacy/',
+        accessibility: baseUrl + 'about-altinn/tilgjengelighet/',
+      };
+    case 'no_nn':
+      return {
+        help: baseUrl + 'hjelp/',
+        about: baseUrl + 'om-altinn/',
+        serviceAnnouncements: baseUrl + 'om-altinn/driftsmeldingar/',
+        privacy: baseUrl + 'om-altinn/personvern/',
+        accessibility: baseUrl + 'om-altinn/tilgjengelighet/',
+      };
+    case 'no':
+    default:
+      return {
+        help: baseUrl + 'hjelp/',
+        about: baseUrl + 'om-altinn/',
+        serviceAnnouncements: baseUrl + 'om-altinn/driftsmeldinger/',
+        privacy: baseUrl + 'om-altinn/personvern/',
+        accessibility: baseUrl + 'om-altinn/tilgjengelighet/',
+      };
+  }
 };

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -135,7 +135,8 @@
     "help": "Help and contact",
     "service_messages": "Service messages",
     "privacy_policy": "Privacy policy",
-    "accessibility": "Accessibility"
+    "accessibility": "Accessibility",
+    "service_announcement": "Service announcements"
   },
   "sidebar": {
     "access_management": "Access management",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -154,7 +154,8 @@
     "help": "Hjelp og kontakt",
     "service_messages": "Driftsmeldinger",
     "privacy_policy": "Personvern",
-    "accessibility": "Tilgjengelighet"
+    "accessibility": "Tilgjengelighet",
+    "service_announcement": "Driftsmeldinger"
   },
   "sidebar": {
     "access_management": "Tilgangsstyring",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -132,7 +132,8 @@
     "help": "Hjelp og kontakt",
     "service_messages": "Driftsmeldingar",
     "privacy_policy": "Personvern",
-    "accessibility": "Tilgjengeligheit"
+    "accessibility": "Tilgjengeligheit",
+    "service_announcement": "Driftsmeldingar"
   },
   "sidebar": {
     "access_management": "Tilgangsstyring",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<img width="623" height="123" alt="image" src="https://github.com/user-attachments/assets/a352cac6-0d5d-4fa3-8ac3-e865cadb18a4" />

## Description
<!--- Describe your changes in detail -->

By request from the InfoPortal team, the footer has been updated to include a new link for Service Announcements.
Taking this as an opportunity, the other links have also been updated to link to their more language specific counterparts, with one notable exceptions: Accessibility does not have a language specific page, hence why it always links to the standard Norwegian Bokmål.

## Related Issue(s)
- https://github.com/Altinn/altinn-components/issues/940


## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added service announcements feature to the footer with full multilingual support
  * Implemented language-specific URL mappings to provide localized footer links for help, about, service announcements, privacy, and accessibility resources
  * Enhanced footer navigation structure with improved language support for English and multiple Norwegian language variants

<!-- end of auto-generated comment: release notes by coderabbit.ai -->