### PR TITLE
Add search field to access package tab on reporteeRightsPage

### DIFF
--- a/src/features/amUI/reporteeRightsPage/ReporteeAccessPackageSection.tsx
+++ b/src/features/amUI/reporteeRightsPage/ReporteeAccessPackageSection.tsx
@@ -46,12 +46,6 @@ export const ReporteeAccessPackageSection = () => {
   return (
     <>
       <AccessPackageInfoAlert />
-      {numberOfAccesses > 0 && (
-        <DebouncedSearchField
-          placeholder={t('access_packages.search_label')}
-          setDebouncedSearchString={setDebouncedSearchString}
-        />
-      )}
       <Skeleton loading={isLoadingAccesses || isLoadingParty}>
         <DsHeading
           level={2}
@@ -63,6 +57,12 @@ export const ReporteeAccessPackageSection = () => {
           })}
         </DsHeading>
       </Skeleton>
+      {numberOfAccesses > 0 && (
+        <DebouncedSearchField
+          placeholder={t('access_packages.search_label')}
+          setDebouncedSearchString={setDebouncedSearchString}
+        />
+      )}
       <AccessPackageList
         isLoading={isLoadingAccesses || isLoadingParty}
         availableActions={[DelegationAction.REVOKE, DelegationAction.REQUEST]}


### PR DESCRIPTION
## Description
- Add search field to access package tab on reporteeRightsPage. Shown if there is at least 1 access package
<img width="1039" height="782" alt="image" src="https://github.com/user-attachments/assets/4bc17a5a-bd1e-4e6e-aadb-de9f709baac0" />

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a debounced search field to filter access packages on the reportee rights page.
  * Search field appears only when access packages exist.
  * Available packages automatically collapse when a search is active to simplify navigation and selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->