### PR TITLE
add feature toggle to use connection API in backend for agent systemuser

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/ClientInterfaces/ISystemUserAgentDelegationClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/ClientInterfaces/ISystemUserAgentDelegationClient.cs
@@ -42,12 +42,12 @@ namespace Altinn.AccessManagement.UI.Core.ClientInterfaces
         /// Remove client from system user - new implementation
         /// </summary>
         /// <param name="partyId">The party id of the party owning system user to remove customer from</param>
-        /// <param name="facilitatorId">Facilitator uuid, uuid of partyId</param>
-        /// <param name="delegationId">The delegation id to remove</param>
         /// <param name="systemUserGuid">The system user UUID to remove customer from</param>
+        /// <param name="facilitatorId">Facilitator uuid, uuid of partyId</param>
+        /// <param name="clientId">The client id to remove</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Boolean result of remove</returns>
-        Task<Result<bool>> RemoveClient2(int partyId, Guid facilitatorId, Guid delegationId, Guid systemUserGuid, CancellationToken cancellationToken);
+        Task<Result<bool>> RemoveClient2(int partyId, Guid systemUserGuid, Guid facilitatorId, Guid clientId, CancellationToken cancellationToken);
 
         /// <summary>
         /// Add own organization to this systemuser

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/ClientInterfaces/ISystemUserAgentDelegationClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/ClientInterfaces/ISystemUserAgentDelegationClient.cs
@@ -29,6 +29,16 @@ namespace Altinn.AccessManagement.UI.Core.ClientInterfaces
         Task<Result<List<AgentDelegation>>> AddClient(int partyId, Guid systemUserGuid, AgentDelegationRequest delegationRequest, CancellationToken cancellationToken);
 
         /// <summary>
+        /// Add client to system user
+        /// </summary>
+        /// <param name="partyId">The party id of the party owning system user to add customer to</param>
+        /// <param name="systemUserGuid">The system user UUID to add customer to</param>
+        /// <param name="delegationRequest">The party uuid of the customer to add + partyUuid of system user owner party</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>List of AgentDelegation objects with delegation info</returns>
+        Task<Result<List<AgentDelegation>>> AddClient2(int partyId, Guid systemUserGuid, AgentDelegationRequest delegationRequest, CancellationToken cancellationToken);
+
+        /// <summary>
         /// Remove client from system user
         /// </summary>
         /// <param name="partyId">The party id of the party owning system user to remove customer from</param>

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/ClientInterfaces/ISystemUserAgentDelegationClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/ClientInterfaces/ISystemUserAgentDelegationClient.cs
@@ -39,6 +39,17 @@ namespace Altinn.AccessManagement.UI.Core.ClientInterfaces
         Task<Result<bool>> RemoveClient(int partyId, Guid facilitatorId, Guid delegationId, CancellationToken cancellationToken);
 
         /// <summary>
+        /// Remove client from system user - new implementation
+        /// </summary>
+        /// <param name="partyId">The party id of the party owning system user to remove customer from</param>
+        /// <param name="facilitatorId">Facilitator uuid, uuid of partyId</param>
+        /// <param name="delegationId">The delegation id to remove</param>
+        /// <param name="systemUserGuid">The system user UUID to remove customer from</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Boolean result of remove</returns>
+        Task<Result<bool>> RemoveClient2(int partyId, Guid facilitatorId, Guid delegationId, Guid systemUserGuid, CancellationToken cancellationToken);
+
+        /// <summary>
         /// Add own organization to this systemuser
         /// </summary>
         /// <param name="partyId">Party id user represents</param>

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Configuration/FeatureFlags.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Configuration/FeatureFlags.cs
@@ -105,5 +105,10 @@ namespace Altinn.AccessManagement.UI.Core.Configuration
         /// Whether to enrich instance delegations with dialogporten lookup data
         /// </summary>
         public bool EnableDialogportenDialogLookup { get; set; }
+        
+        /// <summary>
+        /// Whether to use connections API in backend for agent system users
+        /// </summary>
+        public bool UseConnectionsForAgentSystemuser { get; set; }
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/Interfaces/ISystemUserAgentDelegationService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/Interfaces/ISystemUserAgentDelegationService.cs
@@ -46,9 +46,10 @@ namespace Altinn.AccessManagement.UI.Core.Services.Interfaces
         /// <param name="partyId">The party id of the party owning system user to remove customer from</param>
         /// <param name="delegationId">The delegation id to remove</param>
         /// <param name="partyUuid">The party uuid of the party owning system user to remove customer from</param>
+        /// <param name="systemUserGuid">The system user UUID to remove customer from</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Boolean result of remove</returns>
-        Task<Result<bool>> RemoveClient(int partyId, Guid delegationId, Guid partyUuid, CancellationToken cancellationToken);
+        Task<Result<bool>> RemoveClient(int partyId, Guid delegationId, Guid partyUuid, Guid systemUserGuid, CancellationToken cancellationToken);
 
         /// <summary>
         /// Add own organization to this systemuser

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/SystemUserAgentDelegationService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/SystemUserAgentDelegationService.cs
@@ -1,9 +1,11 @@
 using Altinn.AccessManagement.UI.Core.ClientInterfaces;
+using Altinn.AccessManagement.UI.Core.Configuration;
 using Altinn.AccessManagement.UI.Core.Constants;
 using Altinn.AccessManagement.UI.Core.Models.SystemUser;
 using Altinn.AccessManagement.UI.Core.Models.SystemUser.Frontend;
 using Altinn.AccessManagement.UI.Core.Services.Interfaces;
 using Altinn.Authorization.ProblemDetails;
+using Microsoft.Extensions.Options;
 
 namespace Altinn.AccessManagement.UI.Core.Services
 {
@@ -12,18 +14,22 @@ namespace Altinn.AccessManagement.UI.Core.Services
     {
         private readonly ISystemUserAgentDelegationClient _systemUserAgentDelegationClient;
         private readonly ISystemUserClient _systemUserClient;
+        private readonly FeatureFlags _featureFlags;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SystemUserAgentDelegationService"/> class.
         /// </summary>
         /// <param name="systemUserAgentDelegationClient">The system user client administration client.</param>
         /// <param name="systemUserClient">The system user client</param>
+        /// <param name="featureFlags">Feature flags</param>
         public SystemUserAgentDelegationService(
             ISystemUserAgentDelegationClient systemUserAgentDelegationClient,
-            ISystemUserClient systemUserClient)
+            ISystemUserClient systemUserClient,
+            IOptions<FeatureFlags> featureFlags)
         {
             _systemUserAgentDelegationClient = systemUserAgentDelegationClient;
             _systemUserClient = systemUserClient;
+            _featureFlags = featureFlags.Value;
         }
         
         /// <inheritdoc /> 
@@ -51,15 +57,7 @@ namespace Altinn.AccessManagement.UI.Core.Services
         {
             List<AgentDelegation> delegations = await _systemUserAgentDelegationClient.GetSystemUserAgentDelegations(partyId, partyUuid, systemUserGuid, cancellationToken);
 
-            return delegations.Select(delegation => 
-            {
-                return new AgentDelegationFE()
-                {
-                    AgentSystemUserId = delegation.AgentSystemUserId,
-                    CustomerId = delegation.CustomerId,
-                    DelegationId = delegation.DelegationId,
-                };
-            }).ToList();
+            return delegations.Select(MapAgentDelegationToAgentDelegationFE).ToList();
         }
 
         /// <inheritdoc />
@@ -85,18 +83,15 @@ namespace Altinn.AccessManagement.UI.Core.Services
                 return Problem.CustomerIdNotFound;
             }
 
-            return new AgentDelegationFE()
-            {
-                AgentSystemUserId = addedDelegation.AgentSystemUserId,
-                CustomerId = addedDelegation.CustomerId,
-                DelegationId = addedDelegation.DelegationId,
-            };
+            return MapAgentDelegationToAgentDelegationFE(addedDelegation);
         }
 
         /// <inheritdoc />
-        public async Task<Result<bool>> RemoveClient(int partyId, Guid delegationId, Guid partyUuid, CancellationToken cancellationToken)
+        public async Task<Result<bool>> RemoveClient(int partyId, Guid delegationId, Guid partyUuid, Guid systemUserGuid, CancellationToken cancellationToken)
         {
-            Result<bool> response = await _systemUserAgentDelegationClient.RemoveClient(partyId, partyUuid, delegationId, cancellationToken);
+            Result<bool> response = _featureFlags.UseConnectionsForAgentSystemuser
+                ? await _systemUserAgentDelegationClient.RemoveClient2(partyId, partyUuid, delegationId, systemUserGuid, cancellationToken)
+                : await _systemUserAgentDelegationClient.RemoveClient(partyId, partyUuid, delegationId, cancellationToken);
             if (response.IsProblem)
             {
                 return new Result<bool>(response.Problem);
@@ -139,6 +134,16 @@ namespace Altinn.AccessManagement.UI.Core.Services
             }
 
             return response.Value;
+        }
+
+        private AgentDelegationFE MapAgentDelegationToAgentDelegationFE(AgentDelegation delegation)
+        {
+            return new AgentDelegationFE()
+            {
+                AgentSystemUserId = delegation.AgentSystemUserId,
+                CustomerId = delegation.CustomerId,
+                DelegationId = _featureFlags.UseConnectionsForAgentSystemuser ? delegation.CustomerId : delegation.DelegationId
+            };
         }
 
         private static List<CustomerPartyFE> MapCustomerListToCustomerFE(List<Customer> customers)

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/SystemUserAgentDelegationService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/SystemUserAgentDelegationService.cs
@@ -90,7 +90,7 @@ namespace Altinn.AccessManagement.UI.Core.Services
         public async Task<Result<bool>> RemoveClient(int partyId, Guid delegationId, Guid partyUuid, Guid systemUserGuid, CancellationToken cancellationToken)
         {
             Result<bool> response = _featureFlags.UseConnectionsForAgentSystemuser
-                ? await _systemUserAgentDelegationClient.RemoveClient2(partyId, partyUuid, delegationId, systemUserGuid, cancellationToken)
+                ? await _systemUserAgentDelegationClient.RemoveClient2(partyId, systemUserGuid, partyUuid, delegationId, cancellationToken)
                 : await _systemUserAgentDelegationClient.RemoveClient(partyId, partyUuid, delegationId, cancellationToken);
             if (response.IsProblem)
             {

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/SystemUserAgentDelegationService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/SystemUserAgentDelegationService.cs
@@ -70,8 +70,10 @@ namespace Altinn.AccessManagement.UI.Core.Services
                 FacilitatorId = partyUuid
             };
 
-            Result<List<AgentDelegation>> newAgentDelegations = await _systemUserAgentDelegationClient.AddClient(partyId, systemUserGuid, delegationRequest, cancellationToken);
-            
+            Result<List<AgentDelegation>> newAgentDelegations = _featureFlags.UseConnectionsForAgentSystemuser
+                ? await _systemUserAgentDelegationClient.AddClient2(partyId, systemUserGuid, delegationRequest, cancellationToken)
+                : await _systemUserAgentDelegationClient.AddClient(partyId, systemUserGuid, delegationRequest, cancellationToken);
+
             if (newAgentDelegations.IsProblem)
             {
                 return new Result<AgentDelegationFE>(newAgentDelegations.Problem);

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/SystemUserAgentDelegationClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/SystemUserAgentDelegationClient.cs
@@ -158,7 +158,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
             try
             {
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
-                string endpointUrl = $"systemuser/agent/{partyId}/{systemUserGuid}?provider={facilitatorId}&client={clientId}";
+                string endpointUrl = $"systemuser/agent/{partyId}/{systemUserGuid}/client?provider={facilitatorId}&client={clientId}";
 
                 HttpResponseMessage response = await _client.DeleteAsync(token, endpointUrl);
                 string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/SystemUserAgentDelegationClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/SystemUserAgentDelegationClient.cs
@@ -126,12 +126,12 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
         }
 
         /// <inheritdoc/>
-        public async Task<Result<bool>> RemoveClient2(int partyId, Guid systemUserId, Guid facilitatorId, Guid clientId, CancellationToken cancellationToken)
+        public async Task<Result<bool>> RemoveClient2(int partyId, Guid systemUserGuid, Guid facilitatorId, Guid clientId, CancellationToken cancellationToken)
         {
             try
             {
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
-                string endpointUrl = $"systemuser/agent/{partyId}/{systemUserId}?provider={facilitatorId}client={clientId}";
+                string endpointUrl = $"systemuser/agent/{partyId}/{systemUserGuid}?provider={facilitatorId}client={clientId}";
 
                 HttpResponseMessage response = await _client.DeleteAsync(token, endpointUrl);
                 string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/SystemUserAgentDelegationClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/SystemUserAgentDelegationClient.cs
@@ -126,6 +126,32 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
         }
 
         /// <inheritdoc/>
+        public async Task<Result<bool>> RemoveClient2(int partyId, Guid systemUserId, Guid facilitatorId, Guid clientId, CancellationToken cancellationToken)
+        {
+            try
+            {
+                string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
+                string endpointUrl = $"systemuser/agent/{partyId}/{systemUserId}?provider={facilitatorId}client={clientId}";
+
+                HttpResponseMessage response = await _client.DeleteAsync(token, endpointUrl);
+                string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
+
+                if (response.IsSuccessStatusCode)
+                {
+                    return true;
+                }
+
+                _logger.LogError("AccessManagement.UI // SystemUserAgentDelegationClient // RemoveClient // Unexpected HttpStatusCode: {StatusCode}\n {responseBody}", response.StatusCode, responseContent);
+                return ProblemMapper.MapToAuthUiError(responseContent, response.StatusCode);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "AccessManagement.UI // SystemUserAgentDelegationClient // RemoveClient // Exception");
+                throw;
+            }
+        }
+
+        /// <inheritdoc/>
         public async Task<Result<bool>> AddSelf(int partyId, Guid systemUserGuid, Guid partyUuid, CancellationToken cancellationToken)
         {
             try

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/SystemUserAgentDelegationClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/SystemUserAgentDelegationClient.cs
@@ -100,6 +100,33 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
         }
 
         /// <inheritdoc/>
+        public async Task<Result<List<AgentDelegation>>> AddClient2(int partyId, Guid systemUserGuid, AgentDelegationRequest delegationRequest, CancellationToken cancellationToken)
+        {
+            try
+            {
+                string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
+                string endpointUrl = $"systemuser/agent/{partyId}/{systemUserGuid}?provider={delegationRequest.FacilitatorId}&client={delegationRequest.CustomerId}";
+                StringContent requestBody = new StringContent(JsonSerializer.Serialize(delegationRequest, _serializerOptions), System.Text.Encoding.UTF8, "application/json");
+
+                HttpResponseMessage response = await _client.PostAsync(token, endpointUrl, requestBody);
+                string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
+
+                if (response.IsSuccessStatusCode)
+                {
+                    return JsonSerializer.Deserialize<List<AgentDelegation>>(responseContent, _serializerOptions);
+                }
+
+                _logger.LogError("AccessManagement.UI // SystemUserAgentDelegationClient // AddClient // Unexpected HttpStatusCode: {StatusCode}\n {responseBody}", response.StatusCode, responseContent);
+                return ProblemMapper.MapToAuthUiError(responseContent, response.StatusCode);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "AccessManagement.UI // SystemUserAgentDelegationClient // AddClient // Exception");
+                throw;
+            }
+        }
+
+        /// <inheritdoc/>
         public async Task<Result<bool>> RemoveClient(int partyId, Guid facilitatorId, Guid delegationId, CancellationToken cancellationToken)
         {
             try

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/SystemUserAgentDelegationClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/SystemUserAgentDelegationClient.cs
@@ -131,7 +131,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
             try
             {
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
-                string endpointUrl = $"systemuser/agent/{partyId}/{systemUserGuid}?provider={facilitatorId}client={clientId}";
+                string endpointUrl = $"systemuser/agent/{partyId}/{systemUserGuid}?provider={facilitatorId}&client={clientId}";
 
                 HttpResponseMessage response = await _client.DeleteAsync(token, endpointUrl);
                 string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
@@ -141,12 +141,12 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
                     return true;
                 }
 
-                _logger.LogError("AccessManagement.UI // SystemUserAgentDelegationClient // RemoveClient // Unexpected HttpStatusCode: {StatusCode}\n {responseBody}", response.StatusCode, responseContent);
+                _logger.LogError("AccessManagement.UI // SystemUserAgentDelegationClient // RemoveClient2 // Unexpected HttpStatusCode: {StatusCode}\n {responseBody}", response.StatusCode, responseContent);
                 return ProblemMapper.MapToAuthUiError(responseContent, response.StatusCode);
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "AccessManagement.UI // SystemUserAgentDelegationClient // RemoveClient // Exception");
+                _logger.LogError(ex, "AccessManagement.UI // SystemUserAgentDelegationClient // RemoveClient2 // Exception");
                 throw;
             }
         }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/SystemUserAgentDelegationClientMock.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/SystemUserAgentDelegationClientMock.cs
@@ -64,6 +64,20 @@ namespace Altinn.AccessManagement.UI.Mocks.Mocks
             }]));
         }
 
+        public Task<Result<List<AgentDelegation>>> AddClient2(int partyId, Guid systemUserGuid, AgentDelegationRequest delegationRequest, CancellationToken cancellationToken)
+        {
+            if (delegationRequest.CustomerId.Equals(Guid.Parse("82cc64c5-60ff-4184-8c07-964c3a1e6fc7"))) 
+            {
+                return Task.FromResult(new Result<List<AgentDelegation>>(TestErrors.CustomerNotFound));
+            }
+            return Task.FromResult(new Result<List<AgentDelegation>>([new AgentDelegation()
+            {
+                DelegationId = Guid.NewGuid(),
+                AgentSystemUserId = systemUserGuid,
+                CustomerId = delegationRequest.CustomerId
+            }]));
+        }
+
         public Task<Result<bool>> RemoveClient(int partyId, Guid facilitatorId, Guid delegationId, CancellationToken cancellationToken)
         {
             if (delegationId.Equals(Guid.Parse("60f1ade9-ed48-4083-a369-178d45d6ffd1"))) 

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/SystemUserAgentDelegationClientMock.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/SystemUserAgentDelegationClientMock.cs
@@ -73,9 +73,9 @@ namespace Altinn.AccessManagement.UI.Mocks.Mocks
             return Task.FromResult(new Result<bool>(true));
         }
 
-        public Task<Result<bool>> RemoveClient2(int partyId, Guid facilitatorId, Guid delegationId, Guid systemUserGuid, CancellationToken cancellationToken)
+        public Task<Result<bool>> RemoveClient2(int partyId, Guid systemUserGuid, Guid facilitatorId, Guid clientId, CancellationToken cancellationToken)
         {
-            if (delegationId.Equals(Guid.Parse("60f1ade9-ed48-4083-a369-178d45d6ffd1"))) 
+            if (clientId.Equals(Guid.Parse("60f1ade9-ed48-4083-a369-178d45d6ffd1"))) 
             {
                 return Task.FromResult(new Result<bool>(TestErrors.CustomerNotFound));
             }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/SystemUserAgentDelegationClientMock.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/SystemUserAgentDelegationClientMock.cs
@@ -73,6 +73,15 @@ namespace Altinn.AccessManagement.UI.Mocks.Mocks
             return Task.FromResult(new Result<bool>(true));
         }
 
+        public Task<Result<bool>> RemoveClient2(int partyId, Guid facilitatorId, Guid delegationId, Guid systemUserGuid, CancellationToken cancellationToken)
+        {
+            if (delegationId.Equals(Guid.Parse("60f1ade9-ed48-4083-a369-178d45d6ffd1"))) 
+            {
+                return Task.FromResult(new Result<bool>(TestErrors.CustomerNotFound));
+            }
+            return Task.FromResult(new Result<bool>(true));
+        }
+
         public Task<Result<bool>> AddSelf(int partyId, Guid systemUserGuid, Guid partyUuid, CancellationToken cancellationToken)
         {
             if (new List<Guid> { regnskapsforerSystemUserId, revisorSystemUserId, forretningsforerSystemUserId }.Contains(systemUserGuid))

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/SystemUserAgentDelegationController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/SystemUserAgentDelegationController.cs
@@ -104,7 +104,7 @@ namespace Altinn.AccessManagement.UI.Controllers
         [HttpDelete("{partyId}/{systemUserGuid}/delegation/{delegationId}")]
         public async Task<ActionResult> RemoveClient([FromRoute] int partyId, [FromRoute] Guid systemUserGuid, [FromRoute] Guid delegationId, [FromQuery] Guid partyUuid, CancellationToken cancellationToken)
         {
-            Result<bool> result = await _systemUserAgentDelegationService.RemoveClient(partyId, delegationId, partyUuid, cancellationToken);
+            Result<bool> result = await _systemUserAgentDelegationService.RemoveClient(partyId, delegationId, partyUuid, systemUserGuid, cancellationToken);
 
             if (result.IsProblem)
             {

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.AT22.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.AT22.json
@@ -53,6 +53,7 @@
     "AddAllSystemuserCustomers": true,
     "EnableRequestAccess": true,
     "EnableAddSelfToSystemuser": true,
-    "EnableDialogportenDialogLookup": false
+    "EnableDialogportenDialogLookup": false,
+    "UseConnectionsForAgentSystemuser": true
   }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.json
@@ -70,6 +70,7 @@
     "AddAllSystemuserCustomers": false,
     "EnableRequestAccess": false,
     "EnableAddSelfToSystemuser": false,
-    "EnableDialogportenDialogLookup": false
+    "EnableDialogportenDialogLookup": false,
+    "UseConnectionsForAgentSystemuser": false
   }
 }


### PR DESCRIPTION
## Description
- Add feature flag to use new backend endpoint which use connections API for agent system user client delegation. The bff must support both old API and new API (toggled with feature flag)

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Agent delegation flows now support an alternate "connections" method for system-user agents, toggleable via a new feature flag.
  * Delegation identifiers shown in the UI may switch to a connection-based ID when the flag is enabled.
  * Add/remove agent actions route via the alternate connections path when enabled to improve compatibility with different backend setups.

* **Chore**
  * New feature flag added to configuration to control this behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->