### PR TITLE
Potential fix for code scanning alert no. 110: Missing cross-site request forgery token validation

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/ConnectionController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/ConnectionController.cs
@@ -162,6 +162,7 @@ namespace Altinn.AccessManagement.UI.Controllers
         /// <response code="429">TooManyRequests</response>
         [HttpPost]
         [Authorize]
+        [ValidateAntiForgeryToken]
         [Route("reportee/{partyUuid}/rightholder")]
         public async Task<ActionResult<Guid>> AddReporteeRightHolder([FromRoute] Guid partyUuid, [FromQuery] Guid? rightholderPartyUuid)
         {


### PR DESCRIPTION
Potential fix for [https://github.com/Altinn/altinn-access-management-frontend/security/code-scanning/110](https://github.com/Altinn/altinn-access-management-frontend/security/code-scanning/110)

Add anti-forgery validation to the flagged POST action by annotating `AddReporteeRightHolder` with `[ValidateAntiForgeryToken]` directly above the method (alongside `[HttpPost]`, `[Authorize]`, and `[Route(...)]`).

Best single fix without changing functionality:
- File: `backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/ConnectionController.cs`
- Region: method attributes immediately above `AddReporteeRightHolder` (around lines 163–166 in the snippet).
- Change: insert `[ValidateAntiForgeryToken]` between existing attributes and method declaration.
- No new imports are required because `Microsoft.AspNetCore.Mvc` is already present in the file and contains `ValidateAntiForgeryTokenAttribute`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
