### PR TITLE
Only system user requests with status 'New' can be escalated

### DIFF
--- a/src/features/amUI/systemUser/SystemUserAgentRequestPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserAgentRequestPage.tsx
@@ -62,7 +62,7 @@ export const SystemUserAgentRequestPage = () => {
     { isError: isRejectCreationRequestError, isLoading: isRejectingSystemUser },
   ] = useRejectAgentSystemUserRequestMutation();
 
-  const isEscalationPossible = request?.userMayEscalateButNotApprove;
+  const isEscalationPossible = request?.userMayEscalateButNotApprove && request?.status === 'New';
 
   const isActionButtonDisabled =
     isAcceptingSystemUser || isRejectingSystemUser || request?.status !== 'New';

--- a/src/features/amUI/systemUser/SystemUserRequestPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserRequestPage.tsx
@@ -62,7 +62,7 @@ export const SystemUserRequestPage = () => {
     { isError: isRejectCreationRequestError, isLoading: isRejectingSystemUser },
   ] = useRejectSystemUserRequestMutation();
 
-  const isEscalationPossible = request?.userMayEscalateButNotApprove;
+  const isEscalationPossible = request?.userMayEscalateButNotApprove && request?.status === 'New';
 
   const isActionButtonDisabled =
     isAcceptingSystemUser || isRejectingSystemUser || request?.status !== 'New';


### PR DESCRIPTION
## Description
- Only system user requests with status 'New' can be escalated. Hide escalate button if request is not 'New'

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
