### PR TITLE
Use Referrer-Policy header with stricter value

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/HomeControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/HomeControllerTest.cs
@@ -44,7 +44,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             IEnumerable<string> xframeHeaders = response.Headers.GetValues("X-Frame-Options");
             IEnumerable<string> contentTypeHeaders = response.Headers.GetValues("X-Content-Type-Options");
             IEnumerable<string> xxsProtectionHeaders = response.Headers.GetValues("X-XSS-Protection");
-            IEnumerable<string> refererpolicyHeaders = response.Headers.GetValues("Referer-Policy");
+            IEnumerable<string> referrerPolicyHeaders = response.Headers.GetValues("Referrer-Policy");
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -57,7 +57,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             Assert.StartsWith("deny", xframeHeaders.ElementAt(0));
             Assert.StartsWith("nosniff", contentTypeHeaders.ElementAt(0));
             Assert.StartsWith("0", xxsProtectionHeaders.ElementAt(0));
-            Assert.StartsWith("no-referer", refererpolicyHeaders.ElementAt(0));
+            Assert.StartsWith("strict-origin-when-cross-origin", referrerPolicyHeaders.ElementAt(0));
         }
 
         /// <summary>

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Middleware/SecurityHeadersMiddleware.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Middleware/SecurityHeadersMiddleware.cs
@@ -10,7 +10,7 @@ namespace Altinn.AccessManagement.UI.Middleware
     /// X-Frame-Options
     /// X-Content-Type-Options
     /// X-XSS-Protection
-    /// Referer-Policy
+    /// Referrer-Policy
     /// </summary>
     public class SecurityHeadersMiddleware
     {
@@ -35,7 +35,7 @@ namespace Altinn.AccessManagement.UI.Middleware
             context.Response.Headers.Append("X-Frame-Options", "deny");
             context.Response.Headers.Append("X-Content-Type-Options", "nosniff");
             context.Response.Headers.Append("X-XSS-Protection", "0");
-            context.Response.Headers.Append("Referer-Policy", "no-referer");
+            context.Response.Headers.Append("Referrer-Policy", "strict-origin-when-cross-origin");
 
             return _next(context);
         }


### PR DESCRIPTION
Fix middleware to set the standard "Referrer-Policy" header with value "strict-origin-when-cross-origin" instead of the nonstandard name/value. Update unit test to use the renamed referrerPolicy variable and assert the new header/value. This corrects header naming and strengthens the default referrer policy.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
[- #{2123}](https://github.com/Altinn/risiko/issues/16)

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the HTTP Referrer-Policy security header configuration to use `strict-origin-when-cross-origin`, replacing the previous `no-referer` setting for improved handling of referrer information across origins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->