### PR TITLE
Clarify buttons in instance delegation UI

### DIFF
--- a/src/features/amUI/InstanceDetailPage/AddUserModal.tsx
+++ b/src/features/amUI/InstanceDetailPage/AddUserModal.tsx
@@ -48,7 +48,7 @@ export const AddUserButton = ({ resourceId, instanceUrn, isLarge }: AddUserButto
   return (
     <>
       <DsButton
-        variant={isLarge ? 'primary' : 'secondary'}
+        variant={isLarge ? 'secondary' : 'primary'}
         onClick={() => {
           setIsOpen(true);
           modalRef.current?.showModal();

--- a/src/features/amUI/InstanceDetailPage/InstanceDetailPageContent.tsx
+++ b/src/features/amUI/InstanceDetailPage/InstanceDetailPageContent.tsx
@@ -136,18 +136,18 @@ export const InstanceDetailPageContent = () => {
     ? `${getAfUrl()}inbox/${encodeURIComponent(dialogId)}`
     : `${getAfUrl()}redirect?instanceUrn=${encodeURIComponent(instanceUrn)}`;
 
-  const showInboxLink = dialogId || !isCorrespondenceInstance;
+  const showInboxLink = !dialogId && !isCorrespondenceInstance;
 
   const inboxLink = showInboxLink ? (
     <div className={classes.inboxLinkContainer}>
       <DsButton
         asChild
-        variant={dialogId ? 'primary' : 'secondary'}
+        variant={'secondary'}
         className={classes.inboxButton}
       >
         <a href={inboxUrl}>
-          {dialogId ? <CheckmarkIcon aria-hidden /> : <EnvelopeClosedIcon aria-hidden />}
-          {dialogId ? t('common.finished') : t('instance_detail_page.see_in_inbox')}
+          {<EnvelopeClosedIcon aria-hidden />}
+          {t('instance_detail_page.see_in_inbox')}
         </a>
       </DsButton>
     </div>

--- a/src/features/amUI/InstanceDetailPage/InstanceDetailPageContent.tsx
+++ b/src/features/amUI/InstanceDetailPage/InstanceDetailPageContent.tsx
@@ -22,7 +22,7 @@ import {
   useGetIsInstanceAdminQuery,
 } from '@/rtk/features/userInfoApi';
 import { getAfUrl } from '@/resources/utils/pathUtils';
-import { CheckmarkIcon, EnvelopeClosedIcon } from '@navikt/aksel-icons';
+import { EnvelopeClosedIcon } from '@navikt/aksel-icons';
 import { DelegationAction, EditModal } from '../common/DelegationModal/EditModal';
 import type { ActionError } from '@/resources/hooks/useActionError';
 import type { UserActionTarget } from '../common/UserSearch/types';
@@ -132,9 +132,7 @@ export const InstanceDetailPageContent = () => {
 
   const isCorrespondenceInstance = instanceUrn.startsWith('urn:altinn:correspondence-id:');
 
-  const inboxUrl = dialogId
-    ? `${getAfUrl()}inbox/${encodeURIComponent(dialogId)}`
-    : `${getAfUrl()}redirect?instanceUrn=${encodeURIComponent(instanceUrn)}`;
+  const inboxUrl = `${getAfUrl()}redirect?instanceUrn=${encodeURIComponent(instanceUrn)}`;
 
   const showInboxLink = !dialogId && !isCorrespondenceInstance;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<img width="1525" height="582" alt="image" src="https://github.com/user-attachments/assets/c9184450-d9c8-4f4e-9b73-e5a46fe0b007" />

## Description
<!--- Describe your changes in detail -->

This PR makes the "+ New user" button the primary button on the delegation/poaDetails page.
This is because we want to draw attention to this button, especially in the case where the enduser is delegating from the inbox where adding new users to the element is likely the primary function.

As part of this, and due to other feedback, the "Done" button is removed. The button remains as a "See in inbox" button when part of the poa overview flow.

## Related Issue(s)
- https://github.com/Altinn/altinn-tests/issues/486
- https://github.com/Altinn/altinn-authorization-tmp/issues/2639

<img width="1539" height="738" alt="image" src="https://github.com/user-attachments/assets/9cafcb01-e44d-4541-8390-2406aaab89d7" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted button styling in the user-add modal so variant now swaps based on button size.
  * Standardized inbox button to always use the secondary variant.

* **UI Changes**
  * Updated when the inbox link is shown in the instance detail view (link now hidden in more contexts).
  * Simplified the inbox button to use a single icon and label across instance types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->