### PR TITLE
Disable inclusion of migrated apps in resource search

### DIFF
--- a/src/features/amUI/common/DelegationModal/SingleRights/ResourceSearch.tsx
+++ b/src/features/amUI/common/DelegationModal/SingleRights/ResourceSearch.tsx
@@ -47,7 +47,7 @@ export const ResourceSearch = ({ onSelect, availableActions }: ResourceSearchPro
     page: currentPage,
     resultsPerPage: searchResultsPerPage,
     includeA2Services: false,
-    includeMigratedApps: true,
+    includeMigratedApps: false,
   });
   const { data: delegatedResources } = useGetSingleRightsForRightholderQuery(
     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Ref denne [slacktråden og avgjørelsen](https://digdir.slack.com/archives/C0A20VAS9R9/p1772188660876129?thread_ts=1772118153.661479&cid=C0A20VAS9R9) så skal vi ikke vise migrerte tjenester enda i nytt GUI.


## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated search results to exclude migrated apps from delegation workflow searches, providing a more focused set of available options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->