### PR TITLE
2114 add content security policy

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/HomeControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/HomeControllerTest.cs
@@ -45,7 +45,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             IEnumerable<string> contentTypeHeaders = response.Headers.GetValues("X-Content-Type-Options");
             IEnumerable<string> xxsProtectionHeaders = response.Headers.GetValues("X-XSS-Protection");
             IEnumerable<string> referrerPolicyHeaders = response.Headers.GetValues("Referrer-Policy");
-            IEnumerable<string> cspReportOnlyHeaders = response.Headers.GetValues("Content-Security-Policy-Report-Only");
+            IEnumerable<string> contentSecurityPolicyHeaders = response.Headers.GetValues("Content-Security-Policy");
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -59,12 +59,15 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             Assert.StartsWith("nosniff", contentTypeHeaders.ElementAt(0));
             Assert.StartsWith("0", xxsProtectionHeaders.ElementAt(0));
             Assert.StartsWith("strict-origin-when-cross-origin", referrerPolicyHeaders.ElementAt(0));
-            Assert.Contains("default-src 'self';", cspReportOnlyHeaders.ElementAt(0));
-            Assert.Contains("script-src 'self' 'unsafe-inline'", cspReportOnlyHeaders.ElementAt(0));
-            Assert.Contains("style-src 'self' 'unsafe-inline' https://altinncdn.no;", cspReportOnlyHeaders.ElementAt(0));
-            Assert.Contains("font-src 'self' https://altinncdn.no data:;", cspReportOnlyHeaders.ElementAt(0));
-            Assert.Contains("img-src 'self' data: https://altinncdn.no;", cspReportOnlyHeaders.ElementAt(0));
-            Assert.Contains("frame-ancestors 'none';", cspReportOnlyHeaders.ElementAt(0));
+            Assert.Contains("default-src 'self';", contentSecurityPolicyHeaders.ElementAt(0));
+            Assert.Contains("script-src 'self' 'unsafe-inline'", contentSecurityPolicyHeaders.ElementAt(0));
+            Assert.Contains("style-src 'self' 'unsafe-inline' https://altinncdn.no;", contentSecurityPolicyHeaders.ElementAt(0));
+            Assert.Contains("font-src 'self' https://altinncdn.no data:;", contentSecurityPolicyHeaders.ElementAt(0));
+            Assert.Contains("img-src 'self' data: https://altinncdn.no;", contentSecurityPolicyHeaders.ElementAt(0));
+            Assert.Contains("connect-src 'self';", contentSecurityPolicyHeaders.ElementAt(0));
+            Assert.Contains("frame-ancestors 'none';", contentSecurityPolicyHeaders.ElementAt(0));
+            Assert.Contains("base-uri 'self';", contentSecurityPolicyHeaders.ElementAt(0));
+            Assert.Contains("object-src 'none';", contentSecurityPolicyHeaders.ElementAt(0));
         }
 
         /// <summary>

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/HomeControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/HomeControllerTest.cs
@@ -45,6 +45,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             IEnumerable<string> contentTypeHeaders = response.Headers.GetValues("X-Content-Type-Options");
             IEnumerable<string> xxsProtectionHeaders = response.Headers.GetValues("X-XSS-Protection");
             IEnumerable<string> refererpolicyHeaders = response.Headers.GetValues("Referer-Policy");
+            IEnumerable<string> cspReportOnlyHeaders = response.Headers.GetValues("Content-Security-Policy-Report-Only");
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -58,6 +59,12 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             Assert.StartsWith("nosniff", contentTypeHeaders.ElementAt(0));
             Assert.StartsWith("0", xxsProtectionHeaders.ElementAt(0));
             Assert.StartsWith("no-referer", refererpolicyHeaders.ElementAt(0));
+            Assert.Contains("default-src 'self';", cspReportOnlyHeaders.ElementAt(0));
+            Assert.Contains("script-src 'self' 'unsafe-inline'", cspReportOnlyHeaders.ElementAt(0));
+            Assert.Contains("style-src 'self' 'unsafe-inline' https://altinncdn.no;", cspReportOnlyHeaders.ElementAt(0));
+            Assert.Contains("font-src 'self' https://altinncdn.no data:;", cspReportOnlyHeaders.ElementAt(0));
+            Assert.Contains("img-src 'self' data: https://altinncdn.no;", cspReportOnlyHeaders.ElementAt(0));
+            Assert.Contains("frame-ancestors 'none';", cspReportOnlyHeaders.ElementAt(0));
         }
 
         /// <summary>

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Middleware/SecurityHeadersMiddleware.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Middleware/SecurityHeadersMiddleware.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Hosting;
 
 namespace Altinn.AccessManagement.UI.Middleware
 {
@@ -15,14 +16,17 @@ namespace Altinn.AccessManagement.UI.Middleware
     public class SecurityHeadersMiddleware
     {
         private readonly RequestDelegate _next;
+        private readonly IHostEnvironment _environment;
 
         /// <summary>
         /// Default constructor for ASPNET Core Middleware.
         /// </summary>
         /// <param name="next">The next middleware</param>
-        public SecurityHeadersMiddleware(RequestDelegate next)
+        /// <param name="environment">The current host environment</param>
+        public SecurityHeadersMiddleware(RequestDelegate next, IHostEnvironment environment)
         {
             _next = next;
+            _environment = environment;
         }
 
         /// <summary>
@@ -36,8 +40,31 @@ namespace Altinn.AccessManagement.UI.Middleware
             context.Response.Headers.Append("X-Content-Type-Options", "nosniff");
             context.Response.Headers.Append("X-XSS-Protection", "0");
             context.Response.Headers.Append("Referer-Policy", "no-referer");
+            context.Response.Headers.Append("Content-Security-Policy-Report-Only", CreateContentSecurityPolicy());
 
             return _next(context);
+        }
+
+        private string CreateContentSecurityPolicy()
+        {
+            string scriptSrc = _environment.IsDevelopment()
+                ? "script-src 'self' 'unsafe-inline' http://localhost:5173;"
+                : "script-src 'self' 'unsafe-inline';";
+
+            string connectSrc = _environment.IsDevelopment()
+                ? "connect-src 'self' http://localhost:5173 ws://localhost:5173;"
+                : "connect-src 'self';";
+
+            return string.Join(" ",
+                "default-src 'self';",
+                scriptSrc,
+                "style-src 'self' 'unsafe-inline' https://altinncdn.no;",
+                "font-src 'self' https://altinncdn.no data:;",
+                "img-src 'self' data: https://altinncdn.no;",
+                connectSrc,
+                "frame-ancestors 'none';",
+                "base-uri 'self';",
+                "object-src 'none';");
         }
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Middleware/SecurityHeadersMiddleware.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Middleware/SecurityHeadersMiddleware.cs
@@ -12,6 +12,7 @@ namespace Altinn.AccessManagement.UI.Middleware
     /// X-Content-Type-Options
     /// X-XSS-Protection
     /// Referrer-Policy
+    /// Content-Security-Policy-Report-Only
     /// </summary>
     public class SecurityHeadersMiddleware
     {
@@ -55,7 +56,8 @@ namespace Altinn.AccessManagement.UI.Middleware
                 ? "connect-src 'self' http://localhost:5173 ws://localhost:5173;"
                 : "connect-src 'self';";
 
-            return string.Join(" ",
+            return string.Join(
+                " ",
                 "default-src 'self';",
                 scriptSrc,
                 "style-src 'self' 'unsafe-inline' https://altinncdn.no;",

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Middleware/SecurityHeadersMiddleware.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Middleware/SecurityHeadersMiddleware.cs
@@ -12,7 +12,7 @@ namespace Altinn.AccessManagement.UI.Middleware
     /// X-Content-Type-Options
     /// X-XSS-Protection
     /// Referrer-Policy
-    /// Content-Security-Policy-Report-Only
+    /// Content-Security-Policy
     /// </summary>
     public class SecurityHeadersMiddleware
     {
@@ -41,7 +41,7 @@ namespace Altinn.AccessManagement.UI.Middleware
             context.Response.Headers.Append("X-Content-Type-Options", "nosniff");
             context.Response.Headers.Append("X-XSS-Protection", "0");
             context.Response.Headers.Append("Referrer-Policy", "strict-origin-when-cross-origin");
-            context.Response.Headers.Append("Content-Security-Policy-Report-Only", CreateContentSecurityPolicy());
+            context.Response.Headers.Append("Content-Security-Policy", CreateContentSecurityPolicy());
 
             return _next(context);
         }

--- a/src/rtk/features/singleRights/singleRightsApi.ts
+++ b/src/rtk/features/singleRights/singleRightsApi.ts
@@ -107,7 +107,7 @@ export const singleRightsApi = createApi({
           // Default is to not include migrated apps, so only add param if true
           searchParams = searchParams + `&includeMigratedApps=true`;
         }
-        return `resources/search?Page=${page}&ResultsPerPage=${resultsPerPage}&SearchString=${searchString}${searchParams}`;
+        return `resources/search?Page=${page}&ResultsPerPage=${resultsPerPage}&SearchString=${encodeURIComponent(searchString)}${searchParams}`;
       },
     }),
     getSingleRightsForRightholder: builder.query<


### PR DESCRIPTION
The PR improves security monitoring by adding a non-blocking CSP header and fixes search reliability by URL-encoding user input so special characters do not break API requests.

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
https://github.com/Altinn/risiko/issues/25
https://github.com/Altinn/risiko/issues/24

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add Content-Security-Policy response header with environment-aware rules (development allows localhost tooling; production restricts to same-origin and trusted CDN resources).

* **Bug Fixes**
  * Properly URL-encode search queries sent to the backend to avoid malformed requests.

* **Tests**
  * Updated tests to assert the CSP header is present and includes the expected directives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->