### PR TITLE
Styling updates for filters and lists on mobile or small screens

### DIFF
--- a/src/features/amUI/clientAdministration/ClientAdministrationAgentsTab.module.css
+++ b/src/features/amUI/clientAdministration/ClientAdministrationAgentsTab.module.css
@@ -14,3 +14,10 @@
 .filters label {
   white-space: nowrap;
 }
+
+@media only screen and (max-width: 768px) {
+  .filters {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}

--- a/src/features/amUI/clientDetails/ClientDetailsAgentsList.tsx
+++ b/src/features/amUI/clientDetails/ClientDetailsAgentsList.tsx
@@ -25,6 +25,7 @@ import { isNewUser } from '../common/isNewUser';
 import { AccessPackageListItems } from '../common/AccessPackageListItems/AccessPackageListItems';
 import { UserListItems, type UserListItemData } from '../common/UserListItems/UserListItems';
 import { useClientDetailsAccessPackageActions } from './useClientDetailsAccessPackageActions';
+import { useIsMobileOrSmaller } from '@/resources/utils/screensizeUtils';
 
 type ClientDetailsAgentsListProps = {
   agents: Agent[];
@@ -103,7 +104,7 @@ export const ClientDetailsAgentsList = ({
     const isRecentlyAdded = isNewUser(agent.agentAddedAt);
     const isSubUnit = isSubUnitByType(agent.agent.variant);
     const userType = getUserListItemType(agent.agent.type);
-
+    const isMobileOrSmaller = useIsMobileOrSmaller();
     const nodes = clientAccess.reduce((acc, access) => {
       if (access.packages.length === 0) return acc;
 
@@ -112,6 +113,7 @@ export const ClientDetailsAgentsList = ({
         fullName: agent.agent.name,
         type: agent.agent.type === 'Person' ? 'person' : 'company',
       });
+
       const packages = access.packages?.map<AccessPackageListItemProps>((pkg) => {
         const hasAccess = packageIdsByAgentId.get(agentId)?.has(pkg.id) ?? false;
         const accessPackage = getAccessPackageById(pkg.id);
@@ -134,6 +136,11 @@ export const ClientDetailsAgentsList = ({
               <Button
                 variant='tertiary'
                 disabled={removeDisabled}
+                aria-label={
+                  isMobileOrSmaller
+                    ? t('client_administration_page.remove_package_button')
+                    : undefined
+                }
                 onClick={() => {
                   removeClientAccessPackage(
                     agentId,
@@ -145,12 +152,17 @@ export const ClientDetailsAgentsList = ({
                 }}
               >
                 <MinusCircleIcon />
-                {t('client_administration_page.remove_package_button')}
+                {!isMobileOrSmaller && t('client_administration_page.remove_package_button')}
               </Button>
             ) : (
               <Button
                 variant='tertiary'
                 disabled={delegateDisabled}
+                aria-label={
+                  isMobileOrSmaller
+                    ? t('client_administration_page.delegate_package_button')
+                    : undefined
+                }
                 onClick={() => {
                   addClientAccessPackage(
                     agentId,
@@ -162,7 +174,7 @@ export const ClientDetailsAgentsList = ({
                 }}
               >
                 <PlusCircleIcon />
-                {t('client_administration_page.delegate_package_button')}
+                {!isMobileOrSmaller && t('client_administration_page.delegate_package_button')}
               </Button>
             )),
         };

--- a/src/features/amUI/common/AdvancedUserSearch/AdvancedUserSearch.module.css
+++ b/src/features/amUI/common/AdvancedUserSearch/AdvancedUserSearch.module.css
@@ -28,15 +28,6 @@
   flex-direction: row;
   gap: var(--ds-spacing-3);
 }
-@media only screen and (max-width: 768px) {
-  .controls {
-    flex-direction: column;
-    align-items: stretch;
-  }
-  .searchBar {
-    max-width: 100%;
-  }
-}
 
 .showMoreButtonContainer {
   display: flex;
@@ -54,4 +45,18 @@
   flex-direction: column;
   align-items: flex-start;
   gap: var(--ds-spacing-3);
+}
+
+@media only screen and (max-width: 768px) {
+  .controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .searchBar {
+    max-width: 100%;
+  }
+  .searchAndFilters {
+    flex-direction: column;
+    align-items: stretch;
+  }
 }

--- a/src/features/amUI/common/UserListItems/UserListItems.module.css
+++ b/src/features/amUI/common/UserListItems/UserListItems.module.css
@@ -44,3 +44,13 @@
   color: var(--ds-text-color-secondary);
   font-size: 1rem;
 }
+
+@media screen and (max-width: 768px) {
+  .accessRoleItem {
+    margin-left: 0;
+  }
+  .search {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}


### PR DESCRIPTION
Diverse styling for filter og lister for liten skjerm

## Description
<img width="355" height="298" alt="Skjermbilde 2026-02-23 kl  16 07 21" src="https://github.com/user-attachments/assets/7afdb86e-3682-4caa-ae47-a06bc679fe2c" />
<img width="363" height="274" alt="Skjermbilde 2026-02-23 kl  16 06 43" src="https://github.com/user-attachments/assets/a870888a-fc4f-4f06-a24e-6d9e9a2a678c" />
<img width="362" height="582" alt="Skjermbilde 2026-02-23 kl  16 06 33" src="https://github.com/user-attachments/assets/45742130-57be-40a4-a833-8c103f25f380" />


## Related Issue(s)
https://github.com/Altinn/altinn-authorization-tmp/issues/2211
https://github.com/Altinn/altinn-authorization-tmp/issues/2215

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
