### PR TITLE
Update help-pages link and text + skip fetch clients if toggle is off

### DIFF
--- a/src/features/amUI/common/PageLayoutWrapper/useSidebarItems.tsx
+++ b/src/features/amUI/common/PageLayoutWrapper/useSidebarItems.tsx
@@ -36,6 +36,7 @@ export const useSidebarItems = ({ isSmall }: { isSmall?: boolean }) => {
   const displaySettingsPage = window.featureFlags?.displaySettingsPage;
   const displayPoaOverviewPage = window.featureFlags?.displayPoaOverviewPage;
   const displayRequestsPage = window.featureFlags?.displayRequestsPage;
+
   const displayClientAdministrationPage = clientAdministrationPageEnabled();
   const { data: currentUser } = useGetPartyFromLoggedInUserQuery();
   const { data: reportee, isLoading: isLoadingReportee } = useGetReporteeQuery();
@@ -47,6 +48,7 @@ export const useSidebarItems = ({ isSmall }: { isSmall?: boolean }) => {
     { provider: [actingPartyUuid] },
     {
       skip:
+        !displayClientAdministrationPage ||
         !actingPartyUuid ||
         !reportee?.partyUuid ||
         !currentUser?.partyUuid ||

--- a/src/features/amUI/landingPage/LandingPage.tsx
+++ b/src/features/amUI/landingPage/LandingPage.tsx
@@ -63,6 +63,7 @@ export const LandingPage = () => {
   const { data: currentUser, isLoading: currentUserIsLoading } = useGetPartyFromLoggedInUserQuery();
   const { pendingRequests, isLoadingRequests } = useRequests();
   const actingPartyUuid = getCookie('AltinnPartyUuid') ?? '';
+  const displayClientAdministrationPage = clientAdministrationPageEnabled();
 
   const reporteeName = formatDisplayName({
     fullName: reportee?.name || '',
@@ -74,6 +75,7 @@ export const LandingPage = () => {
     { provider: [actingPartyUuid] },
     {
       skip:
+        !displayClientAdministrationPage ||
         !actingPartyUuid ||
         !reportee?.partyUuid ||
         !currentUser?.partyUuid ||
@@ -99,7 +101,6 @@ export const LandingPage = () => {
     isLoadingCanAccessSettings ||
     currentUserIsLoading ||
     isLoadingRequests;
-  const displayClientAdministrationPage = clientAdministrationPageEnabled();
 
   const getMenuItems = (): MenuItemProps[] => {
     const displayConfettiPackage = window.featureFlags?.displayConfettiPackage;

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -609,7 +609,7 @@
     "no_access_title": "You do not have access to client administration",
     "page_heading": "Client administration for {{name}}",
     "page_description": "Org.no. {{organisationidentifier}} ({{unitType}})",
-    "forwarding_accesses_info": "New! You can now forward accesses that your business has received from others. These can only be given to private individuals. Read more about this on the <a href='https://info.altinn.no/en/help/ny-tilgangsstyring/'>help pages</a>.",
+    "forwarding_accesses_info": "New! You can now forward accesses that your business has received from others. These can only be given to private individuals. <a href='https://info.altinn.no/en/help/ny-tilgangsstyring/klientadministrasjon/'>Read more about client administration on the help pages.</a>",
     "clients_tab_title": "Clients",
     "agents_tab_title": "Users",
     "add_agent_button": "Add new user",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -606,7 +606,7 @@
     "no_access_title": "Du har ikke tilgang til klientadministrasjon",
     "page_heading": "Klientadministrasjon for {{name}}",
     "page_description": "org.nr. {{organisationidentifier}} ({{unitType}})",
-    "forwarding_accesses_info": "Nyhet! Du kan nå gi videre fullmakter som din virksomhet har mottatt fra andre. Disse kan kun gis til privatpersoner. Les mer om dette på <a href='https://info.altinn.no/hjelp/ny-tilgangsstyring/'>hjelpesidene</a>.",
+    "forwarding_accesses_info": "Nyhet! Du kan nå gi videre fullmakter som din virksomhet har mottatt fra andre. Disse kan kun gis til privatpersoner. <a href='https://info.altinn.no/hjelp/ny-tilgangsstyring/klientadministrasjon/'>Les mer om klientadministrasjon på hjelpesidene.</a>",
     "clients_tab_title": "Klienter",
     "agents_tab_title": "Brukere",
     "add_agent_button": "Legg til ny bruker",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -606,7 +606,7 @@
     "no_access_title": "Du har ikkje tilgang til klientadministrasjon",
     "page_heading": "Klientadministrasjon for {{name}}",
     "page_description": "org.nr. {{organisationidentifier}} ({{unitType}})",
-    "forwarding_accesses_info": "Nyheit! Du kan no gi vidare fullmakter som verksemda di har motteke frå andre. Desse kan berre givast til privatpersonar. Les meir om dette på <a href='https://info.altinn.no/nn/hjelp/ny-tilgangsstyring/'>hjelpesidene</a>.",
+    "forwarding_accesses_info": "Nyheit! Du kan no gi vidare fullmakter som verksemda di har motteke frå andre. Desse kan berre givast til privatpersonar. <a href='https://info.altinn.no/nn/hjelp/ny-tilgangsstyring/klientadministrasjon/'>Les meir om klientadministrasjon på hjelpesidene.</a>",
     "clients_tab_title": "Klientar",
     "agents_tab_title": "Brukarar",
     "add_agent_button": "Legg til ny brukar",


### PR DESCRIPTION
Oppdaterer lenke til hjelpesiden for klientadministrasjon. 
Oppdaterer lenke med mer selvforklarende lenketekst. 
Skipper henting av klienter hvis feature-toggle er av.

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Client administration functionality now subject to feature flag control for enhanced release management.

* **Documentation**
  * Updated help documentation links across multiple languages (English, Norwegian Bokmål, and Norwegian Nynorsk) to direct users to client administration-specific resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->