### PR TITLE
Disable display of popular services in the new GUI

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/ResourceService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/ResourceService.cs
@@ -62,9 +62,9 @@ namespace Altinn.AccessManagement.UI.Core.Services
                 List<ServiceResourceFE> resourcesFE = MapResourceToFrontendModel(resourceList, languageCode);
 
                 bool displayPopularServicesOnly = _featureFlags.DisplayPopularSingleRightsServices;
-                if (string.IsNullOrEmpty(searchParams.SearchString) && (searchParams.ROFilters == null || searchParams.ROFilters.Length == 0) && displayPopularServicesOnly)
+                if (string.IsNullOrEmpty(searchParams.SearchString) && (searchParams.ROFilters == null || searchParams.ROFilters.Length == 0) && displayPopularServicesOnly && searchParams.IncludeA2Services)
                 {
-                    // Return a selection of popular services
+                    // Return a selection of popular services (A2 services)
                     List<ServiceResourceFE> popularResources = FilterOutPopularResources(resourcesFE);
                     return PaginationUtils.GetListPage(popularResources, searchParams.Page, searchParams.ResultsPerPage);
                 }

--- a/src/features/amUI/common/DelegationModal/SingleRights/ResourceSearch.tsx
+++ b/src/features/amUI/common/DelegationModal/SingleRights/ResourceSearch.tsx
@@ -58,7 +58,10 @@ export const ResourceSearch = ({ onSelect, availableActions }: ResourceSearchPro
   );
 
   const displayPopularResources =
-    !searchString && filters.length === 0 && window.featureFlags.displayPopularSingleRightsServices;
+    !searchString &&
+    filters.length === 0 &&
+    window.featureFlags.displayPopularSingleRightsServices &&
+    false; // Popular resources are currently disabled as the list is not curated for the new UI. Will be re-enabled when a curated list is in place.
 
   const resources = searchData?.pageList;
   const totalNumberOfResults = searchData?.numEntriesTotal;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<img width="1048" height="718" alt="image" src="https://github.com/user-attachments/assets/a24112ff-fc50-41d9-9f02-96b123886a67" />

In TT02 and Production, we have previously (in the old UI) displayed only a list of popular services on empty search. (To hide test services and the likes) But we only have a list of popular A2-services, which will not work in the new UI.
Thus, we disable this feature for now. (To be enabled later)

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified resource search filtering logic to correctly handle service discovery scenarios.
  * Disabled popular resources display pending implementation of curated resource list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->