### PR TITLE
Show 'new' badge in system user list for system user just created by approving escalated request

### DIFF
--- a/src/features/amUI/systemUser/SystemUserAgentRequestPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserAgentRequestPage.tsx
@@ -89,7 +89,9 @@ export const SystemUserAgentRequestPage = () => {
 
   const onRejectOrApprove = (): void => {
     if (skipLogout) {
-      navigate(`/${SystemUserPath.SystemUser}/${SystemUserPath.Overview}`);
+      navigate(`/${SystemUserPath.SystemUser}/${SystemUserPath.Overview}`, {
+        state: { createdId: request?.id },
+      });
     } else {
       const url = request?.redirectUrl
         ? `${getApiBaseUrl()}/agentrequest/${request?.id}/logout`

--- a/src/features/amUI/systemUser/SystemUserRequestPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserRequestPage.tsx
@@ -89,7 +89,9 @@ export const SystemUserRequestPage = () => {
 
   const onRejectOrApprove = (): void => {
     if (skipLogout) {
-      navigate(`/${SystemUserPath.SystemUser}/${SystemUserPath.Overview}`);
+      navigate(`/${SystemUserPath.SystemUser}/${SystemUserPath.Overview}`, {
+        state: { createdId: request?.id },
+      });
     } else {
       const url = request?.redirectUrl
         ? `${getApiBaseUrl()}/request/${request?.id}/logout`


### PR DESCRIPTION
## Description
- When an escalated system user request is approved, the user is redirected back to the system user list. Show badge on the newly created system user

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Improved navigation behavior when skipping logout. The system now correctly preserves and passes created request ID information when navigating back to the Overview page. This ensures request identification data remains available throughout your session and prevents loss of important request tracking information during navigation transitions in system user request workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->