### PR TITLE
ikke vis switch for 'vis brukere med klienttilgang' på brukersiden for privatpersoner

### DIFF
--- a/src/features/amUI/users/UsersList.tsx
+++ b/src/features/amUI/users/UsersList.tsx
@@ -35,10 +35,11 @@ export const UsersList = () => {
       partyUuid: fromParty?.partyUuid ?? '',
       fromUuid: fromParty?.partyUuid ?? '',
       toUuid: '', // all
-      includeAgentConnections,
+      includeAgentConnections:
+        fromParty?.partyTypeName === PartyType.Person || includeAgentConnections,
     },
     {
-      skip: !fromParty?.partyUuid || !isAdmin,
+      skip: !fromParty || !isAdmin,
     },
   );
   const { partyConnection: currentUser, isLoading: currentUserLoading } = useSelfConnection();


### PR DESCRIPTION
## Description
- Ikke vis switch for 'vis brukere med klienttilgang' på brukersiden for privatpersoner

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/2315

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed conditional display so the "include agent connections" switch only appears when viewing an organization account.
  * Corrected data-fetching conditions so queries run only when the source party is present and admin checks pass.
  * Ensured agent-connection inclusion is applied automatically for person-type parties while preserving the switch behavior for organizations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->