### PR TITLE
Make icons large again

### DIFF
--- a/src/features/amUI/common/DelegationModal/SingleRights/ResourceHeading.tsx
+++ b/src/features/amUI/common/DelegationModal/SingleRights/ResourceHeading.tsx
@@ -17,6 +17,7 @@ export const ResourceHeading = ({ resource }: { resource: ServiceResource }) => 
         <Icon
           iconUrl={emblem ?? resource.resourceOwnerLogoUrl}
           size={small ? 'sm' : 'xl'}
+          className={!small ? classes.lgAvatar : undefined}
         />
       ) : (
         <Avatar


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->


The last PR introduced a bug where serviceowner icons were shrunken down also on big screens.
This PR fixes that by adding the missing class

Before:
<img width="1384" height="497" alt="image" src="https://github.com/user-attachments/assets/0304dd23-2f78-4817-bf4e-be8ae3e9b04b" />

After:
<img width="1450" height="523" alt="image" src="https://github.com/user-attachments/assets/f3030f9c-6ad4-4a05-b2da-51f381ab4b08" />

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced visual alignment of icons in the delegation interface to ensure consistent sizing across different display modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->