### PR TITLE
Update instance list with dialog-lookup

### DIFF
--- a/src/features/amUI/InstanceDetailPage/InstanceDetailHeader.tsx
+++ b/src/features/amUI/InstanceDetailPage/InstanceDetailHeader.tsx
@@ -1,17 +1,16 @@
 import { DsHeading, DsParagraph, Icon, formatDisplayName } from '@altinn/altinn-components';
 import { useTranslation } from 'react-i18next';
 
-import type { DialogLookup } from '@/rtk/features/instanceApi';
+import type { DelegationInstance, DialogLookup } from '@/rtk/features/instanceApi';
 import { PartyType } from '@/rtk/features/userInfoApi';
 import type { ServiceResource } from '@/rtk/features/singleRights/singleRightsApi';
-import { getDialogTitle, resolveInstanceTitle } from '../common/InstanceList/instanceListUtils';
+import { resolveInstanceTitle } from '../common/InstanceList/instanceListUtils';
 
 import classes from './InstanceDetailHeader.module.css';
 
 interface InstanceDetailHeaderProps {
   resource: ServiceResource;
-  resourceId: string;
-  instanceUrn: string;
+  instance?: DelegationInstance;
   dialogLookup?: DialogLookup;
   providerLogoUrl?: string;
   fromPartyName?: string;
@@ -20,8 +19,7 @@ interface InstanceDetailHeaderProps {
 
 export const InstanceDetailHeader = ({
   resource,
-  resourceId,
-  instanceUrn,
+  instance,
   dialogLookup,
   providerLogoUrl,
   fromPartyName,
@@ -29,18 +27,16 @@ export const InstanceDetailHeader = ({
 }: InstanceDetailHeaderProps) => {
   const { t, i18n } = useTranslation();
   const title = resolveInstanceTitle(
-    {
-      instance: {
-        refId: instanceUrn,
-        type: null,
-      },
-      dialogLookup,
-    },
+    instance
+      ? {
+          instance,
+          dialogLookup,
+        }
+      : undefined,
     resource,
     t,
     i18n.language,
   );
-  const dialogTitle = getDialogTitle(dialogLookup, i18n.language);
 
   return (
     <div className={classes.infoHeading}>
@@ -48,11 +44,7 @@ export const InstanceDetailHeader = ({
         level={1}
         data-size='sm'
       >
-        {dialogTitle
-          ? dialogTitle
-          : t('instance_detail_page.resource_title', {
-              title: title || (resource.title ?? resourceId),
-            })}
+        {title}
       </DsHeading>
       <div className={classes.resourceOwner}>
         <Icon

--- a/src/features/amUI/InstanceDetailPage/InstanceDetailHeader.tsx
+++ b/src/features/amUI/InstanceDetailPage/InstanceDetailHeader.tsx
@@ -1,14 +1,18 @@
 import { DsHeading, DsParagraph, Icon, formatDisplayName } from '@altinn/altinn-components';
 import { useTranslation } from 'react-i18next';
 
+import type { DialogLookup } from '@/rtk/features/instanceApi';
 import { PartyType } from '@/rtk/features/userInfoApi';
 import type { ServiceResource } from '@/rtk/features/singleRights/singleRightsApi';
+import { resolveInstanceTitle } from '../common/InstanceList/instanceListUtils';
 
 import classes from './InstanceDetailHeader.module.css';
 
 interface InstanceDetailHeaderProps {
   resource: ServiceResource;
   resourceId: string;
+  instanceUrn: string;
+  dialogLookup?: DialogLookup;
   providerLogoUrl?: string;
   fromPartyName?: string;
   fromPartyTypeName?: PartyType;
@@ -17,11 +21,25 @@ interface InstanceDetailHeaderProps {
 export const InstanceDetailHeader = ({
   resource,
   resourceId,
+  instanceUrn,
+  dialogLookup,
   providerLogoUrl,
   fromPartyName,
   fromPartyTypeName,
 }: InstanceDetailHeaderProps) => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const title = resolveInstanceTitle(
+    {
+      instance: {
+        refId: instanceUrn,
+        type: null,
+      },
+      dialogLookup,
+    },
+    resource,
+    t,
+    i18n.language,
+  );
 
   return (
     <div className={classes.infoHeading}>
@@ -29,7 +47,9 @@ export const InstanceDetailHeader = ({
         level={1}
         data-size='sm'
       >
-        {t('instance_detail_page.resource_title', { title: resource.title ?? resourceId })}
+        {t('instance_detail_page.resource_title', {
+          title: title || (resource.title ?? resourceId),
+        })}
       </DsHeading>
       <div className={classes.resourceOwner}>
         <Icon

--- a/src/features/amUI/InstanceDetailPage/InstanceDetailHeader.tsx
+++ b/src/features/amUI/InstanceDetailPage/InstanceDetailHeader.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import type { DialogLookup } from '@/rtk/features/instanceApi';
 import { PartyType } from '@/rtk/features/userInfoApi';
 import type { ServiceResource } from '@/rtk/features/singleRights/singleRightsApi';
-import { resolveInstanceTitle } from '../common/InstanceList/instanceListUtils';
+import { getDialogTitle, resolveInstanceTitle } from '../common/InstanceList/instanceListUtils';
 
 import classes from './InstanceDetailHeader.module.css';
 
@@ -40,6 +40,7 @@ export const InstanceDetailHeader = ({
     t,
     i18n.language,
   );
+  const dialogTitle = getDialogTitle(dialogLookup, i18n.language);
 
   return (
     <div className={classes.infoHeading}>
@@ -47,9 +48,11 @@ export const InstanceDetailHeader = ({
         level={1}
         data-size='sm'
       >
-        {t('instance_detail_page.resource_title', {
-          title: title || (resource.title ?? resourceId),
-        })}
+        {dialogTitle
+          ? dialogTitle
+          : t('instance_detail_page.resource_title', {
+              title: title || (resource.title ?? resourceId),
+            })}
       </DsHeading>
       <div className={classes.resourceOwner}>
         <Icon

--- a/src/features/amUI/InstanceDetailPage/InstanceDetailPageContent.tsx
+++ b/src/features/amUI/InstanceDetailPage/InstanceDetailPageContent.tsx
@@ -185,8 +185,7 @@ export const InstanceDetailPageContent = () => {
       {resource && (
         <InstanceDetailHeader
           resource={resource}
-          resourceId={resourceId}
-          instanceUrn={instanceUrn}
+          instance={instanceDelegation?.instance}
           dialogLookup={instanceDelegation?.dialogLookup}
           providerLogoUrl={providerLogoUrl}
           fromPartyName={fromParty?.name}

--- a/src/features/amUI/InstanceDetailPage/InstanceDetailPageContent.tsx
+++ b/src/features/amUI/InstanceDetailPage/InstanceDetailPageContent.tsx
@@ -27,6 +27,7 @@ import { DelegationAction, EditModal } from '../common/DelegationModal/EditModal
 import type { ActionError } from '@/resources/hooks/useActionError';
 import type { UserActionTarget } from '../common/UserSearch/types';
 import { AddUserButton } from './AddUserModal';
+import { isCorrespondenceInstanceUrn } from '../common/InstanceList/instanceListUtils';
 
 import classes from './InstanceDetailPageContent.module.css';
 
@@ -130,11 +131,9 @@ export const InstanceDetailPageContent = () => {
     );
   }
 
-  const isCorrespondenceInstance = instanceUrn.startsWith('urn:altinn:correspondence-id:');
-
   const inboxUrl = `${getAfUrl()}redirect?instanceUrn=${encodeURIComponent(instanceUrn)}`;
 
-  const showInboxLink = !dialogId && !isCorrespondenceInstance;
+  const showInboxLink = !dialogId && !isCorrespondenceInstanceUrn(instanceUrn);
 
   const inboxLink = showInboxLink ? (
     <div className={classes.inboxLinkContainer}>

--- a/src/features/amUI/InstanceDetailPage/InstanceDetailPageContent.tsx
+++ b/src/features/amUI/InstanceDetailPage/InstanceDetailPageContent.tsx
@@ -145,7 +145,7 @@ export const InstanceDetailPageContent = () => {
   const { href: inboxUrl, showInboxLink } = getInboxLinkData({
     instanceUrn,
     dialogLookup: instanceDelegation?.dialogLookup,
-    dialogId: dialogId ?? undefined,
+    isDialogDeepLink: Boolean(dialogId),
   });
 
   const inboxLink = showInboxLink ? (

--- a/src/features/amUI/InstanceDetailPage/InstanceDetailPageContent.tsx
+++ b/src/features/amUI/InstanceDetailPage/InstanceDetailPageContent.tsx
@@ -13,7 +13,7 @@ import {
   createErrorDetails,
   TechnicalErrorParagraphs,
 } from '../common/TechnicalErrorParagraphs/TechnicalErrorParagraphs';
-import { useRemoveInstanceMutation } from '@/rtk/features/instanceApi';
+import { useGetInstancesQuery, useRemoveInstanceMutation } from '@/rtk/features/instanceApi';
 import { useGetResourceQuery } from '@/rtk/features/resourceApi';
 import { useProviderLogoUrl } from '@/resources/hooks';
 import {
@@ -21,18 +21,17 @@ import {
   useGetIsAdminQuery,
   useGetIsInstanceAdminQuery,
 } from '@/rtk/features/userInfoApi';
-import { getAfUrl } from '@/resources/utils/pathUtils';
 import { EnvelopeClosedIcon } from '@navikt/aksel-icons';
 import { DelegationAction, EditModal } from '../common/DelegationModal/EditModal';
 import type { ActionError } from '@/resources/hooks/useActionError';
 import type { UserActionTarget } from '../common/UserSearch/types';
 import { AddUserButton } from './AddUserModal';
-import { isCorrespondenceInstanceUrn } from '../common/InstanceList/instanceListUtils';
+import { getInboxLinkData } from '../common/InstanceList/instanceListUtils';
 
 import classes from './InstanceDetailPageContent.module.css';
 
 export const InstanceDetailPageContent = () => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const [searchParams] = useSearchParams();
   const { actingParty, fromParty } = usePartyRepresentation();
 
@@ -121,6 +120,18 @@ export const InstanceDetailPageContent = () => {
   } = useGetResourceQuery(resourceId, {
     skip: !resourceId,
   });
+  const { data: instanceDelegations = [] } = useGetInstancesQuery(
+    {
+      party: actingParty?.partyUuid || '',
+      from: fromParty?.partyUuid,
+      resource: resourceId,
+      instance: instanceUrn,
+      language: i18n.language,
+    },
+    {
+      skip: !actingParty?.partyUuid || !fromParty?.partyUuid || !resourceId || !instanceUrn,
+    },
+  );
 
   if (!resourceId || !instanceUrn) {
     return (
@@ -130,10 +141,12 @@ export const InstanceDetailPageContent = () => {
       />
     );
   }
-
-  const inboxUrl = `${getAfUrl()}redirect?instanceUrn=${encodeURIComponent(instanceUrn)}`;
-
-  const showInboxLink = !dialogId && !isCorrespondenceInstanceUrn(instanceUrn);
+  const instanceDelegation = instanceDelegations[0];
+  const { href: inboxUrl, showInboxLink } = getInboxLinkData({
+    instanceUrn,
+    dialogLookup: instanceDelegation?.dialogLookup,
+    dialogId: dialogId ?? undefined,
+  });
 
   const inboxLink = showInboxLink ? (
     <div className={classes.inboxLinkContainer}>
@@ -173,6 +186,8 @@ export const InstanceDetailPageContent = () => {
         <InstanceDetailHeader
           resource={resource}
           resourceId={resourceId}
+          instanceUrn={instanceUrn}
+          dialogLookup={instanceDelegation?.dialogLookup}
           providerLogoUrl={providerLogoUrl}
           fromPartyName={fromParty?.name}
           fromPartyTypeName={fromParty?.partyTypeName}
@@ -238,8 +253,9 @@ export const InstanceDetailPageContent = () => {
           toParty={{
             partyUuid: selectedUser.id,
             name: selectedUser.name,
-            partyTypeName:
+            partyTypeName: String(
               selectedUser.type === 'person' ? PartyType.Person : PartyType.Organization,
+            ),
           }}
           openWithError={actionError}
           onSuccess={selectedUserMode === 'delegate' ? () => modalRef.current?.close() : undefined}

--- a/src/features/amUI/InstanceDetailPage/InstanceUsersAsAdmin.tsx
+++ b/src/features/amUI/InstanceDetailPage/InstanceUsersAsAdmin.tsx
@@ -34,7 +34,7 @@ export const InstanceUsersAsAdmin = ({
   onRevoke,
   isRevoking,
 }: InstanceUsersAsAdminProps) => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { actingParty, fromParty } = usePartyRepresentation();
 
   const {
@@ -48,6 +48,7 @@ export const InstanceUsersAsAdmin = ({
       from: fromParty?.partyUuid,
       resource: resourceId,
       instance: instanceUrn,
+      language: i18n.language,
     },
     {
       skip: !actingParty?.partyUuid || !fromParty?.partyUuid || !resourceId || !instanceUrn,

--- a/src/features/amUI/common/DelegationModal/EditModal.tsx
+++ b/src/features/amUI/common/DelegationModal/EditModal.tsx
@@ -6,6 +6,7 @@ import type { ActionError } from '@/resources/hooks/useActionError';
 import type { ServiceResource } from '@/rtk/features/singleRights/singleRightsApi';
 import type { AccessPackage } from '@/rtk/features/accessPackageApi';
 import type { Role } from '@/rtk/features/roleApi';
+import type { DialogLookup } from '@/rtk/features/instanceApi';
 import { ResourceInfo } from './SingleRights/ResourceInfo';
 import { InstanceInfo } from './Instance/InstanceInfo';
 import classes from './DelegationModal.module.css';
@@ -28,7 +29,7 @@ export enum DelegationAction {
 
 export interface InstanceData {
   instanceUrn: string;
-  instanceName?: string;
+  dialogLookup?: DialogLookup;
 }
 
 export interface EditModalProps {
@@ -133,7 +134,7 @@ const renderModalContent = ({
       <InstanceInfo
         resource={resource}
         instanceUrn={instance.instanceUrn}
-        instanceName={instance.instanceName}
+        dialogLookup={instance.dialogLookup}
         toParty={toParty}
         availableActions={availableActions}
         onSuccess={onSuccess}

--- a/src/features/amUI/common/DelegationModal/Instance/InstanceHeading.tsx
+++ b/src/features/amUI/common/DelegationModal/Instance/InstanceHeading.tsx
@@ -1,27 +1,45 @@
 import { useProviderLogoUrl } from '@/resources/hooks';
 import { ServiceResource } from '@/rtk/features/singleRights/singleRightsApi';
+import type { DialogLookup } from '@/rtk/features/instanceApi';
 import { Avatar, DsHeading, DsParagraph, formatDisplayName, Icon } from '@altinn/altinn-components';
 
 import classes from './InstanceHeading.module.css';
 import { PartyType } from '@/rtk/features/userInfoApi';
 import { useTranslation } from 'react-i18next';
+import { resolveInstanceTitle } from '@/features/amUI/common/InstanceList/instanceListUtils';
 
 export const InstanceHeading = ({
   resource,
+  instanceUrn,
+  dialogLookup,
   fromPartyName,
   fromPartyType,
 }: {
   resource: ServiceResource;
+  instanceUrn: string;
+  dialogLookup?: DialogLookup;
   fromPartyName?: string;
   fromPartyType?: PartyType;
 }) => {
   const { getProviderLogoUrl } = useProviderLogoUrl();
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const emblem = getProviderLogoUrl(resource.resourceOwnerOrgcode ?? '');
   const fromName = formatDisplayName({
     fullName: fromPartyName ?? '',
     type: fromPartyType === PartyType.Person ? 'person' : 'company',
   });
+  const title = resolveInstanceTitle(
+    {
+      instance: {
+        refId: instanceUrn,
+        type: null,
+      },
+      dialogLookup,
+    },
+    resource,
+    t,
+    i18n.language,
+  );
 
   const icon = () => (
     <>
@@ -48,7 +66,7 @@ export const InstanceHeading = ({
             level={3}
             data-size={'sm'}
           >
-            {resource.title}
+            {title}
           </DsHeading>
         </div>
 

--- a/src/features/amUI/common/DelegationModal/Instance/InstanceInfo.tsx
+++ b/src/features/amUI/common/DelegationModal/Instance/InstanceInfo.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { MinusCircleIcon } from '@navikt/aksel-icons';
 
 import type { ServiceResource } from '@/rtk/features/singleRights/singleRightsApi';
+import type { DialogLookup } from '@/rtk/features/instanceApi';
 
 import type { DelegationRecipient } from '../EditModal';
 import { StatusMessageForScreenReader } from '@/components/StatusMessageForScreenReader/StatusMessageForScreenReader';
@@ -25,7 +26,7 @@ import classes from './InstanceInfo.module.css';
 export interface InstanceInfoProps {
   resource: ServiceResource;
   instanceUrn: string;
-  instanceName?: string;
+  dialogLookup?: DialogLookup;
   toParty?: DelegationRecipient;
   availableActions?: DelegationAction[];
   onSuccess?: () => void;
@@ -34,7 +35,7 @@ export interface InstanceInfoProps {
 export const InstanceInfo = ({
   resource,
   instanceUrn,
-  instanceName,
+  dialogLookup,
   toParty: toPartyProp,
   availableActions,
   onSuccess,
@@ -103,6 +104,8 @@ export const InstanceInfo = ({
       <div>
         <InstanceHeading
           resource={resource}
+          instanceUrn={instanceUrn}
+          dialogLookup={dialogLookup}
           fromPartyName={fromParty?.name}
           fromPartyType={fromParty?.partyTypeName}
         />

--- a/src/features/amUI/common/InstanceList/InstanceInboxLink.tsx
+++ b/src/features/amUI/common/InstanceList/InstanceInboxLink.tsx
@@ -1,0 +1,51 @@
+import { Button, DsButton } from '@altinn/altinn-components';
+import { EnvelopeClosedIcon } from '@navikt/aksel-icons';
+import { useTranslation } from 'react-i18next';
+
+import type { InstanceDelegation } from '@/rtk/features/instanceApi';
+
+import { getInboxLinkData } from './instanceListUtils';
+
+interface InstanceInboxLinkProps {
+  instance: Pick<InstanceDelegation, 'instance' | 'dialogLookup'>;
+  isLarge?: boolean;
+}
+
+export const InstanceInboxLink = ({ instance, isLarge = false }: InstanceInboxLinkProps) => {
+  const { t } = useTranslation();
+  const { href, showInboxLink } = getInboxLinkData({
+    instanceUrn: instance.instance.refId,
+    dialogLookup: instance.dialogLookup ?? undefined,
+    dialogId: instance.dialogLookup?.dialogId,
+  });
+
+  if (!showInboxLink) {
+    return null;
+  }
+
+  if (isLarge) {
+    return (
+      <DsButton
+        asChild
+        variant='secondary'
+      >
+        <a href={href}>
+          <EnvelopeClosedIcon aria-hidden />
+          {t('instance_detail_page.see_in_inbox')}
+        </a>
+      </DsButton>
+    );
+  }
+
+  return (
+    <Button
+      variant='tertiary'
+      rounded
+      size='xs'
+      as='a'
+      href={href}
+    >
+      <EnvelopeClosedIcon aria-hidden /> {t('instance_detail_page.see_in_inbox')}
+    </Button>
+  );
+};

--- a/src/features/amUI/common/InstanceList/InstanceInboxLink.tsx
+++ b/src/features/amUI/common/InstanceList/InstanceInboxLink.tsx
@@ -16,7 +16,6 @@ export const InstanceInboxLink = ({ instance, isLarge = false }: InstanceInboxLi
   const { href, showInboxLink } = getInboxLinkData({
     instanceUrn: instance.instance.refId,
     dialogLookup: instance.dialogLookup ?? undefined,
-    dialogId: instance.dialogLookup?.dialogId,
   });
 
   if (!showInboxLink) {

--- a/src/features/amUI/common/InstanceList/InstanceList.module.css
+++ b/src/features/amUI/common/InstanceList/InstanceList.module.css
@@ -1,0 +1,7 @@
+.container {
+  margin-top: var(--ds-size-4);
+}
+
+.subtleTitle h2 {
+  color: var(--ds-color-neutral-text-subtle);
+}

--- a/src/features/amUI/common/InstanceList/InstanceList.stories.tsx
+++ b/src/features/amUI/common/InstanceList/InstanceList.stories.tsx
@@ -8,6 +8,11 @@ import type { InstanceDelegation } from '@/rtk/features/instanceApi';
 
 import { InstanceList } from './InstanceList';
 
+window.featureFlags = {
+  ...window.featureFlags,
+  enableDialogportenDialogLookup: true,
+};
+
 const digdirResource = {
   identifier: 'digdir-eksempeltjeneste',
   title: 'Eksempeltjeneste',

--- a/src/features/amUI/common/InstanceList/InstanceList.stories.tsx
+++ b/src/features/amUI/common/InstanceList/InstanceList.stories.tsx
@@ -1,0 +1,119 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { ReactNode } from 'react';
+import { RootProvider } from '@altinn/altinn-components';
+import { Provider } from 'react-redux';
+
+import store from '@/rtk/app/store';
+import type { InstanceDelegation } from '@/rtk/features/instanceApi';
+
+import { InstanceList } from './InstanceList';
+
+const digdirResource = {
+  identifier: 'digdir-eksempeltjeneste',
+  title: 'Eksempeltjeneste',
+  description: 'Eksempeltjeneste fra Digitaliseringsdirektoratet',
+  resourceOwnerName: 'Digitaliseringsdirektoratet',
+  resourceOwnerLogoUrl: 'https://altinncdn.no/orgs/digdir/digdir.png',
+  resourceOwnerOrgcode: 'digdir',
+  resourceOwnerOrgNumber: '991825827',
+  rightDescription: '',
+  resourceReferences: [],
+  authorizationReference: [],
+  resourceType: 'GenericAccessResource',
+  delegable: true,
+};
+
+const skdResource = {
+  ...digdirResource,
+  identifier: 'skd-kravogbetaling',
+  title: 'Krav og betaling',
+  resourceOwnerName: 'Skatteetaten',
+  resourceOwnerLogoUrl: 'https://altinncdn.no/orgs/skd/skd.png',
+  resourceOwnerOrgcode: 'skd',
+  resourceOwnerOrgNumber: '974761076',
+};
+
+const dialogSuccess: InstanceDelegation = {
+  resource: digdirResource,
+  instance: { refId: 'urn:altinn:instance-id:abc1234567', type: { id: '1', name: 'Soknad' } },
+  permissions: [],
+  dialogLookup: {
+    status: 'Success',
+    dialogId: 'df333e75-0000-0000-0000-000000000001',
+    instanceRef: 'urn:altinn:instance-id:abc123567',
+    title: [
+      { languageCode: 'nb', value: 'Melding om innvilget soknad om dagpenger' },
+      { languageCode: 'en', value: 'Application for unemployment benefits approved' },
+    ],
+  },
+};
+
+const dialogNotFound: InstanceDelegation = {
+  resource: digdirResource,
+  instance: { refId: 'urn:altinn:instance-id:def4569878', type: null },
+  permissions: [],
+  dialogLookup: { status: 'NotFound' },
+};
+
+const dialogNotFoundCorrespondence: InstanceDelegation = {
+  resource: skdResource,
+  instance: {
+    refId: 'urn:altinn:correspondence-id:ghi7892344',
+    type: { id: '2', name: 'Melding' },
+  },
+  permissions: [],
+  dialogLookup: { status: 'NotFound' },
+};
+
+const dialogForbidden: InstanceDelegation = {
+  resource: digdirResource,
+  instance: { refId: 'urn:altinn:instance-id:jkl0123456', type: null },
+  permissions: [],
+  dialogLookup: { status: 'Forbidden' },
+};
+
+const noDialogLookup: InstanceDelegation = {
+  resource: digdirResource,
+  instance: { refId: 'urn:altinn:instance-id:mno3456789', type: null },
+  permissions: [],
+};
+
+const Wrapper = ({ children }: { children: ReactNode }) => (
+  <Provider store={store}>
+    <RootProvider>{children}</RootProvider>
+  </Provider>
+);
+
+const meta: Meta<typeof InstanceList> = {
+  title: 'Features/AMUI/InstanceList',
+  component: InstanceList,
+  render: (args) => (
+    <Wrapper>
+      <InstanceList {...args} />
+    </Wrapper>
+  ),
+};
+
+export default meta;
+
+type Story = StoryObj<typeof InstanceList>;
+
+export const AllTitleCases: Story = {
+  args: {
+    instances: [
+      dialogSuccess,
+      dialogNotFound,
+      dialogNotFoundCorrespondence,
+      dialogForbidden,
+      noDialogLookup,
+    ],
+  },
+};
+
+export const Loading: Story = {
+  args: { instances: [], isLoading: true },
+};
+
+export const Empty: Story = {
+  args: { instances: [] },
+};

--- a/src/features/amUI/common/InstanceList/InstanceList.tsx
+++ b/src/features/amUI/common/InstanceList/InstanceList.tsx
@@ -1,20 +1,25 @@
 import { ElementType, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
-  Button,
   DialogListItem,
   DsParagraph,
   List,
   type DialogListItemProps,
 } from '@altinn/altinn-components';
+import type { TFunction } from 'i18next';
 
 import { DebouncedSearchField } from '../DebouncedSearchField/DebouncedSearchField';
 import { InstanceDelegation } from '@/rtk/features/instanceApi';
 import { useProviderLogoUrl } from '@/resources/hooks';
 
 import { InstanceListSkeleton } from './InstanceListSkeleton';
-import { EnvelopeClosedIcon } from '@navikt/aksel-icons';
-import { getAfUrl } from '@/resources/utils/pathUtils';
+import { InstanceInboxLink } from './InstanceInboxLink';
+import {
+  getInstanceShortId,
+  resolveInstanceTitle,
+  toInstancePresentationData,
+} from './instanceListUtils';
+import classes from './InstanceList.module.css';
 
 interface InstanceListProps {
   instances: InstanceDelegation[];
@@ -24,31 +29,17 @@ interface InstanceListProps {
   interactive?: boolean;
 }
 
-const toInstanceListItem = (
+const getResolvedInstanceTitle = (
   instanceDelegation: InstanceDelegation,
-  getProviderLogoUrl: (orgCode: string) => string | undefined,
-): DialogListItemProps => {
-  const { instance, resource } = instanceDelegation;
-  const providerLogoUrl = resource.resourceOwnerOrgcode
-    ? getProviderLogoUrl(resource.resourceOwnerOrgcode)
-    : undefined;
-  const dialogItemId = `${resource.identifier}-${instance.refId}`;
-  const shortId = instance.refId.slice(-10);
-
-  return {
-    id: dialogItemId,
-    title: resource.title ?? resource.identifier,
-    description: `${instance.refId} ${resource.title}`,
-    sender: {
-      name: resource.resourceOwnerName ?? '',
-      type: 'company',
-      imageUrl: providerLogoUrl ?? resource.resourceOwnerLogoUrl ?? undefined,
-      imageUrlAlt: resource.resourceOwnerName ?? '',
-    },
-    updatedAt: instance.refId,
-    updatedAtLabel: shortId,
-  };
-};
+  t: TFunction,
+  language: string,
+) =>
+  resolveInstanceTitle(
+    toInstancePresentationData(instanceDelegation),
+    instanceDelegation.resource,
+    t,
+    language,
+  );
 
 export const InstanceList = ({
   instances,
@@ -57,7 +48,7 @@ export const InstanceList = ({
   onSelect,
   interactive,
 }: InstanceListProps) => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const [debouncedSearchString, setDebouncedSearchString] = useState('');
   const hasSearch = debouncedSearchString.trim().length > 0;
 
@@ -72,12 +63,16 @@ export const InstanceList = ({
     const normalizedSearch = debouncedSearchString.trim().toLowerCase();
 
     return instanceList.filter((instanceDelegation) =>
-      [instanceDelegation.resource.title, instanceDelegation.resource.resourceOwnerName]
+      [
+        getResolvedInstanceTitle(instanceDelegation, t, i18n.language),
+        instanceDelegation.resource.title,
+        instanceDelegation.resource.resourceOwnerName,
+      ]
         .join(' ')
         .toLowerCase()
         .includes(normalizedSearch),
     );
-  }, [debouncedSearchString, hasSearch, instances]);
+  }, [debouncedSearchString, hasSearch, i18n.language, instances, t]);
 
   return (
     <>
@@ -85,52 +80,58 @@ export const InstanceList = ({
         placeholder={t('poa_overview_page.instances_tab.search_label')}
         setDebouncedSearchString={setDebouncedSearchString}
       />
-      {isLoading ? (
-        <InstanceListSkeleton />
-      ) : filteredInstances.length > 0 ? (
-        <List>
-          {filteredInstances.map((instanceDelegation) => {
-            const item = toInstanceListItem(instanceDelegation, getProviderLogoUrl);
+      <div className={classes.container}>
+        {isLoading ? (
+          <InstanceListSkeleton />
+        ) : filteredInstances.length > 0 ? (
+          <List>
+            {filteredInstances.map((instanceDelegation) => {
+              const { instance, resource, dialogLookup } = instanceDelegation;
+              const providerLogoUrl = resource.resourceOwnerOrgcode
+                ? getProviderLogoUrl(resource.resourceOwnerOrgcode)
+                : undefined;
+              const title = getResolvedInstanceTitle(instanceDelegation, t, i18n.language);
+              const serviceTitle = resource.title ?? resource.identifier;
+              const item: DialogListItemProps = {
+                id: `${resource.identifier}-${instance.refId}`,
+                title,
+                description: `${instance.refId} ${title}`,
+                sender: {
+                  name: resource.resourceOwnerName ?? '',
+                  type: 'company',
+                  imageUrl: providerLogoUrl ?? resource.resourceOwnerLogoUrl ?? undefined,
+                  imageUrlAlt: resource.resourceOwnerName ?? '',
+                },
+                updatedAt: instance.refId,
+                updatedAtLabel: `${t('instance.instance_id_label')}: ${getInstanceShortId(instance.refId)}`,
+                extendedStatusLabel: serviceTitle
+                  ? `${t('instance.service_title_label')}: ${serviceTitle}`
+                  : undefined,
+              };
+              const Component = getItemAs?.(instanceDelegation);
 
-            const Component = getItemAs?.(instanceDelegation);
-            const isCorrespondenceInstance = instanceDelegation.instance.refId.startsWith(
-              'urn:altinn:correspondence-id:',
-            );
-            const inboxUrl = `${getAfUrl()}redirect?instanceUrn=${encodeURIComponent(instanceDelegation.instance.refId)}`;
-
-            return (
-              <DialogListItem
-                key={item.id}
-                size='md'
-                as={Component ?? (onSelect ? 'button' : undefined)}
-                interactive={interactive || !!onSelect}
-                onClick={onSelect ? () => onSelect(instanceDelegation) : undefined}
-                {...item}
-                controls={
-                  !isCorrespondenceInstance && (
-                    <Button
-                      variant='tertiary'
-                      rounded
-                      size={'xs'}
-                      as='a'
-                      href={inboxUrl}
-                    >
-                      <EnvelopeClosedIcon aria-hidden='true' />{' '}
-                      {t('instance_detail_page.see_in_inbox')}
-                    </Button>
-                  )
-                }
-              />
-            );
-          })}
-        </List>
-      ) : (
-        <DsParagraph>
-          {hasSearch
-            ? t('poa_overview_page.instances_tab.no_search_results')
-            : t('poa_overview_page.instances_tab.no_results')}
-        </DsParagraph>
-      )}
+              return (
+                <DialogListItem
+                  key={item.id}
+                  size='md'
+                  as={Component ?? (onSelect ? 'button' : undefined)}
+                  interactive={interactive || !!onSelect}
+                  onClick={onSelect ? () => onSelect(instanceDelegation) : undefined}
+                  className={dialogLookup?.status === 'Success' ? undefined : classes.subtleTitle}
+                  {...item}
+                  controls={<InstanceInboxLink instance={instanceDelegation} />}
+                />
+              );
+            })}
+          </List>
+        ) : (
+          <DsParagraph>
+            {hasSearch
+              ? t('poa_overview_page.instances_tab.no_search_results')
+              : t('poa_overview_page.instances_tab.no_results')}
+          </DsParagraph>
+        )}
+      </div>
     </>
   );
 };

--- a/src/features/amUI/common/InstanceList/InstanceList.tsx
+++ b/src/features/amUI/common/InstanceList/InstanceList.tsx
@@ -109,7 +109,8 @@ export const InstanceList = ({
                   : undefined,
               };
               const Component = getItemAs?.(instanceDelegation);
-              const hasDialogLookup = dialogLookup !== null && dialogLookup !== undefined;
+              const className =
+                dialogLookup && dialogLookup.status !== 'Success' ? classes.subtleTitle : undefined;
 
               return (
                 <DialogListItem
@@ -118,11 +119,7 @@ export const InstanceList = ({
                   as={Component ?? (onSelect ? 'button' : undefined)}
                   interactive={interactive || !!onSelect}
                   onClick={onSelect ? () => onSelect(instanceDelegation) : undefined}
-                  className={
-                    hasDialogLookup && dialogLookup.status !== 'Success'
-                      ? classes.subtleTitle
-                      : undefined
-                  }
+                  className={className}
                   {...item}
                   controls={<InstanceInboxLink instance={instanceDelegation} />}
                 />

--- a/src/features/amUI/common/InstanceList/InstanceList.tsx
+++ b/src/features/amUI/common/InstanceList/InstanceList.tsx
@@ -109,6 +109,7 @@ export const InstanceList = ({
                   : undefined,
               };
               const Component = getItemAs?.(instanceDelegation);
+              const hasDialogLookup = dialogLookup !== null && dialogLookup !== undefined;
 
               return (
                 <DialogListItem
@@ -117,7 +118,11 @@ export const InstanceList = ({
                   as={Component ?? (onSelect ? 'button' : undefined)}
                   interactive={interactive || !!onSelect}
                   onClick={onSelect ? () => onSelect(instanceDelegation) : undefined}
-                  className={dialogLookup?.status === 'Success' ? undefined : classes.subtleTitle}
+                  className={
+                    hasDialogLookup && dialogLookup.status !== 'Success'
+                      ? classes.subtleTitle
+                      : undefined
+                  }
                   {...item}
                   controls={<InstanceInboxLink instance={instanceDelegation} />}
                 />

--- a/src/features/amUI/common/InstanceList/InstanceListSkeleton.tsx
+++ b/src/features/amUI/common/InstanceList/InstanceListSkeleton.tsx
@@ -1,22 +1,20 @@
 import { DialogListItem, List, type DialogListItemProps } from '@altinn/altinn-components';
 
-const createLoadingListItem = (index: number): DialogListItemProps => ({
-  id: `instance-loading-${index}`,
-  title: 'xxxxxxxxxxxxxxxxxxxxxxxxxx',
-  description: 'xxxxxxxxx',
-  sender: {
-    name: 'xxxxxxxxx',
-    type: 'company',
-  },
-  updatedAt: 'xxxxxxxxxx',
-  updatedAtLabel: 'xxxxxxxxxx',
-});
-
 export const InstanceListSkeleton = () => {
   return (
     <List>
       {Array.from({ length: 3 }, (_, index) => {
-        const item = createLoadingListItem(index);
+        const item: DialogListItemProps = {
+          id: `instance-loading-${index}`,
+          title: 'xxxxxxxxxxxxxxxxxxxxxxxxxx',
+          description: 'xxxxxxxxx',
+          sender: {
+            name: 'xxxxxxxxx',
+            type: 'company',
+          },
+          updatedAt: 'xxxxxxxxxx',
+          updatedAtLabel: 'xxxxxxxxxx',
+        };
 
         return (
           <DialogListItem

--- a/src/features/amUI/common/InstanceList/instanceListUtils.ts
+++ b/src/features/amUI/common/InstanceList/instanceListUtils.ts
@@ -1,0 +1,110 @@
+import type { TFunction } from 'i18next';
+
+import { enableDialogportenDialogLookup } from '@/resources/utils/featureFlagUtils';
+import { getAfUrl } from '@/resources/utils/pathUtils';
+import type {
+  DelegationInstance,
+  DialogLookup,
+  InstanceDelegation,
+} from '@/rtk/features/instanceApi';
+import type { ServiceResource } from '@/rtk/features/singleRights/singleRightsApi';
+
+export interface InstancePresentationData {
+  instance: DelegationInstance;
+  dialogLookup?: DialogLookup | null;
+}
+
+export const isCorrespondenceInstanceUrn = (instanceUrn: string | undefined): boolean =>
+  instanceUrn?.startsWith('urn:altinn:correspondence-id:') ?? false;
+
+export const getInstanceShortId = (instanceUrn: string | undefined): string | undefined =>
+  instanceUrn?.slice(-10);
+
+export const getDialogTitle = (
+  dialogLookup: DialogLookup | null | undefined,
+  language: string,
+): string | undefined => {
+  if (dialogLookup?.status !== 'Success' || !dialogLookup.title?.length) {
+    return undefined;
+  }
+
+  const langCode = language.replace('no_', '');
+  return (
+    dialogLookup.title.find((title) => title.languageCode === langCode)?.value ??
+    dialogLookup.title[0].value
+  );
+};
+
+export const resolveInstanceTitle = (
+  instanceData: InstancePresentationData | undefined,
+  resource: ServiceResource | undefined,
+  t: TFunction,
+  language: string,
+): string => {
+  const dialogLookup = instanceData?.dialogLookup;
+  const instanceUrn = instanceData?.instance.refId;
+  const dialogTitle = getDialogTitle(dialogLookup, language);
+
+  if (dialogTitle) {
+    return dialogTitle;
+  }
+
+  if (dialogLookup?.status === 'Forbidden') {
+    return t('instance.title_forbidden');
+  }
+
+  if (dialogLookup?.status === 'NotFound' && isCorrespondenceInstanceUrn(instanceUrn)) {
+    const resourceName = resource?.title ?? resource?.identifier;
+    if (!resourceName) {
+      return t('instance.title_not_found');
+    }
+
+    return t('instance.title_correspondence_not_found', { resourceName });
+  }
+
+  if (dialogLookup?.status === 'NotFound') {
+    return t('instance.title_not_found');
+  }
+
+  return resource?.title ?? resource?.identifier ?? '';
+};
+
+export const getInboxLinkData = ({
+  instanceUrn,
+  dialogLookup,
+  dialogId,
+}: {
+  instanceUrn: string;
+  dialogLookup?: DialogLookup;
+  dialogId?: string;
+}) => {
+  const dialogLookupEnabled = enableDialogportenDialogLookup();
+  const href = `${getAfUrl()}redirect?instanceUrn=${encodeURIComponent(instanceUrn)}`;
+
+  // Correspondence and deeplink should hide the inbox link.
+  // When Dialogporten lookup is enabled, we require a successful lookup to show the inbox link.
+  if (dialogId || isCorrespondenceInstanceUrn(instanceUrn)) {
+    return {
+      showInboxLink: false,
+    };
+  }
+
+  if (!dialogLookupEnabled) {
+    return {
+      href,
+      showInboxLink: true,
+    };
+  }
+
+  return {
+    href,
+    showInboxLink: dialogLookup?.status === 'Success',
+  };
+};
+
+export const toInstancePresentationData = (
+  instanceDelegation: Pick<InstanceDelegation, 'instance' | 'dialogLookup'>,
+): InstancePresentationData => ({
+  instance: instanceDelegation.instance,
+  dialogLookup: instanceDelegation.dialogLookup,
+});

--- a/src/features/amUI/common/InstanceList/instanceListUtils.ts
+++ b/src/features/amUI/common/InstanceList/instanceListUtils.ts
@@ -11,24 +11,24 @@ import type { ServiceResource } from '@/rtk/features/singleRights/singleRightsAp
 
 export interface InstancePresentationData {
   instance: DelegationInstance;
-  dialogLookup?: DialogLookup | null;
+  dialogLookup?: DialogLookup;
 }
 
-export const isCorrespondenceInstanceUrn = (instanceUrn: string | undefined): boolean =>
+export const isCorrespondenceInstanceUrn = (instanceUrn?: string): boolean =>
   instanceUrn?.startsWith('urn:altinn:correspondence-id:') ?? false;
 
-export const getInstanceShortId = (instanceUrn: string | undefined): string | undefined =>
+export const getInstanceShortId = (instanceUrn?: string): string | undefined =>
   instanceUrn?.slice(-10);
 
 export const getDialogTitle = (
-  dialogLookup: DialogLookup | null | undefined,
-  language: string,
+  dialogLookup?: DialogLookup,
+  language?: string,
 ): string | undefined => {
   if (dialogLookup?.status !== 'Success' || !dialogLookup.title?.length) {
     return undefined;
   }
 
-  const langCode = language.replace('no_', '');
+  const langCode = language?.replace('no_', '');
   return (
     dialogLookup.title.find((title) => title.languageCode === langCode)?.value ??
     dialogLookup.title[0].value
@@ -39,7 +39,7 @@ export const resolveInstanceTitle = (
   instanceData: InstancePresentationData | undefined,
   resource: ServiceResource | undefined,
   t: TFunction,
-  language: string,
+  language?: string,
 ): string => {
   const dialogLookup = instanceData?.dialogLookup;
   const instanceUrn = instanceData?.instance.refId;

--- a/src/features/amUI/common/InstanceList/instanceListUtils.ts
+++ b/src/features/amUI/common/InstanceList/instanceListUtils.ts
@@ -72,18 +72,18 @@ export const resolveInstanceTitle = (
 export const getInboxLinkData = ({
   instanceUrn,
   dialogLookup,
-  dialogId,
+  isDialogDeepLink = false,
 }: {
   instanceUrn: string;
   dialogLookup?: DialogLookup;
-  dialogId?: string;
+  isDialogDeepLink?: boolean;
 }) => {
   const dialogLookupEnabled = enableDialogportenDialogLookup();
   const href = `${getAfUrl()}redirect?instanceUrn=${encodeURIComponent(instanceUrn)}`;
 
   // Correspondence and deeplink should hide the inbox link.
   // When Dialogporten lookup is enabled, we require a successful lookup to show the inbox link.
-  if (dialogId || isCorrespondenceInstanceUrn(instanceUrn)) {
+  if (isDialogDeepLink || isCorrespondenceInstanceUrn(instanceUrn)) {
     return {
       showInboxLink: false,
     };

--- a/src/features/amUI/poaOverview/InstancePermissions.tsx
+++ b/src/features/amUI/poaOverview/InstancePermissions.tsx
@@ -8,7 +8,7 @@ import { InstanceList } from '../common/InstanceList/InstanceList';
 import { InstanceDelegation, useGetInstancesQuery } from '@/rtk/features/instanceApi';
 
 export const InstancePermissions = () => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { actingParty, fromParty, toParty } = usePartyRepresentation();
   const getItemAs = useCallback(
     (item: InstanceDelegation): ElementType =>
@@ -30,6 +30,7 @@ export const InstancePermissions = () => {
       party: actingParty?.partyUuid || '',
       from: fromParty?.partyUuid,
       to: toParty?.partyUuid,
+      language: i18n.language,
     },
     {
       skip: !actingParty?.partyUuid || !fromParty?.partyUuid,

--- a/src/features/amUI/userRightsPage/InstanceSection/InstanceSection.tsx
+++ b/src/features/amUI/userRightsPage/InstanceSection/InstanceSection.tsx
@@ -11,7 +11,7 @@ import { useCanGiveAccess } from '@/resources/hooks/useCanGiveAccess';
 import { useParams } from 'react-router';
 
 export const InstanceSection = ({ isReportee = false }: { isReportee?: boolean }) => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { toParty, actingParty, fromParty } = usePartyRepresentation();
 
   const modalRef = React.useRef<HTMLDialogElement>(null);
@@ -29,6 +29,7 @@ export const InstanceSection = ({ isReportee = false }: { isReportee?: boolean }
       party: actingParty?.partyUuid || '',
       from: fromParty?.partyUuid,
       to: toParty?.partyUuid,
+      language: i18n.language,
     },
     {
       skip: !actingParty?.partyUuid || !fromParty?.partyUuid || !toParty?.partyUuid,
@@ -68,7 +69,7 @@ export const InstanceSection = ({ isReportee = false }: { isReportee?: boolean }
           selectedInstance
             ? {
                 instanceUrn: selectedInstance.instance.refId,
-                instanceName: selectedInstance.instance.type?.name,
+                dialogLookup: selectedInstance.dialogLookup,
               }
             : undefined
         }

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -22,6 +22,7 @@ declare global {
       addAllSystemuserCustomers: boolean;
       enableAddSelfToSystemuser: boolean;
       enableRequestAccess: boolean;
+      enableDialogportenDialogLookup: boolean;
     };
   }
 }

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -960,8 +960,8 @@
     "title_forbidden": "Message or form you do not have access to",
     "title_not_found": "Unknown message or form",
     "title_correspondence_not_found": "Message about service {{resourceName}}",
-    "service_title_label": "Form for service",
-    "instance_id_label": "Id"
+    "service_title_label": "Service",
+    "instance_id_label": "ID"
   },
   "instance_detail_page": {
     "document_title": "Shared from inbox",

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -956,6 +956,13 @@
       "no_search_results": "No matches for message or form."
     }
   },
+  "instance": {
+    "title_forbidden": "Message or form you do not have access to",
+    "title_not_found": "Unknown message or form",
+    "title_correspondence_not_found": "Message about service {{resourceName}}",
+    "service_title_label": "Form for service",
+    "instance_id_label": "Id"
+  },
   "instance_detail_page": {
     "document_title": "Shared from inbox",
     "resource_title": "Message or form: {{title}}",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -953,6 +953,13 @@
       "no_search_results": "Ingen treff på melding eller skjema."
     }
   },
+  "instance": {
+    "title_forbidden": "Melding eller skjema du ikke har fullmakt til",
+    "title_not_found": "Ukjent melding eller skjema",
+    "title_correspondence_not_found": "Melding om tjenesten {{resourceName}}",
+    "service_title_label": "Skjema av tjenesten",
+    "instance_id_label": "Id"
+  },
   "instance_detail_page": {
     "document_title": "Delt fra innboks",
     "resource_title": "Melding eller skjema: {{title}}",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -957,8 +957,8 @@
     "title_forbidden": "Melding eller skjema du ikke har fullmakt til",
     "title_not_found": "Ukjent melding eller skjema",
     "title_correspondence_not_found": "Melding om tjenesten {{resourceName}}",
-    "service_title_label": "Skjema av tjenesten",
-    "instance_id_label": "Id"
+    "service_title_label": "Tjeneste",
+    "instance_id_label": "ID"
   },
   "instance_detail_page": {
     "document_title": "Delt fra innboks",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -953,6 +953,13 @@
       "no_search_results": "Ingen treff på melding eller skjema."
     }
   },
+  "instance": {
+    "title_forbidden": "Melding eller skjema du ikkje har fullmakt til",
+    "title_not_found": "Ukjent melding eller skjema",
+    "title_correspondence_not_found": "Melding om tenesta {{resourceName}}",
+    "service_title_label": "Skjema av tenesta",
+    "instance_id_label": "Id"
+  },
   "instance_detail_page": {
     "document_title": "Delt frå innboks",
     "resource_title": "Melding eller skjema: {{title}}",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -957,8 +957,8 @@
     "title_forbidden": "Melding eller skjema du ikkje har fullmakt til",
     "title_not_found": "Ukjent melding eller skjema",
     "title_correspondence_not_found": "Melding om tenesta {{resourceName}}",
-    "service_title_label": "Skjema av tenesta",
-    "instance_id_label": "Id"
+    "service_title_label": "Teneste",
+    "instance_id_label": "ID"
   },
   "instance_detail_page": {
     "document_title": "Delt frå innboks",

--- a/src/resources/utils/featureFlagUtils.tsx
+++ b/src/resources/utils/featureFlagUtils.tsx
@@ -99,3 +99,7 @@ export const enableAddSelfToSystemuser = () => {
 export const enableRequestSingleRight = () => {
   return window.featureFlags?.enableRequestAccess === true;
 };
+
+export const enableDialogportenDialogLookup = () => {
+  return window.featureFlags?.enableDialogportenDialogLookup === true;
+};

--- a/src/rtk/features/instanceApi.ts
+++ b/src/rtk/features/instanceApi.ts
@@ -68,12 +68,28 @@ export const instanceApi = createApi({
   endpoints: (builder) => ({
     getInstances: builder.query<
       InstanceDelegation[],
-      { party: string; from?: string; to?: string; resource?: string; instance?: string }
+      {
+        party: string;
+        from?: string;
+        to?: string;
+        resource?: string;
+        instance?: string;
+        language: string;
+      }
     >({
       query: ({ party, from, to, resource, instance }) => {
         return `instances/delegation/instances?party=${party}&from=${from ?? ''}&to=${to ?? ''}&resource=${encodeURIComponent(resource ?? '')}&instance=${encodeURIComponent(instance ?? '')}`;
       },
       providesTags: ['instances'],
+      serializeQueryArgs: ({ queryArgs, endpointName }) => ({
+        endpointName,
+        party: queryArgs.party,
+        from: queryArgs.from,
+        to: queryArgs.to,
+        resource: queryArgs.resource,
+        instance: queryArgs.instance,
+        language: queryArgs.language,
+      }),
     }),
     getInstanceRights: builder.query<
       InstanceRights,

--- a/src/rtk/features/instanceApi.ts
+++ b/src/rtk/features/instanceApi.ts
@@ -81,15 +81,6 @@ export const instanceApi = createApi({
         return `instances/delegation/instances?party=${party}&from=${from ?? ''}&to=${to ?? ''}&resource=${encodeURIComponent(resource ?? '')}&instance=${encodeURIComponent(instance ?? '')}`;
       },
       providesTags: ['instances'],
-      serializeQueryArgs: ({ queryArgs, endpointName }) => ({
-        endpointName,
-        party: queryArgs.party,
-        from: queryArgs.from,
-        to: queryArgs.to,
-        resource: queryArgs.resource,
-        instance: queryArgs.instance,
-        language: queryArgs.language,
-      }),
     }),
     getInstanceRights: builder.query<
       InstanceRights,

--- a/src/rtk/features/instanceApi.ts
+++ b/src/rtk/features/instanceApi.ts
@@ -37,7 +37,7 @@ export interface InstanceDelegation {
   resource: ServiceResource;
   instance: DelegationInstance;
   permissions: Permissions[];
-  dialogLookup?: DialogLookup | null;
+  dialogLookup?: DialogLookup;
 }
 
 export interface InstanceRights {


### PR DESCRIPTION
- Updates the InstanceList with dialog-lookup data when available. Adds fallbacks for `Forbidden` / `NotFound`
- Inbox-link behavior:
  - never show for correspondence instances
  - if Dialogporten lookup is off, keep old behavior
  - if it’s on, only show the link when dialog lookup succeeds
- adds instance id and service title fields on the list-items 
- Updates the titles and inbox link in the moal and details page 

**PR: The UI updates for details view and the instance-info- modal was left out for now to limit the scope of this PR.**




<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable "See in inbox" link for instances and a feature-flagged dialog lookup toggle.
  * New Storybook stories demonstrating instance list states.

* **Improvements**
  * Smarter instance title resolution with clearer messages for forbidden, not found, and correspondence cases.
  * Instances list: updated layout, labels, loading/empty visuals, and search inclusion of resolved titles.
  * Added localized instance strings (en, no_nb, no_nn).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->