### PR TITLE
Revert "Force "nb_no" on fetching package metadata"

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/AccessPackageController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/AccessPackageController.cs
@@ -49,8 +49,7 @@ namespace Altinn.AccessManagement.UI.Controllers
         [Route("search")]
         public async Task<ActionResult<List<AccessAreaFE>>> Search([FromQuery] string searchString, [FromQuery] string typeName = null)
         {
-            // Temporarily hardcoding language to nb until backend has a fix for wrong translations of package names and descriptions. 
-            var languageCode = "nb"; // LanguageHelper.GetSelectedLanguageCookieValueBackendStandard(_httpContextAccessor.HttpContext);
+            var languageCode = LanguageHelper.GetSelectedLanguageCookieValueBackendStandard(_httpContextAccessor.HttpContext);
             try
             {
                 return await _accessPackageService.GetSearch(languageCode, searchString, typeName);
@@ -126,8 +125,7 @@ namespace Altinn.AccessManagement.UI.Controllers
                 return BadRequest("Either 'from' or 'to' query parameter must be provided.");
             }
 
-            // Temporarily hardcoding language to nb until backend has a fix for wrong translations of package names and descriptions.
-            var languageCode = "nb"; // LanguageHelper.GetSelectedLanguageCookieValueBackendStandard(_httpContextAccessor.HttpContext);
+            var languageCode = LanguageHelper.GetSelectedLanguageCookieValueBackendStandard(_httpContextAccessor.HttpContext);
             try
             {
                 var result = await _accessPackageService.GetSinglePackagePermission(party, to, from, packageId, languageCode);

--- a/src/rtk/features/accessPackageApi.ts
+++ b/src/rtk/features/accessPackageApi.ts
@@ -76,12 +76,7 @@ export const accessPackageApi = createApi({
   endpoints: (builder) => ({
     search: builder.query<
       AccessArea[],
-      {
-        searchString: string;
-        // Temporarily disable refetch on language change until backend has a fix for wrong translations of package names and descriptions.
-        // language: string;
-        typeName?: string;
-      }
+      { searchString: string; language: string; typeName?: string }
     >({
       query: ({ searchString, typeName }) => {
         const typeNameParam = typeName ? `&typeName=${typeName}` : '';
@@ -100,14 +95,7 @@ export const accessPackageApi = createApi({
     }),
     getPackagePermissionDetails: builder.query<
       AccessPackage,
-      {
-        from?: string;
-        to?: string;
-        party?: string;
-        packageId: string;
-        // Temporarily disable refetch on language change until backend has a fix for wrong translations of package names and descriptions.
-        // language: string
-      }
+      { from?: string; to?: string; party?: string; packageId: string; language: string }
     >({
       query: ({ from, to, party = getCookie('AltinnPartyUuid'), packageId }) => {
         return `permission/${packageId}?from=${from ?? ''}&to=${to ?? ''}&party=${party}`;


### PR DESCRIPTION
Reverts Altinn/altinn-access-management-frontend#2082 since backend is ready to handle translations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved language preference handling in access package search to properly respect user-selected language settings instead of defaulting to a fixed language
  * Improved permission details lookup to correctly apply selected language preferences when retrieving package information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->