### PR TITLE
Clear search string when closing delegation modal

### DIFF
--- a/src/features/amUI/common/DebouncedSearchField/DebouncedSearchField.tsx
+++ b/src/features/amUI/common/DebouncedSearchField/DebouncedSearchField.tsx
@@ -25,6 +25,10 @@ export const DebouncedSearchField = ({
   );
 
   useEffect(() => {
+    setSearchString(initialValue);
+  }, [initialValue]);
+
+  useEffect(() => {
     return () => {
       debouncedUpdate.cancel();
     };

--- a/src/features/amUI/common/DelegationModal/DelegationModalContext.tsx
+++ b/src/features/amUI/common/DelegationModal/DelegationModalContext.tsx
@@ -71,6 +71,7 @@ export const DelegationModalProvider = ({ children }: DelegationModalProps) => {
     setExpandedAreas([]);
     setInfoView(false);
     setFilters([]);
+    setSearchString('');
   };
 
   return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

To avoid the same search string appearing on both single right delegation and access package delegation, we clear it from context when closing the modal.

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/2353

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search field state now correctly synchronizes with initial values
  * Search field is properly cleared when resetting the delegation modal

<!-- end of auto-generated comment: release notes by coderabbit.ai -->