### PR TITLE
Use same counter as sidebar on received tab

### DIFF
--- a/src/features/amUI/requestPage/RequestsPage.tsx
+++ b/src/features/amUI/requestPage/RequestsPage.tsx
@@ -1,6 +1,13 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Badge, BadgeVariant, Color, DsTabs, formatDisplayName } from '@altinn/altinn-components';
+import {
+  Badge,
+  BadgeVariant,
+  Color,
+  DsAlert,
+  DsTabs,
+  formatDisplayName,
+} from '@altinn/altinn-components';
 import { PageWrapper } from '@/components';
 import { PageLayoutWrapper } from '../common/PageLayoutWrapper';
 import {
@@ -41,7 +48,7 @@ export const RequestPage = () => {
   useDocumentTitle(t('request_page.page_title'));
 
   const { data: reportee, isLoading: isLoadingReportee } = useGetReporteeQuery();
-  const { data: isAdmin } = useGetIsAdminQuery();
+  const { data: isAdmin, isLoading: isLoadingAdmin } = useGetIsAdminQuery();
   const {
     pendingRequests,
     isLoadingSentRequests,
@@ -59,7 +66,7 @@ export const RequestPage = () => {
     displayRequestsPage: true,
     isAdmin,
     reportee,
-    isLoadingPermissions: isLoadingReportee,
+    isLoadingPermissions: isLoadingAdmin,
   });
 
   const getBadgeProps = (tabValue: string) =>
@@ -76,68 +83,74 @@ export const RequestPage = () => {
   return (
     <PageWrapper>
       <PageLayoutWrapper>
-        <Breadcrumbs items={['root', 'requests']} />
-        <PartyRepresentationProvider
-          fromPartyUuid={getCookie('AltinnPartyUuid')}
-          actingPartyUuid={getCookie('AltinnPartyUuid')}
-          isLoading={isLoadingReportee}
-        >
-          <ReporteePageHeading
-            title={t('request_page.heading', { name })}
-            reportee={reportee}
-            isLoading={isLoadingReportee}
-          />
-          <DsTabs
-            value={selectedTab}
-            onChange={setSelectedTab}
-            data-size='sm'
-          >
-            <DsTabs.List className={classes.requestPageTabs}>
-              <DsTabs.Tab
-                value={INCOMING_REQUESTS_TAB}
-                className={classes.requestTab}
+        {!isAdmin && !isLoadingAdmin ? (
+          <DsAlert data-color='warning'>{t('common.no_access_to_page')}</DsAlert>
+        ) : (
+          <>
+            <Breadcrumbs items={['root', 'requests']} />
+            <PartyRepresentationProvider
+              fromPartyUuid={getCookie('AltinnPartyUuid')}
+              actingPartyUuid={getCookie('AltinnPartyUuid')}
+              isLoading={isLoadingReportee}
+            >
+              <ReporteePageHeading
+                title={t('request_page.heading', { name })}
+                reportee={reportee}
+                isLoading={isLoadingReportee}
+              />
+              <DsTabs
+                value={selectedTab}
+                onChange={setSelectedTab}
+                data-size='sm'
               >
-                {!!receivedRequestsCount && (
-                  <Badge
-                    {...getBadgeProps(INCOMING_REQUESTS_TAB)}
-                    label={receivedRequestsCount}
-                  />
-                )}
-                {t('request_page.incoming_requests')}
-              </DsTabs.Tab>
-              <DsTabs.Tab
-                value={SENT_REQUESTS_TAB}
-                className={classes.requestTab}
-              >
-                <Badge
-                  {...getBadgeProps(SENT_REQUESTS_TAB)}
-                  label={String(resolvedSentRequestCount)}
-                />
-                {t('request_page.sent_requests')}
-              </DsTabs.Tab>
-            </DsTabs.List>
-            <DsTabs.Panel value={INCOMING_REQUESTS_TAB}>
-              <RequestsTabPanel
-                count={receivedRequestsCount}
-                isLoading={isLoadingReceivedRequests}
-                isError={isReceivedRequestsError}
-                emptyMessageKey='request_page.no_received_requests'
-              >
-                <PendingRequests pendingRequests={pendingRequests.received} />
-              </RequestsTabPanel>
-            </DsTabs.Panel>
-            <DsTabs.Panel value={SENT_REQUESTS_TAB}>
-              <RequestsTabPanel
-                count={sentRequestCount ?? 0}
-                isLoading={isLoadingSentRequests}
-                isError={isSentRequestsError}
-                emptyMessageKey='request_page.no_sent_requests'
-              >
-                <SentRequestsTabPanel pendingRequests={pendingRequests.sent} />
-              </RequestsTabPanel>
-            </DsTabs.Panel>
-          </DsTabs>
-        </PartyRepresentationProvider>
+                <DsTabs.List className={classes.requestPageTabs}>
+                  <DsTabs.Tab
+                    value={INCOMING_REQUESTS_TAB}
+                    className={classes.requestTab}
+                  >
+                    {!!receivedRequestsCount && (
+                      <Badge
+                        {...getBadgeProps(INCOMING_REQUESTS_TAB)}
+                        label={receivedRequestsCount}
+                      />
+                    )}
+                    {t('request_page.incoming_requests')}
+                  </DsTabs.Tab>
+                  <DsTabs.Tab
+                    value={SENT_REQUESTS_TAB}
+                    className={classes.requestTab}
+                  >
+                    <Badge
+                      {...getBadgeProps(SENT_REQUESTS_TAB)}
+                      label={String(resolvedSentRequestCount)}
+                    />
+                    {t('request_page.sent_requests')}
+                  </DsTabs.Tab>
+                </DsTabs.List>
+                <DsTabs.Panel value={INCOMING_REQUESTS_TAB}>
+                  <RequestsTabPanel
+                    count={receivedRequestsCount}
+                    isLoading={isLoadingReceivedRequests}
+                    isError={isReceivedRequestsError}
+                    emptyMessageKey='request_page.no_received_requests'
+                  >
+                    <PendingRequests pendingRequests={pendingRequests.received} />
+                  </RequestsTabPanel>
+                </DsTabs.Panel>
+                <DsTabs.Panel value={SENT_REQUESTS_TAB}>
+                  <RequestsTabPanel
+                    count={sentRequestCount ?? 0}
+                    isLoading={isLoadingSentRequests}
+                    isError={isSentRequestsError}
+                    emptyMessageKey='request_page.no_sent_requests'
+                  >
+                    <SentRequestsTabPanel pendingRequests={pendingRequests.sent} />
+                  </RequestsTabPanel>
+                </DsTabs.Panel>
+              </DsTabs>
+            </PartyRepresentationProvider>
+          </>
+        )}
       </PageLayoutWrapper>
     </PageWrapper>
   );

--- a/src/features/amUI/requestPage/RequestsPage.tsx
+++ b/src/features/amUI/requestPage/RequestsPage.tsx
@@ -18,6 +18,7 @@ import classes from './RequestPage.module.css';
 import { SentRequestsTabPanel } from './SentRequestsTabPanel';
 import { PartyRepresentationProvider } from '../common/PartyRepresentationContext/PartyRepresentationContext';
 import { getCookie } from '@/resources/Cookie/CookieMethods';
+import { useSidebarRequestCount } from '@/resources/hooks/useSidebarRequestCount';
 
 const selectedTabProps = {
   'data-size': 'sm',
@@ -50,11 +51,16 @@ export const RequestPage = () => {
   } = useRequests();
 
   const partyUuid = getCookie('AltinnPartyUuid');
-  const { data: sentRequestCount, isLoading: isLoadingSentRequestCount } =
-    useGetSentRequestsCountQuery(
-      { party: partyUuid || '', status: ['Pending'] },
-      { skip: !partyUuid || !isAdmin || !enableRequestSingleRight() },
-    );
+  const { data: sentRequestCount } = useGetSentRequestsCountQuery(
+    { party: partyUuid || '', status: ['Pending'] },
+    { skip: !partyUuid || !isAdmin || !enableRequestSingleRight() },
+  );
+  const { requestsBadgeCount: receivedRequestCount } = useSidebarRequestCount({
+    displayRequestsPage: true,
+    isAdmin,
+    reportee,
+    isLoadingPermissions: isLoadingReportee,
+  });
 
   const getBadgeProps = (tabValue: string) =>
     selectedTab === tabValue ? selectedTabProps : unselectedTabProps;
@@ -64,7 +70,7 @@ export const RequestPage = () => {
     type: reportee?.type === 'Person' ? 'person' : 'company',
   });
 
-  const receivedRequestsCount = pendingRequests ? pendingRequests.received.length : 0;
+  const receivedRequestsCount = receivedRequestCount ?? 0;
   const resolvedSentRequestCount = sentRequestCount ?? 0;
 
   return (

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -98,7 +98,8 @@
     "save_changes": "Save changes",
     "none": "no",
     "digdir": "The Norwegian Digitalisation Agency",
-    "skiplink": "Skip to main content"
+    "skiplink": "Skip to main content",
+    "no_access_to_page": "You do not have access to this page for the selected actor"
   },
   "beta_banner": {
     "info": "This is a beta version of the new access management pages in Altinn.",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -95,7 +95,8 @@
     "save_changes": "Lagre endringer",
     "none": "ingen",
     "digdir": "Digitaliseringsdirektoratet",
-    "skiplink": "Hopp til hovedinnholdet"
+    "skiplink": "Hopp til hovedinnholdet",
+    "no_access_to_page": "Du har ikke tilgang til denne siden for valgt aktør"
   },
   "beta_banner": {
     "info": "Du ser nå på en betaversjon av de nye sidene for tilgangsstyring i Altinn.",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -95,7 +95,8 @@
     "save_changes": "Lagre endringar",
     "none": "ingen",
     "digdir": "Digitaliseringsdirektoratet",
-    "skiplink": "Hopp til hovudinnhaldet"
+    "skiplink": "Hopp til hovudinnhaldet",
+    "no_access_to_page": "Du har ikkje tilgang til denne sida for vald aktør"
   },
   "beta_banner": {
     "info": "Du ser no på ein betaversjon av dei nye sidene for tilgangsstyring i Altinn.",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<img width="1559" height="876" alt="image" src="https://github.com/user-attachments/assets/d661cb6c-b448-469a-8794-232a8e5d5d80" />

## Description
<!--- Describe your changes in detail -->

The number of active received requests were counted differently on the requests page than in the sidebar menu, causing confusion. This is fixed by using the same hook both places.

## Related Issue(s)
- https://github.com/Altinn/altinn-tests/issues/489

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated how request counts are sourced and displayed for more consistent badge/tab values.
* **New Features**
  * Page now shows an access warning to non-admins instead of full page content when appropriate.
* **Chores (Localization)**
  * Added a new "no access to page" message in English and Norwegian localizations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->