### PR TITLE
Backend: add dialog lookup handling for instance delegations

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/Dialogporten/DialogLookup.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/Dialogporten/DialogLookup.cs
@@ -1,10 +1,33 @@
+using System.Text.Json.Serialization;
+
 namespace Altinn.AccessManagement.UI.Core.Models.Dialogporten
 {
+    /// <summary>
+    /// Status of a dialogporten lookup attempt.
+    /// </summary>
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum DialogLookupStatus
+    {
+        /// <summary>Dialog was found and title is available.</summary>
+        Success,
+
+        /// <summary>Dialog was not found (404).</summary>
+        NotFound,
+
+        /// <summary>The caller does not have access to the dialog content (403).</summary>
+        Forbidden,
+    }
+
     /// <summary>
     /// Dialogporten lookup result for an instance reference.
     /// </summary>
     public class DialogLookup
     {
+        /// <summary>
+        /// Gets or sets the outcome of the lookup.
+        /// </summary>
+        public DialogLookupStatus Status { get; set; } = DialogLookupStatus.Success;
+
         /// <summary>
         /// Gets or sets the dialog identifier.
         /// </summary>
@@ -16,7 +39,7 @@ namespace Altinn.AccessManagement.UI.Core.Models.Dialogporten
         public string InstanceRef { get; set; }
 
         /// <summary>
-        /// Gets or sets localized title values.
+        /// Gets or sets localized title values. Only populated when <see cref="Status"/> is <see cref="DialogLookupStatus.Success"/>.
         /// </summary>
         public List<DialogLookupLocalization> Title { get; set; }
     }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/InstanceService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/InstanceService.cs
@@ -1,5 +1,8 @@
+using System.Net;
 using Altinn.AccessManagement.UI.Core.ClientInterfaces;
 using Altinn.AccessManagement.UI.Core.Configuration;
+using Altinn.AccessManagement.UI.Core.Helpers;
+using Altinn.AccessManagement.UI.Core.Models.Dialogporten;
 using Altinn.AccessManagement.UI.Core.Models.InstanceDelegation;
 using Altinn.AccessManagement.UI.Core.Models.InstanceDelegation.Frontend;
 using Altinn.AccessManagement.UI.Core.Models.ResourceRegistry.Frontend;
@@ -99,6 +102,14 @@ namespace Altinn.AccessManagement.UI.Core.Services
                 try
                 {
                     d.DialogLookup = await _dialogportClient.GetDialogLookupByInstanceRef(enrichedToken, languageCode, d.Instance.RefId);
+                }
+                catch (HttpStatusException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+                {
+                    d.DialogLookup = new DialogLookup { Status = DialogLookupStatus.NotFound };
+                }
+                catch (HttpStatusException ex) when (ex.StatusCode == HttpStatusCode.Forbidden)
+                {
+                    d.DialogLookup = new DialogLookup { Status = DialogLookupStatus.Forbidden };
                 }
                 catch (Exception ex)
                 {

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/DialogportClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/DialogportClient.cs
@@ -46,11 +46,6 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
             string endpointUrl = $"enduser/dialoglookup?instanceRef={Uri.EscapeDataString(instanceRef)}";
             HttpResponseMessage response = await _httpClient.GetAsync(authorizationToken, endpointUrl, languageCode: languageCode);
 
-            if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
-            {
-                return null;
-            }
-
             return await ClientUtils.DeserializeIfSuccessfullStatusCode<DialogLookup>(
                 response,
                 _logger,

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/Dialogporten/DialogLookup/b42df1f3-56f2-436a-bad7-222222222222.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/Dialogporten/DialogLookup/b42df1f3-56f2-436a-bad7-222222222222.json
@@ -1,4 +1,5 @@
 {
+  "status": "Success",
   "dialogId": "44444444-4444-4444-4444-444444444444",
   "instanceRef": "urn:altinn:instance-id:51599233/b42df1f3-56f2-436a-bad7-222222222222",
   "title": [

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/Dialogporten/DialogLookup/c1d2e3f4-1111-2222-3333-444455556666.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/Dialogporten/DialogLookup/c1d2e3f4-1111-2222-3333-444455556666.json
@@ -1,4 +1,5 @@
 {
+  "status": "Success",
   "dialogId": "22222222-2222-2222-2222-222222222222",
   "instanceRef": "urn:altinn:instance-id:51599233/c1d2e3f4-1111-2222-3333-444455556666",
   "title": [

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/Dialogporten/DialogLookup/df333e75-5896-4254-a69f-146736eaf668.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/Dialogporten/DialogLookup/df333e75-5896-4254-a69f-146736eaf668.json
@@ -1,4 +1,5 @@
 {
+  "status": "Success",
   "dialogId": "11111111-1111-1111-1111-111111111111",
   "instanceRef": "urn:altinn:instance-id:51599233/df333e75-5896-4254-a69f-146736eaf668",
   "title": [

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/Dialogporten/DialogLookup/ffffffff-forb-forb-forb-000000000000.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/Dialogporten/DialogLookup/ffffffff-forb-forb-forb-000000000000.json
@@ -1,0 +1,3 @@
+{
+  "status": "Forbidden"
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/Instance/GetInstances/instances.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/Instance/GetInstances/instances.json
@@ -242,5 +242,125 @@
         "reason": null
       }
     ]
+  },
+  {
+    "resource": {
+      "id": "7e2058a4-4c01-4db4-a74e-e70f4b6d6e5b",
+      "providerId": "5c6e075d-343d-8bcb-b08e-54a4bb7e223e",
+      "typeId": "0197f8a2-db76-7d5a-8120-0f2937d528a9",
+      "name": "generic-access-resource",
+      "description": "An Altinn 3 app",
+      "refId": "generic-access-resource",
+      "provider": {
+        "id": "5c6e075d-343d-8bcb-b08e-54a4bb7e223e",
+        "name": "Testdepartementet",
+        "refId": "",
+        "logoUrl": "https://altinncdn.no/orgs/ttd/ttd.png",
+        "code": "ttd",
+        "typeId": "0195efb8-7c80-713e-ad96-a9896d12f444",
+        "type": {
+          "id": "0195efb8-7c80-713e-ad96-a9896d12f444",
+          "name": "Tjenesteeier"
+        }
+      },
+      "type": {
+        "id": "0197f8a2-db76-7d5a-8120-0f2937d528a9",
+        "name": "AltinnApp"
+      }
+    },
+    "instance": {
+      "refId": "urn:altinn:correspondence-id:51599233/cccccccc-corr-corr-corr-000000000000",
+      "type": {
+        "id": "eb7cd8eb-eee4-43cf-814b-f54e143cd954",
+        "name": "BrukerstyrtAppInstansDelegering"
+      }
+    },
+    "permissions": [
+      {
+        "from": {
+          "id": "cd35779b-b174-4ecc-bbef-ece13611be7f",
+          "name": "DISKRET NÆR TIGER AS",
+          "type": "organization",
+          "variant": "AS",
+          "parent": null,
+          "children": null,
+          "partyId": 51329012
+        },
+        "to": {
+          "id": "167536b5-f8ed-4c5a-8f48-0279507e53ae",
+          "name": "SITRONGUL MEDALJONG",
+          "type": "person",
+          "variant": null,
+          "parent": null,
+          "children": null,
+          "partyId": 50789533,
+          "dateOfBirth": "1981-03-20"
+        },
+        "via": null,
+        "role": null,
+        "viaRole": null,
+        "reason": null
+      }
+    ]
+  },
+  {
+    "resource": {
+      "id": "7e2058a4-4c01-4db4-a74e-e70f4b6d6e5b",
+      "providerId": "5c6e075d-343d-8bcb-b08e-54a4bb7e223e",
+      "typeId": "0197f8a2-db76-7d5a-8120-0f2937d528a9",
+      "name": "generic-access-resource",
+      "description": "An Altinn 3 app",
+      "refId": "generic-access-resource",
+      "provider": {
+        "id": "5c6e075d-343d-8bcb-b08e-54a4bb7e223e",
+        "name": "Testdepartementet",
+        "refId": "",
+        "logoUrl": "https://altinncdn.no/orgs/ttd/ttd.png",
+        "code": "ttd",
+        "typeId": "0195efb8-7c80-713e-ad96-a9896d12f444",
+        "type": {
+          "id": "0195efb8-7c80-713e-ad96-a9896d12f444",
+          "name": "Tjenesteeier"
+        }
+      },
+      "type": {
+        "id": "0197f8a2-db76-7d5a-8120-0f2937d528a9",
+        "name": "AltinnApp"
+      }
+    },
+    "instance": {
+      "refId": "urn:altinn:instance-id:51599233/ffffffff-forb-forb-forb-000000000000",
+      "type": {
+        "id": "eb7cd8eb-eee4-43cf-814b-f54e143cd954",
+        "name": "BrukerstyrtAppInstansDelegering"
+      }
+    },
+    "permissions": [
+      {
+        "from": {
+          "id": "cd35779b-b174-4ecc-bbef-ece13611be7f",
+          "name": "DISKRET NÆR TIGER AS",
+          "type": "organization",
+          "variant": "AS",
+          "parent": null,
+          "children": null,
+          "partyId": 51329012
+        },
+        "to": {
+          "id": "167536b5-f8ed-4c5a-8f48-0279507e53ae",
+          "name": "SITRONGUL MEDALJONG",
+          "type": "person",
+          "variant": null,
+          "parent": null,
+          "children": null,
+          "partyId": 50789533,
+          "dateOfBirth": "1981-03-20"
+        },
+        "via": null,
+        "role": null,
+        "viaRole": null,
+        "reason": null
+      }
+    ]
   }
 ]

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/DialogportClientMock.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/DialogportClientMock.cs
@@ -27,7 +27,7 @@ namespace Altinn.AccessManagement.UI.Mocks.Mocks
 
             if (!File.Exists(path))
             {
-                return Task.FromResult<DialogLookup>(null);
+                return Task.FromResult(new DialogLookup { Status = DialogLookupStatus.NotFound });
             }
 
             return Task.FromResult(Util.GetMockData<DialogLookup>(path));

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/InstanceControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/InstanceControllerTest.cs
@@ -10,6 +10,7 @@ using Altinn.AccessManagement.UI.Core.Configuration;
 using Altinn.AccessManagement.UI.Core.Helpers;
 using Altinn.AccessManagement.UI.Core.Models.AccessPackage;
 using Altinn.AccessManagement.UI.Core.Models.Connections;
+using Altinn.AccessManagement.UI.Core.Models.Dialogporten;
 using Altinn.AccessManagement.UI.Core.Models.InstanceDelegation;
 using Altinn.AccessManagement.UI.Core.Models.InstanceDelegation.Frontend;
 using Altinn.AccessManagement.UI.Core.Models.ResourceRegistry.Frontend;
@@ -150,10 +151,10 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
 
         /// <summary>
         /// Test case: Returns the instance even when dialogporten lookup is not found.
-        /// Expected: Returns OK and the instance without dialog lookup data.
+        /// Expected: Returns OK and the instance with dialog lookup marked as not found.
         /// </summary>
         [Fact]
-        public async Task GetInstances_WhenDialogLookupIsMissing_ReturnsInstanceWithoutDialogData()
+        public async Task GetInstances_WhenDialogLookupIsMissing_ReturnsInstanceWithDialogLookupMarkedNotFound()
         {
             Guid party = Guid.Parse("cd35779b-b174-4ecc-bbef-ece13611be7f");
             Guid from = Guid.Parse("cd35779b-b174-4ecc-bbef-ece13611be7f");
@@ -169,7 +170,8 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             Assert.NotNull(actualResponse);
             Assert.Single(actualResponse);
             AssertionUtil.AssertEqual(expectedResponse, actualResponse[0]);
-            Assert.Null(actualResponse[0].DialogLookup);
+            Assert.NotNull(actualResponse[0].DialogLookup);
+            Assert.Equal(DialogLookupStatus.NotFound, actualResponse[0].DialogLookup.Status);
         }
 
         /// <summary>
@@ -278,6 +280,57 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             Assert.NotNull(actualResponse);
             Assert.Single(actualResponse);
             Assert.Null(actualResponse[0].DialogLookup);
+        }
+
+        /// <summary>
+        /// Test case: Dialogporten lookup returns a handled HTTP status.
+        /// Expected: Returns OK with the instance included and the mapped DialogLookup status.
+        /// </summary>
+        [Theory]
+        [InlineData(HttpStatusCode.NotFound, DialogLookupStatus.NotFound)]
+        [InlineData(HttpStatusCode.Forbidden, DialogLookupStatus.Forbidden)]
+        public async Task GetInstances_WhenDialogLookupReturnsHandledHttpStatus_MapsDialogLookupStatus(
+            HttpStatusCode dialogLookupStatusCode,
+            DialogLookupStatus expectedStatus)
+        {
+            Guid party = Guid.Parse("cd35779b-b174-4ecc-bbef-ece13611be7f");
+            Guid from = Guid.Parse("cd35779b-b174-4ecc-bbef-ece13611be7f");
+            string instanceRef = "urn:altinn:instance-id:51599233/df333e75-5896-4254-a69f-146736eaf668";
+
+            var authenticationClientMock = new Mock<IAuthenticationClient>();
+            authenticationClientMock
+                .Setup(c => c.GetPidEnrichedToken())
+                .ReturnsAsync("enriched-token");
+
+            var dialogportClientMock = new Mock<IDialogportClient>();
+            dialogportClientMock
+                .Setup(c => c.GetDialogLookupByInstanceRef(It.IsAny<string>(), It.IsAny<string>(), instanceRef))
+                .ThrowsAsync(new HttpStatusException(
+                    dialogLookupStatusCode.ToString(),
+                    dialogLookupStatusCode.ToString(),
+                    dialogLookupStatusCode,
+                    string.Empty,
+                    "Handled dialog lookup error"));
+
+            var instanceService = new InstanceService(
+                authenticationClientMock.Object,
+                Options.Create(new FeatureFlags { EnableDialogportenDialogLookup = true }),
+                dialogportClientMock.Object,
+                new InstanceClientMock(null, new Mock<ILogger<InstanceClientMock>>().Object, null),
+                new Mock<ILogger<InstanceService>>().Object,
+                _factory.Services.GetRequiredService<IResourceService>());
+
+            HttpClient client = GetTestClient(instanceService);
+
+            HttpResponseMessage httpResponse = await client.GetAsync(
+                $"accessmanagement/api/v1/instances/delegation/instances?party={party}&from={from}&instance={Uri.EscapeDataString(instanceRef)}");
+            List<InstanceDelegation> actualResponse = await httpResponse.Content.ReadFromJsonAsync<List<InstanceDelegation>>();
+
+            Assert.Equal(HttpStatusCode.OK, httpResponse.StatusCode);
+            Assert.NotNull(actualResponse);
+            Assert.Single(actualResponse);
+            Assert.NotNull(actualResponse[0].DialogLookup);
+            Assert.Equal(expectedStatus, actualResponse[0].DialogLookup.Status);
         }
 
         /// <summary>

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/Instance/GetInstances/instances.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/Instance/GetInstances/instances.json
@@ -56,6 +56,7 @@
       }
     ],
     "dialogLookup": {
+      "status": "Success",
       "dialogId": "11111111-1111-1111-1111-111111111111",
       "instanceRef": "urn:altinn:instance-id:51599233/df333e75-5896-4254-a69f-146736eaf668",
       "title": [
@@ -127,6 +128,7 @@
       }
     ],
     "dialogLookup": {
+      "status": "Success",
       "dialogId": "22222222-2222-2222-2222-222222222222",
       "instanceRef": "urn:altinn:instance-id:51599233/c1d2e3f4-1111-2222-3333-444455556666",
       "title": [
@@ -193,7 +195,9 @@
         "reason": null
       }
     ],
-    "dialogLookup": null
+    "dialogLookup": {
+      "status": "NotFound"
+    }
   },
   {
     "resource": {
@@ -252,6 +256,7 @@
       }
     ],
     "dialogLookup": {
+      "status": "Success",
       "dialogId": "44444444-4444-4444-4444-444444444444",
       "instanceRef": "urn:altinn:instance-id:51599233/b42df1f3-56f2-436a-bad7-222222222222",
       "title": [
@@ -260,6 +265,126 @@
           "languageCode": "nb"
         }
       ]
+    }
+  },
+  {
+    "resource": {
+      "identifier": "generic-access-resource",
+      "title": "generic-access-resource",
+      "description": "An Altinn 3 app",
+      "rightDescription": null,
+      "homepage": null,
+      "status": null,
+      "spatial": null,
+      "contactPoints": null,
+      "delegable": true,
+      "visible": true,
+      "resourceOwnerName": "Testdepartementet",
+      "resourceOwnerOrgNumber": "",
+      "resourceOwnerLogoUrl": "https://altinncdn.no/orgs/ttd/ttd.png",
+      "resourceOwnerOrgcode": "ttd",
+      "resourceReferences": null,
+      "priorityCounter": null,
+      "resourceType": "AltinnApp",
+      "authorizationReference": null,
+      "keywords": []
+    },
+    "instance": {
+      "refId": "urn:altinn:correspondence-id:51599233/cccccccc-corr-corr-corr-000000000000",
+      "type": {
+        "id": "eb7cd8eb-eee4-43cf-814b-f54e143cd954",
+        "name": "BrukerstyrtAppInstansDelegering"
+      }
+    },
+    "permissions": [
+      {
+        "from": {
+          "id": "cd35779b-b174-4ecc-bbef-ece13611be7f",
+          "name": "DISKRET NÆR TIGER AS",
+          "type": "organization",
+          "variant": "AS",
+          "parent": null,
+          "children": null,
+          "partyId": 51329012
+        },
+        "to": {
+          "id": "167536b5-f8ed-4c5a-8f48-0279507e53ae",
+          "name": "SITRONGUL MEDALJONG",
+          "type": "person",
+          "variant": null,
+          "parent": null,
+          "children": null,
+          "partyId": 50789533,
+          "dateOfBirth": "1981-03-20"
+        },
+        "via": null,
+        "role": null,
+        "viaRole": null,
+        "reason": null
+      }
+    ],
+    "dialogLookup": {
+      "status": "NotFound"
+    }
+  },
+  {
+    "resource": {
+      "identifier": "generic-access-resource",
+      "title": "generic-access-resource",
+      "description": "An Altinn 3 app",
+      "rightDescription": null,
+      "homepage": null,
+      "status": null,
+      "spatial": null,
+      "contactPoints": null,
+      "delegable": true,
+      "visible": true,
+      "resourceOwnerName": "Testdepartementet",
+      "resourceOwnerOrgNumber": "",
+      "resourceOwnerLogoUrl": "https://altinncdn.no/orgs/ttd/ttd.png",
+      "resourceOwnerOrgcode": "ttd",
+      "resourceReferences": null,
+      "priorityCounter": null,
+      "resourceType": "AltinnApp",
+      "authorizationReference": null,
+      "keywords": []
+    },
+    "instance": {
+      "refId": "urn:altinn:instance-id:51599233/ffffffff-forb-forb-forb-000000000000",
+      "type": {
+        "id": "eb7cd8eb-eee4-43cf-814b-f54e143cd954",
+        "name": "BrukerstyrtAppInstansDelegering"
+      }
+    },
+    "permissions": [
+      {
+        "from": {
+          "id": "cd35779b-b174-4ecc-bbef-ece13611be7f",
+          "name": "DISKRET NÆR TIGER AS",
+          "type": "organization",
+          "variant": "AS",
+          "parent": null,
+          "children": null,
+          "partyId": 51329012
+        },
+        "to": {
+          "id": "167536b5-f8ed-4c5a-8f48-0279507e53ae",
+          "name": "SITRONGUL MEDALJONG",
+          "type": "person",
+          "variant": null,
+          "parent": null,
+          "children": null,
+          "partyId": 50789533,
+          "dateOfBirth": "1981-03-20"
+        },
+        "via": null,
+        "role": null,
+        "viaRole": null,
+        "reason": null
+      }
+    ],
+    "dialogLookup": {
+      "status": "Forbidden"
     }
   }
 ]

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Utils/AssertionUtil.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Utils/AssertionUtil.cs
@@ -285,6 +285,7 @@ namespace Altinn.AccessManagement.UI.Tests.Utils
             }
 
             Assert.NotNull(expected);
+            Assert.Equal(expected.Status, actual.Status);
             Assert.Equal(expected.DialogId, actual.DialogId);
             Assert.Equal(expected.InstanceRef, actual.InstanceRef);
             AssertCollections(expected.Title, actual.Title, AssertEqual);

--- a/src/rtk/features/instanceApi.ts
+++ b/src/rtk/features/instanceApi.ts
@@ -19,10 +19,25 @@ export interface DelegationInstance {
   type: InstanceType | null;
 }
 
+export type DialogLookupStatus = 'Success' | 'NotFound' | 'Forbidden';
+
+export interface DialogLookupLocalization {
+  value: string;
+  languageCode: string;
+}
+
+export interface DialogLookup {
+  status: DialogLookupStatus;
+  dialogId?: string;
+  instanceRef?: string;
+  title?: DialogLookupLocalization[];
+}
+
 export interface InstanceDelegation {
   resource: ServiceResource;
   instance: DelegationInstance;
   permissions: Permissions[];
+  dialogLookup?: DialogLookup | null;
 }
 
 export interface InstanceRights {


### PR DESCRIPTION
Isolates the BFF part of the dailog-porten integration update. 

- Adds DialogLookupStatus to DialogLookup : `Success`, `NotFound`, and `Forbidden`.
- Updates InstanceService to map Dialogporten 404 and 403 responses into those statuses instead of dropping the lookup.

https://github.com/Altinn/altinn-authorization-tmp/issues/2676
