### PR TITLE
Add snackbarProvider delegation modal to show snackbar above overlay

### DIFF
--- a/src/features/amUI/common/DelegationModal/DelegationModalContent.tsx
+++ b/src/features/amUI/common/DelegationModal/DelegationModalContent.tsx
@@ -150,25 +150,12 @@ export const DelegationModalContent = ({
               </Button>
             )}
             <div className={classes.content}>
-              <DelegationModalContentWrapper>
-                {infoView ? infoViewContent : searchViewContent}
-              </DelegationModalContentWrapper>
+              {infoView ? infoViewContent : searchViewContent}
+              <Snackbar />
             </div>
           </SnackbarProvider>
         </>
       </DsDialog>
     </DsDialog.TriggerContext>
-  );
-};
-
-interface DelegationModalContentWrapperProps {
-  children: React.ReactNode;
-}
-const DelegationModalContentWrapper = ({ children }: DelegationModalContentWrapperProps) => {
-  return (
-    <>
-      {children}
-      <Snackbar />
-    </>
   );
 };


### PR DESCRIPTION
## Description
- Test fix where SnackbarProvider and Snackbar is added to delegationModal to show snackbar above modal overlay

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added in-modal notification support so users see feedback and confirmations directly in the delegation dialog.
  * Ensured the dialog's back navigation and view content render correctly alongside notifications for a smoother user flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->