### PR TITLE
show consent history entry as h3 instead of paragraph

### DIFF
--- a/src/features/amUI/consent/ConsentHistoryPage/ConsentHistoryPage.module.css
+++ b/src/features/amUI/consent/ConsentHistoryPage/ConsentHistoryPage.module.css
@@ -14,11 +14,6 @@
   max-width: 50rem;
 }
 
-.timelineTitle {
-  font-weight: 500;
-  font-size: 1.125rem;
-}
-
 .timelineContent {
   display: flex;
   flex-direction: column;

--- a/src/features/amUI/consent/ConsentHistoryPage/ConsentTimeline.tsx
+++ b/src/features/amUI/consent/ConsentHistoryPage/ConsentTimeline.tsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Button,
+  DsHeading,
   DsParagraph,
   DsSearch,
   Timeline,
@@ -67,12 +68,12 @@ export const ConsentTimeline = ({ consentLog, showConsentDetails }: ConsentTimel
             >
               <TimelineActivity byline={item.bylineText}>
                 <div className={classes.timelineContent}>
-                  <DsParagraph
-                    data-size='md'
-                    className={classes.timelineTitle}
+                  <DsHeading
+                    level={3}
+                    data-size='2xs'
                   >
                     {item.timelineText}
-                  </DsParagraph>
+                  </DsHeading>
                   {item.validToText && <DsParagraph data-size='xs'>{item.validToText}</DsParagraph>}
                   <span>
                     <Button


### PR DESCRIPTION
## Description
- show consent history entry as h3 instead of paragraph, this makes it easier to navigate headings to correct entry

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the visual styling and typography of timeline item titles in the consent history interface with improved formatting and presentation elements. These adjustments strengthen visual hierarchy, readability, and overall interface consistency, providing clearer distinction and improved clarity for timeline items while maintaining consistent design language throughout the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->