### PR TITLE
map isDelegable for access package

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Helpers/ResourceHelper.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Helpers/ResourceHelper.cs
@@ -92,6 +92,8 @@ namespace Altinn.AccessManagement.UI.Core.Helpers
                         Urn = accessPackage.Urn,
                         Description = accessPackage.Description,
                         Name = accessPackage.Name,
+                        IsAssignable = accessPackage.IsAssignable,
+                        IsDelegable = accessPackage.IsDelegable,
                         Resources = ResourceUtils.MapToAccessPackageResourceFE(accessPackage.Resources)
                     });
                 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/AccessPackage/Frontend/AccessPackageFE.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/AccessPackage/Frontend/AccessPackageFE.cs
@@ -28,6 +28,11 @@ namespace Altinn.AccessManagement.UI.Core.Models.AccessPackage.Frontend
         public bool IsAssignable { get; set; }
 
         /// <summary>
+        /// Indicates if the package can be used for delegation
+        /// </summary>
+        public bool IsDelegable { get; set; }
+
+        /// <summary>
         /// Description
         /// </summary>
         public string Description { get; set; }


### PR DESCRIPTION
## Description
- Map access package isDelegable so frontend can access it

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Access packages now display delegation and assignment capability information, providing enhanced visibility into which packages support these operations and enabling better-informed access management decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->