### PR TITLE
Add agent-user with existing connection without providing ssn 

### DIFF
--- a/src/features/amUI/clientAdministration/ClientAdministrationAgentsTab.tsx
+++ b/src/features/amUI/clientAdministration/ClientAdministrationAgentsTab.tsx
@@ -19,7 +19,7 @@ export const ClientAdministrationAgentsTab = () => {
     isLoading: isAgentsLoading,
     isError: isGetAgentsError,
   } = useGetAgentsQuery();
-  const [addAgent] = useAddAgentMutation();
+  const [addAgent, { isLoading: isAdding }] = useAddAgentMutation();
   const { fromParty } = usePartyRepresentation();
 
   const {
@@ -61,7 +61,7 @@ export const ClientAdministrationAgentsTab = () => {
   );
 
   const handleAddAgent = (userId: string) => {
-    addAgent({ to: userId })
+    void addAgent({ to: userId })
       .unwrap()
       .then(() => {
         openSnackbar({
@@ -99,7 +99,7 @@ export const ClientAdministrationAgentsTab = () => {
         getUserLink={(user) => `/clientadministration/agent/${user.id}`}
         onAddNewUser={(user) => navigate(`/clientadministration/agent/${user.id}`)}
         isLoading={isAgentsLoading || isIndirectLoading}
-        isActionLoading={isIndirectFetching}
+        isActionLoading={isIndirectFetching || isAdding}
         AddUserButton={AddAgentButton}
         addUserButtonLabel={t('client_administration_page.add_agent_button_short')}
         onDelegate={(user) => {


### PR DESCRIPTION
Passes in a list of indirect connections to the user search on the Client Administration page. This allows us to add new agent users who already have an existing rightholder connection without having to provide the full "SSN and last name" form. 
Test by performing a search on the Agents page on a user that has other rightholders in and adding users from the list. 

<img width="999" height="715" alt="Skjermbilde 2026-02-23 kl  12 57 12" src="https://github.com/user-attachments/assets/61f7b2a5-b665-49d0-8984-91c6487371ee" />

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
https://github.com/Altinn/altinn-authorization-tmp/issues/2312

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Snackbar feedback for agent add actions (success and persistent error messages).
  * Add/delegate agents from the UI and navigate directly to agent detail pages.
  * Show indirect connections/right-holders in the agent management view (filtered to person-type connections).
  * Improved search experience with combined loading indicators and action-level loading states.
  * Localized add-user button label and translated feedback messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->