### PR TITLE
Change check for whether to show add self button in agent systemuser

### DIFF
--- a/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPageContent.tsx
+++ b/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPageContent.tsx
@@ -249,9 +249,9 @@ export const SystemUserAgentDelegationPageContent = ({
       .then(refetchIsSelfAdded);
   };
 
-  const isAllAccessPackagesDelegable = systemUser.accessPackages.every((x) => x.isDelegable);
+  const isAllAccessPackagesAssignable = systemUser.accessPackages.every((x) => x.isAssignable);
   const hasAddSelfPermission =
-    isAdmin && isAllAccessPackagesDelegable && enableAddSelfToSystemuser();
+    isAdmin && isAllAccessPackagesAssignable && enableAddSelfToSystemuser();
   const isLoadingSelf = isAssigningSelf || isRemovingSelf || isRefetchingIsSelfAdded;
   const assignedCustomersList =
     hasAddSelfPermission && reporteeData && (isSelfAdded || assignedCustomers.length > 0)

--- a/src/features/amUI/systemUser/SystemUserAgentRequestPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserAgentRequestPage.tsx
@@ -148,7 +148,7 @@ export const SystemUserAgentRequestPage = () => {
                 vendorName: request.system.name,
                 companyName: reporteeData?.name,
                 addSelfInfo:
-                  request.accessPackages.every((p) => p.isDelegable) && enableAddSelfToSystemuser()
+                  request.accessPackages.every((p) => p.isAssignable) && enableAddSelfToSystemuser()
                     ? t('systemuser_agent_request.add_self_possible')
                     : '',
               }}


### PR DESCRIPTION
## Description
- It shoud be possible to add own organization if all access packages are assignable

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated permission requirements for adding yourself to system users, changing the underlying capability check to align with current access control logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->