### PR TITLE
enable and run e-bevis test

### DIFF
--- a/playwright/e2eTests/altinn3/consent/consentMaskinporten.spec.ts
+++ b/playwright/e2eTests/altinn3/consent/consentMaskinporten.spec.ts
@@ -136,7 +136,7 @@ test.describe('Fetch consent token after approval', () => {
    *
    */
 
-  test.skip('Kjent bug som gir 400-feil. E-bevis', async ({ login, consentPage }) => {
+  test('Kjent bug som gir 400-feil. E-bevis', async ({ login, consentPage }) => {
     const [fromOrg, personThatCanApprove] = pickRandom(fromOrgs);
     const toOrg = pickRandom(toOrgs);
     const validTo = addTimeToNowUtc({ days: 2 });


### PR DESCRIPTION
When maskinporten fixes ebevis, enable this 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
