### PR TITLE
Reset resource debounced search on modal close

### DIFF
--- a/src/features/amUI/common/DelegationModal/SingleRights/ResourceSearch.tsx
+++ b/src/features/amUI/common/DelegationModal/SingleRights/ResourceSearch.tsx
@@ -40,6 +40,7 @@ export const ResourceSearch = ({ onSelect, availableActions }: ResourceSearchPro
 
   useEffect(() => {
     if (!searchString) {
+      debouncedSearch.cancel?.();
       setDebouncedSearchString('');
     }
   }, [searchString]);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Added useEffect for clearing debouncedSearch if search is cleared externally (outside of the debounce's normal use)

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/2420

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed clearing behavior in the delegation modal's search: when the search field is emptied, pending debounced searches are cancelled and results/state are reliably reset so the UI no longer shows stale results.
  * Improves responsiveness and accuracy of search feedback when users clear input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->