### PR TITLE
Include identifier in search and boost exact matches

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/ResourceService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/ResourceService.cs
@@ -445,6 +445,7 @@ namespace Altinn.AccessManagement.UI.Core.Services
                     || StringUtils.NotNullAndContains(res.Description, word)
                     || StringUtils.NotNullAndContains(res.RightDescription, word)
                     || StringUtils.NotNullAndContains(res.ResourceOwnerName, word)
+                    || StringUtils.NotNullAndContains(res.Identifier, word)
                     || (res.Keywords != null && res.Keywords.Exists((kw) => StringUtils.NotNullAndContains(kw, word))))
                     {
                         numMatches++;
@@ -454,10 +455,14 @@ namespace Altinn.AccessManagement.UI.Core.Services
                 if (numMatches > 0)
                 {
                     res.PriorityCounter = numMatches;
-
-                    if (res.Title != null && searchString.Trim().Equals(searchString.Trim(), StringComparison.CurrentCultureIgnoreCase))
+                    if (res.Identifier != null && searchString.Trim().Equals(res.Identifier.Trim(), StringComparison.CurrentCultureIgnoreCase))
                     {
-                        res.PriorityCounter++; // Prioritize resources who's title is an exact match
+                        res.PriorityCounter += 2; // Prioritize resources who's identifier is an exact match
+                    }
+
+                    if (res.Title != null && searchString.Trim().Equals(res.Title.Trim(), StringComparison.CurrentCultureIgnoreCase))
+                    {
+                        res.PriorityCounter += 2; // Prioritize resources who's title is an exact match
                     }
 
                     matchedResources.Add(res);

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/ResourceService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/ResourceService.cs
@@ -427,13 +427,14 @@ namespace Altinn.AccessManagement.UI.Core.Services
         /// </returns>
         private List<ServiceResourceFE> SearchInResourceList(List<ServiceResourceFE> resources, string searchString)
         {
-            if (string.IsNullOrEmpty(searchString))
+            string trimmedSearchString = searchString?.Trim();
+            if (string.IsNullOrEmpty(trimmedSearchString))
             {
                 return resources;
             }
 
             List<ServiceResourceFE> matchedResources = new List<ServiceResourceFE>();
-            string[] searchWords = searchString.Trim().ToLower().Split();
+            string[] searchWords = trimmedSearchString.ToLower().Split();
 
             foreach (ServiceResourceFE res in resources)
             {
@@ -455,14 +456,14 @@ namespace Altinn.AccessManagement.UI.Core.Services
                 if (numMatches > 0)
                 {
                     res.PriorityCounter = numMatches;
-                    if (res.Identifier != null && searchString.Trim().Equals(res.Identifier.Trim(), StringComparison.CurrentCultureIgnoreCase))
+                    if (res.Identifier != null && string.Equals(trimmedSearchString, res.Identifier.Trim(), StringComparison.OrdinalIgnoreCase))
                     {
-                        res.PriorityCounter += 2; // Prioritize resources who's identifier is an exact match
+                        res.PriorityCounter += 2; // Prioritize resources whose identifier is an exact match
                     }
 
-                    if (res.Title != null && searchString.Trim().Equals(res.Title.Trim(), StringComparison.CurrentCultureIgnoreCase))
+                    if (res.Title != null && string.Equals(trimmedSearchString, res.Title.Trim(), StringComparison.OrdinalIgnoreCase))
                     {
-                        res.PriorityCounter += 2; // Prioritize resources who's title is an exact match
+                        res.PriorityCounter += 2; // Prioritize resources whose title is an exact match
                     }
 
                     matchedResources.Add(res);

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/ResourceControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/ResourceControllerTest.cs
@@ -33,6 +33,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         private readonly ResourceService _resourceService;
         private readonly JsonSerializerOptions options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
         private readonly string mockFolder;
+        private const string ExpectedDataPath = "Data/ExpectedResults";
 
         /// <summary>
         ///     Constructor setting up factory, test client and dependencies
@@ -248,6 +249,51 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             Assert.Equal(expectedResult.Page, actualResources.Page);
             Assert.Equal(expectedResult.NumEntriesTotal, actualResources.NumEntriesTotal);
             AssertionUtil.AssertCollections(expectedResult.PageList, actualResources.PageList, AssertionUtil.AssertEqual);
+        }
+
+        /// <summary>
+        ///     Test case: PaginatedSearch with exact title, exact identifier, and identifier substring.
+        ///     Expected: PaginatedSearch prioritizes exact title and identifier matches, and returns partial identifier
+        ///     matches with the expected weights.
+        /// </summary>
+        [Fact]
+        public async Task GetSingleRightsSearch_searchByIdentifier_SetsExpectedWeights()
+        {
+            // Arrange
+            string token = PrincipalUtil.GetToken(1337, 501337);
+            _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            PaginatedList<ServiceResourceFE> expectedExactTitleResult = Util.GetMockData<PaginatedList<ServiceResourceFE>>($"{ExpectedDataPath}/ResourceRegistry/Search/exactTitle_digdir-sommerfest.json");
+            PaginatedList<ServiceResourceFE> expectedExactIdentifierResult = Util.GetMockData<PaginatedList<ServiceResourceFE>>($"{ExpectedDataPath}/ResourceRegistry/Search/exactIdentifier_appid-511.json");
+            PaginatedList<ServiceResourceFE> expectedPartialIdentifierResult = Util.GetMockData<PaginatedList<ServiceResourceFE>>($"{ExpectedDataPath}/ResourceRegistry/Search/partialIdentifier_appid-51.json");
+
+            // Act
+            HttpResponseMessage exactTitleResponse = await _client.GetAsync("accessmanagement/api/v1/resources/search?ResultsPerPage=10&Page=1&SearchString=DigDir%20Sommerfest");
+            HttpResponseMessage exactIdentifierResponse = await _client.GetAsync("accessmanagement/api/v1/resources/search?ResultsPerPage=10&Page=1&SearchString=appid-511");
+            HttpResponseMessage partialIdentifierResponse = await _client.GetAsync("accessmanagement/api/v1/resources/search?ResultsPerPage=10&Page=1&SearchString=appid-51");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, exactTitleResponse.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, exactIdentifierResponse.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, partialIdentifierResponse.StatusCode);
+
+            PaginatedList<ServiceResourceFE> exactTitleResults = JsonSerializer.Deserialize<PaginatedList<ServiceResourceFE>>(await exactTitleResponse.Content.ReadAsStringAsync(), options);
+            PaginatedList<ServiceResourceFE> exactIdentifierResults = JsonSerializer.Deserialize<PaginatedList<ServiceResourceFE>>(await exactIdentifierResponse.Content.ReadAsStringAsync(), options);
+            PaginatedList<ServiceResourceFE> partialIdentifierResults = JsonSerializer.Deserialize<PaginatedList<ServiceResourceFE>>(await partialIdentifierResponse.Content.ReadAsStringAsync(), options);
+
+            Assert.Equal(expectedExactTitleResult.Page, exactTitleResults.Page);
+            Assert.Equal(expectedExactTitleResult.NumEntriesTotal, exactTitleResults.NumEntriesTotal);
+            AssertionUtil.AssertCollections(expectedExactTitleResult.PageList, exactTitleResults.PageList, AssertionUtil.AssertEqual);
+            AssertionUtil.AssertCollections(expectedExactTitleResult.PageList.Select(resource => resource.PriorityCounter).ToList(), exactTitleResults.PageList.Select(resource => resource.PriorityCounter).ToList(), Assert.Equal);
+
+            Assert.Equal(expectedExactIdentifierResult.Page, exactIdentifierResults.Page);
+            Assert.Equal(expectedExactIdentifierResult.NumEntriesTotal, exactIdentifierResults.NumEntriesTotal);
+            AssertionUtil.AssertCollections(expectedExactIdentifierResult.PageList, exactIdentifierResults.PageList, AssertionUtil.AssertEqual);
+            AssertionUtil.AssertCollections(expectedExactIdentifierResult.PageList.Select(resource => resource.PriorityCounter).ToList(), exactIdentifierResults.PageList.Select(resource => resource.PriorityCounter).ToList(), Assert.Equal);
+
+            Assert.Equal(expectedPartialIdentifierResult.Page, partialIdentifierResults.Page);
+            Assert.Equal(expectedPartialIdentifierResult.NumEntriesTotal, partialIdentifierResults.NumEntriesTotal);
+            AssertionUtil.AssertCollections(expectedPartialIdentifierResult.PageList, partialIdentifierResults.PageList, AssertionUtil.AssertEqual);
+            AssertionUtil.AssertCollections(expectedPartialIdentifierResult.PageList.Select(resource => resource.PriorityCounter).ToList(), partialIdentifierResults.PageList.Select(resource => resource.PriorityCounter).ToList(), Assert.Equal);
         }
 
         /// <summary>

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/ResourceRegistry/Search/exactIdentifier_appid-511.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/ResourceRegistry/Search/exactIdentifier_appid-511.json
@@ -1,0 +1,36 @@
+{
+  "page": 1,
+  "numEntriesTotal": 1,
+  "pageList": [
+    {
+      "identifier": "appid-511",
+      "title": "DigDir Sommerfest",
+      "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus orci turpis, vehicula a dignissim eget, condimentum at diam. Etiam iaculis, purus vel venenatis condimentum, lectus arcu tempor est, et tempor lorem elit ut nunc. Donec eu bibendum leo. Ut ac dolor erat. Vestibulum posuere fringilla iaculis",
+      "rightDescription": "Her er en beskrivelse.",
+      "homepage": null,
+      "status": null,
+      "spatial": null,
+      "contactPoints": [
+        {
+          "category": "Some category",
+          "email": "email@someemaildigdir.no",
+          "telephone": "12345678",
+          "contactPage": "Some page (webpage maybe?)"
+        }
+      ],
+      "delegable": false,
+      "visible": true,
+      "resourceOwnerName": "Digitaliseringsdirektoratet",
+      "resourceOwnerOrgNumber": "991825827",
+      "resourceReferences": [],
+      "priorityCounter": 3,
+      "resourceType": "Default",
+      "authorizationReference": [
+        {
+          "id": "urn:altinn:resource",
+          "value": "appid-511"
+        }
+      ]
+    }
+  ]
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/ResourceRegistry/Search/exactTitle_digdir-sommerfest.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/ResourceRegistry/Search/exactTitle_digdir-sommerfest.json
@@ -1,0 +1,66 @@
+{
+  "page": 1,
+  "numEntriesTotal": 2,
+  "pageList": [
+    {
+      "identifier": "appid-511",
+      "title": "DigDir Sommerfest",
+      "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus orci turpis, vehicula a dignissim eget, condimentum at diam. Etiam iaculis, purus vel venenatis condimentum, lectus arcu tempor est, et tempor lorem elit ut nunc. Donec eu bibendum leo. Ut ac dolor erat. Vestibulum posuere fringilla iaculis",
+      "rightDescription": "Her er en beskrivelse.",
+      "homepage": null,
+      "status": null,
+      "spatial": null,
+      "contactPoints": [
+        {
+          "category": "Some category",
+          "email": "email@someemaildigdir.no",
+          "telephone": "12345678",
+          "contactPage": "Some page (webpage maybe?)"
+        }
+      ],
+      "delegable": false,
+      "visible": true,
+      "resourceOwnerName": "Digitaliseringsdirektoratet",
+      "resourceOwnerOrgNumber": "991825827",
+      "resourceReferences": [],
+      "priorityCounter": 4,
+      "resourceType": "Default",
+      "authorizationReference": [
+        {
+          "id": "urn:altinn:resource",
+          "value": "appid-511"
+        }
+      ]
+    },
+    {
+      "identifier": "appid-510",
+      "title": "DigDir WiFi",
+      "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus orci turpis, vehicula a dignissim eget, condimentum at diam. Etiam iaculis, purus vel venenatis condimentum, lectus arcu tempor est, et tempor lorem elit ut nunc. Donec eu bibendum leo. Ut ac dolor erat. Vestibulum posuere fringilla iaculis",
+      "rightDescription": "Her er en beskrivelse.",
+      "homepage": null,
+      "status": null,
+      "spatial": null,
+      "contactPoints": [
+        {
+          "category": "Some category",
+          "email": "email@someemaildigdir.no",
+          "telephone": "12345678",
+          "contactPage": "Some page (webpage maybe?)"
+        }
+      ],
+      "delegable": true,
+      "visible": true,
+      "resourceOwnerName": "Digitaliseringsdirektoratet",
+      "resourceOwnerOrgNumber": "991825827",
+      "resourceReferences": [],
+      "priorityCounter": 1,
+      "resourceType": "Default",
+      "authorizationReference": [
+        {
+          "id": "urn:altinn:resource",
+          "value": "appid-510"
+        }
+      ]
+    }
+  ]
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/ResourceRegistry/Search/partialIdentifier_appid-51.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/ResourceRegistry/Search/partialIdentifier_appid-51.json
@@ -1,0 +1,126 @@
+{
+  "page": 1,
+  "numEntriesTotal": 4,
+  "pageList": [
+    {
+      "identifier": "appid-510",
+      "title": "DigDir WiFi",
+      "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus orci turpis, vehicula a dignissim eget, condimentum at diam. Etiam iaculis, purus vel venenatis condimentum, lectus arcu tempor est, et tempor lorem elit ut nunc. Donec eu bibendum leo. Ut ac dolor erat. Vestibulum posuere fringilla iaculis",
+      "rightDescription": "Her er en beskrivelse.",
+      "homepage": null,
+      "status": null,
+      "spatial": null,
+      "contactPoints": [
+        {
+          "category": "Some category",
+          "email": "email@someemaildigdir.no",
+          "telephone": "12345678",
+          "contactPage": "Some page (webpage maybe?)"
+        }
+      ],
+      "delegable": true,
+      "visible": true,
+      "resourceOwnerName": "Digitaliseringsdirektoratet",
+      "resourceOwnerOrgNumber": "991825827",
+      "resourceReferences": [],
+      "priorityCounter": 1,
+      "resourceType": "Default",
+      "authorizationReference": [
+        {
+          "id": "urn:altinn:resource",
+          "value": "appid-510"
+        }
+      ]
+    },
+    {
+      "identifier": "appid-511",
+      "title": "DigDir Sommerfest",
+      "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus orci turpis, vehicula a dignissim eget, condimentum at diam. Etiam iaculis, purus vel venenatis condimentum, lectus arcu tempor est, et tempor lorem elit ut nunc. Donec eu bibendum leo. Ut ac dolor erat. Vestibulum posuere fringilla iaculis",
+      "rightDescription": "Her er en beskrivelse.",
+      "homepage": null,
+      "status": null,
+      "spatial": null,
+      "contactPoints": [
+        {
+          "category": "Some category",
+          "email": "email@someemaildigdir.no",
+          "telephone": "12345678",
+          "contactPage": "Some page (webpage maybe?)"
+        }
+      ],
+      "delegable": false,
+      "visible": true,
+      "resourceOwnerName": "Digitaliseringsdirektoratet",
+      "resourceOwnerOrgNumber": "991825827",
+      "resourceReferences": [],
+      "priorityCounter": 1,
+      "resourceType": "Default",
+      "authorizationReference": [
+        {
+          "id": "urn:altinn:resource",
+          "value": "appid-511"
+        }
+      ]
+    },
+    {
+      "identifier": "appid-512",
+      "title": "Lønningsoversikt",
+      "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus orci turpis, vehicula a dignissim eget, condimentum at diam. Etiam iaculis, purus vel venenatis condimentum, lectus arcu tempor est, et tempor lorem elit ut nunc. Donec eu bibendum leo. Ut ac dolor erat. Vestibulum posuere fringilla iaculis",
+      "rightDescription": "Her er en beskrivelse.",
+      "homepage": null,
+      "status": null,
+      "spatial": null,
+      "contactPoints": [
+        {
+          "category": "Some category",
+          "email": "email@someemaildigdir.no",
+          "telephone": "12345678",
+          "contactPage": "Some page (webpage maybe?)"
+        }
+      ],
+      "delegable": true,
+      "visible": true,
+      "resourceOwnerName": "Digitaliseringsdirektoratet",
+      "resourceOwnerOrgNumber": "991825827",
+      "resourceReferences": [],
+      "priorityCounter": 1,
+      "resourceType": "Default",
+      "authorizationReference": [
+        {
+          "id": "urn:altinn:resource",
+          "value": "appid-512"
+        }
+      ]
+    },
+    {
+      "identifier": "appid-513",
+      "title": "Inngangsdøra på kontoret",
+      "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus orci turpis, vehicula a dignissim eget, condimentum at diam. Etiam iaculis, purus vel venenatis condimentum, lectus arcu tempor est, et tempor lorem elit ut nunc. Donec eu bibendum leo. Ut ac dolor erat. Vestibulum posuere fringilla iaculis",
+      "rightDescription": "Her er en beskrivelse.",
+      "homepage": null,
+      "status": null,
+      "spatial": null,
+      "contactPoints": [
+        {
+          "category": "Some category",
+          "email": "email@someemaildigdir.no",
+          "telephone": "12345678",
+          "contactPage": "Some page (webpage maybe?)"
+        }
+      ],
+      "delegable": true,
+      "visible": true,
+      "resourceOwnerName": "Digitaliseringsdirektoratet",
+      "resourceOwnerOrgNumber": "991825827",
+      "resourceReferences": [],
+      "priorityCounter": 1,
+      "resourceType": "Default",
+      "authorizationReference": [
+        {
+          "id": "urn:altinn:resource",
+          "value": "appid-513"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Add resource.Identifier to the searchable fields and increase priority for exact identifier or title matches. Fix a bug where the title exact-match compared the search string to itself by comparing searchString to res.Title instead. Exact identifier/title matches now add +2 to PriorityCounter to better surface precise results. (Change made in ResourceService.cs)

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected exact-match detection in resource searches
  * Expanded searchable resource attributes to include identifier
  * Improved result ranking by increasing priority scoring for exact matches

* **Tests**
  * Added an integration test to verify search ranking and weighting

* **Test Data**
  * Added expected-result fixtures for exact-title, exact-identifier, and partial-identifier searches
<!-- end of auto-generated comment: release notes by coderabbit.ai -->