### PR TITLE
GET single consent instead of consentRequest

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/Consent/Consent.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/Consent/Consent.cs
@@ -46,5 +46,15 @@ namespace Altinn.AccessManagement.UI.Core.Models.Consent
         /// The request message
         /// </summary>
         public Dictionary<string, string>? RequestMessage { get; set; }
+
+        /// <summary>
+        /// The consent template id.
+        /// </summary>
+        public required string TemplateId { get; set; }
+
+        /// <summary>
+        /// A list of all the consent events.
+        /// </summary>
+        public required List<ConsentRequestEventDto> ConsentRequestEvents { get; set; }
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/ConsentService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/ConsentService.cs
@@ -221,14 +221,30 @@ namespace Altinn.AccessManagement.UI.Core.Services
         /// <inheritdoc />
         public async Task<Result<ConsentFE>> GetConsent(Guid consentId, CancellationToken cancellationToken)
         {
-            Result<ConsentRequestDetails> request = await _consentClient.GetConsentRequest(consentId, cancellationToken);
+            Result<Consent> request = await _consentClient.GetConsent(consentId, cancellationToken);
 
             if (request.IsProblem)
             {
                 return request.Problem;
             }
 
-            Result<EnrichedConsentTemplate> enrichedConsentTemplate = await EnrichConsentTemplate(request.Value, cancellationToken);
+            // convert consent to consentRequest to reuse enrichment logic
+            ConsentRequestDetails consentRequest = new ConsentRequestDetails()
+            {
+                Id = request.Value.Id,
+                From = request.Value.From,
+                To = request.Value.To,
+                HandledBy = request.Value.HandledBy,
+                ValidTo = request.Value.ValidTo,
+                ConsentRights = request.Value.ConsentRights,
+                RequestMessage = request.Value.RequestMessage,
+                TemplateId = request.Value.TemplateId,
+                TemplateVersion = 1,
+                RedirectUrl = string.Empty,
+                ConsentRequestEvents = request.Value.ConsentRequestEvents
+            };
+
+            Result<EnrichedConsentTemplate> enrichedConsentTemplate = await EnrichConsentTemplate(consentRequest, cancellationToken);
 
             if (enrichedConsentTemplate.IsProblem)
             {


### PR DESCRIPTION
## Description
- To show a single consent, get the consent instead of getting the consentRequest

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added template identification and comprehensive event tracking to consent requests for improved audit trails and historical visibility.

* **Improvements**
  * Enhanced consent request processing with better handling of template metadata and event logging capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->