### PR TITLE
Only display delegationCheck error when in delegation mode

### DIFF
--- a/src/features/amUI/common/DelegationModal/SingleRights/RightsSection.tsx
+++ b/src/features/amUI/common/DelegationModal/SingleRights/RightsSection.tsx
@@ -65,9 +65,10 @@ export const RightsSection = ({
     type: toParty?.partyTypeName === PartyType.Organization ? 'company' : 'person',
   });
   const displayResourceAlert =
-    isDelegationCheckError ||
-    resource?.delegable === false ||
-    (rights.length > 0 && !rights.some((r) => r.delegable === true));
+    availableActions?.includes(DelegationAction.DELEGATE) &&
+    (isDelegationCheckError ||
+      resource?.delegable === false ||
+      (rights.length > 0 && !rights.some((r) => r.delegable === true)));
 
   const delegationCheckErrorDetails =
     isDelegationCheckError &&


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<img width="1510" height="586" alt="image" src="https://github.com/user-attachments/assets/f33b86c2-0de6-4c56-9886-49e3c3cfc44e" />

Added condition that delegationCheck errors should only be displayed in cases where the user is trying to delegate

## Related Issue(s)
- #https://github.com/Altinn/altinn-authorization-tmp/issues/2346

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed delegation resource alert visibility to display only when delegation actions are available, improving clarity in the delegation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->