### PR TITLE
BFF endpoints for enriched requests (packages)

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/ClientInterfaces/IRequestClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/ClientInterfaces/IRequestClient.cs
@@ -18,7 +18,7 @@ namespace Altinn.AccessManagement.UI.Core.ClientInterfaces
         /// <param name="type">The type of requests to get. Either "resource" or "package"</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Paginated list of sent requests</returns>
-        Task<PaginatedResult<RequestResourceDto>> GetSentRequests(Guid party, Guid? to, List<RequestStatus> status, string type, CancellationToken cancellationToken);
+        Task<PaginatedResult<Request>> GetSentRequests(Guid party, Guid? to, List<RequestStatus> status, string type, CancellationToken cancellationToken);
 
         /// <summary>
         /// Get requests received by a party
@@ -29,7 +29,7 @@ namespace Altinn.AccessManagement.UI.Core.ClientInterfaces
         /// <param name="type">The type of requests to get. Either "resource" or "package"</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Paginated list of received requests</returns>
-        Task<PaginatedResult<RequestResourceDto>> GetReceivedRequests(Guid party, Guid? from, List<RequestStatus> status, string type, CancellationToken cancellationToken);
+        Task<PaginatedResult<Request>> GetReceivedRequests(Guid party, Guid? from, List<RequestStatus> status, string type, CancellationToken cancellationToken);
 
         /// <summary>
         /// Get a single request by id
@@ -38,7 +38,7 @@ namespace Altinn.AccessManagement.UI.Core.ClientInterfaces
         /// <param name="id">The request id</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>The request</returns>
-        Task<RequestResourceDto> GetRequest(Guid party, Guid id, CancellationToken cancellationToken);
+        Task<Request> GetRequest(Guid party, Guid id, CancellationToken cancellationToken);
 
         /// <summary>
         /// Get a single draft request by id
@@ -46,7 +46,7 @@ namespace Altinn.AccessManagement.UI.Core.ClientInterfaces
         /// <param name="id">The request id</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>The request</returns>
-        Task<RequestResourceDto> GetDraftRequest(Guid id, CancellationToken cancellationToken);
+        Task<Request> GetDraftRequest(Guid id, CancellationToken cancellationToken);
 
         /// <summary>
         /// Create a new resource request
@@ -56,7 +56,7 @@ namespace Altinn.AccessManagement.UI.Core.ClientInterfaces
         /// <param name="resource">The resource to request</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>The request</returns>
-        Task<RequestResourceDto> CreateResourceRequest(Guid party, Guid to, string resource, CancellationToken cancellationToken);
+        Task<Request> CreateResourceRequest(Guid party, Guid to, string resource, CancellationToken cancellationToken);
 
         /// <summary>
         /// Withdraw a request by id
@@ -65,7 +65,7 @@ namespace Altinn.AccessManagement.UI.Core.ClientInterfaces
         /// <param name="id">The request id to withdraw</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>The request</returns>
-        Task<RequestResourceDto> WithdrawRequest(Guid party, Guid id, CancellationToken cancellationToken);
+        Task<Request> WithdrawRequest(Guid party, Guid id, CancellationToken cancellationToken);
 
         /// <summary>
         /// Confirm a draft request (transitions Draft → Pending)
@@ -74,7 +74,7 @@ namespace Altinn.AccessManagement.UI.Core.ClientInterfaces
         /// <param name="id">The request id to confirm</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>The request</returns>
-        Task<RequestResourceDto> ConfirmRequest(Guid party, Guid id, CancellationToken cancellationToken);
+        Task<Request> ConfirmRequest(Guid party, Guid id, CancellationToken cancellationToken);
 
         /// <summary>
         /// Reject a pending request
@@ -83,7 +83,7 @@ namespace Altinn.AccessManagement.UI.Core.ClientInterfaces
         /// <param name="id">The request id to reject</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>The request</returns>
-        Task<RequestResourceDto> RejectRequest(Guid party, Guid id, CancellationToken cancellationToken);
+        Task<Request> RejectRequest(Guid party, Guid id, CancellationToken cancellationToken);
 
         /// <summary>
         /// Approve a pending request
@@ -92,7 +92,7 @@ namespace Altinn.AccessManagement.UI.Core.ClientInterfaces
         /// <param name="id">The request id to approve</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>The request</returns>
-        Task<RequestResourceDto> ApproveRequest(Guid party, Guid id, CancellationToken cancellationToken);
+        Task<Request> ApproveRequest(Guid party, Guid id, CancellationToken cancellationToken);
 
         /// <summary>
         /// Get count of requests sent by a party

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/Request/Frontend/EnrichedPackageRequest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/Request/Frontend/EnrichedPackageRequest.cs
@@ -1,0 +1,15 @@
+using Altinn.AccessManagement.UI.Core.Models.AccessPackage;
+
+namespace Altinn.AccessManagement.UI.Core.Models.Request.Frontend
+{
+    /// <summary>
+    /// Used to show enriched access package requests
+    /// </summary>
+    public class EnrichedPackageRequest : RequestFE
+    {
+        /// <summary>
+        /// The full access package object
+        /// </summary>
+        public AccessPackage.AccessPackage Package { get; set; }
+    }
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/Request/Frontend/EnrichedPackageRequest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/Request/Frontend/EnrichedPackageRequest.cs
@@ -1,4 +1,4 @@
-using Altinn.AccessManagement.UI.Core.Models.AccessPackage;
+using AccessPackageModel = Altinn.AccessManagement.UI.Core.Models.AccessPackage.AccessPackage;
 
 namespace Altinn.AccessManagement.UI.Core.Models.Request.Frontend
 {
@@ -10,6 +10,6 @@ namespace Altinn.AccessManagement.UI.Core.Models.Request.Frontend
         /// <summary>
         /// The full access package object
         /// </summary>
-        public AccessPackage.AccessPackage Package { get; set; }
+        public AccessPackageModel Package { get; set; }
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/Request/Frontend/RequestFE.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/Request/Frontend/RequestFE.cs
@@ -36,9 +36,14 @@ namespace Altinn.AccessManagement.UI.Core.Models.Request.Frontend
         public required Entity To { get; set; }
 
         /// <summary>
-        /// The resource id access is requested for
+        /// The resource id access is requested for (requests are either for a resource or a package, so only one of ResourceId and PackageId will be set)
         /// </summary>
         public string? ResourceId { get; set; }
+
+        /// <summary>
+        /// The package id access is requested for (requests are either for a resource or a package, so only one of ResourceId and PackageId will be set)
+        /// </summary>
+        public string? PackageId { get; set; }
 
         /// <summary>
         /// Last updated

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/Request/Request.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/Request/Request.cs
@@ -3,18 +3,23 @@ namespace Altinn.AccessManagement.UI.Core.Models.Request;
 /// <summary>
 /// Response dto for a resource request
 /// </summary>
-public class RequestResourceDto : RequestDto
+public class Request : RequestDto
 {
     /// <summary>
     /// Resource that is requested
     /// </summary>
-    public ResourceReferenceDto Resource { get; set; }
+    public RequestReferenceDto Resource { get; set; }
+
+    /// <summary>
+    /// Requested package
+    /// </summary>
+    public RequestReferenceDto Package { get; set; }
 }
 
 /// <summary>
 /// Resource reference
 /// </summary>
-public class ResourceReferenceDto
+public class RequestReferenceDto
 {
     /// <summary>
     /// Identifying the resource

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/Interfaces/IRequestService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/Interfaces/IRequestService.cs
@@ -19,7 +19,7 @@ namespace Altinn.AccessManagement.UI.Core.Services.Interfaces
         /// <returns>List of sent requests</returns>
         Task<IEnumerable<RequestFE>> GetSentRequests(Guid party, Guid? to, List<RequestStatus> status, string type, CancellationToken cancellationToken);
 
-         /// <summary>
+        /// <summary>
         /// Get enriched resource requests sent by a party
         /// </summary>
         /// <param name="party">The acting party asking for sent requests</param>
@@ -29,6 +29,17 @@ namespace Altinn.AccessManagement.UI.Core.Services.Interfaces
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>List of enriched resource requests sent by a party</returns>
         Task<IEnumerable<EnrichedResourceRequest>> GetEnrichedSentResourceRequests(Guid party, Guid? to, List<RequestStatus> status, string languageCode, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Get enriched package requests sent by a party
+        /// </summary>
+        /// <param name="party">The acting party asking for sent requests</param>
+        /// <param name="to">The party the requests were sent to</param>
+        /// <param name="status">The statuses to get</param>
+        /// <param name="languageCode">The language code for the response</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>List of enriched package requests sent by a party</returns>
+        Task<IEnumerable<EnrichedPackageRequest>> GetEnrichedSentPackageRequests(Guid party, Guid? to, List<RequestStatus> status, string languageCode, CancellationToken cancellationToken);
 
         /// <summary>
         /// Get requests received by a party
@@ -51,6 +62,17 @@ namespace Altinn.AccessManagement.UI.Core.Services.Interfaces
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>List of received requests</returns>
         Task<IEnumerable<EnrichedResourceRequest>> GetEnrichedReceivedResourceRequests(Guid party, Guid? from, List<RequestStatus> status, string languageCode, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Get enriched package requests received by a party
+        /// </summary>
+        /// <param name="party">The acting party asking for received requests</param>
+        /// <param name="from">The party who sent the requests</param>
+        /// <param name="status">The statuses to get</param>
+        /// <param name="languageCode">The language code for the response</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>List of enriched package requests received by a party</returns>
+        Task<IEnumerable<EnrichedPackageRequest>> GetEnrichedReceivedPackageRequests(Guid party, Guid? from, List<RequestStatus> status, string languageCode, CancellationToken cancellationToken);
 
         /// <summary>
         /// Get a single request by id

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/RequestService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/RequestService.cs
@@ -2,6 +2,7 @@ using Altinn.AccessManagement.UI.Core.ClientInterfaces;
 using Altinn.AccessManagement.UI.Core.Enums;
 using Altinn.AccessManagement.UI.Core.Exceptions;
 using Altinn.AccessManagement.UI.Core.Helpers;
+using Altinn.AccessManagement.UI.Core.Models.AccessPackage;
 using Altinn.AccessManagement.UI.Core.Models.Common;
 using Altinn.AccessManagement.UI.Core.Models.Request;
 using Altinn.AccessManagement.UI.Core.Models.Request.Frontend;
@@ -14,16 +15,19 @@ namespace Altinn.AccessManagement.UI.Core.Services
     public class RequestService : IRequestService
     {
         private readonly IRequestClient _requestClient;
+        private readonly IAccessPackageClient _accessPackageClient;
         private readonly ResourceHelper _resourceHelper;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RequestService"/> class.
         /// </summary>
         /// <param name="requestClient">The request client.</param>
+        /// <param name="accessPackageClient">The access package client.</param>
         /// <param name="resourceHelper">The resource helper.</param>
-        public RequestService(IRequestClient requestClient, ResourceHelper resourceHelper)
+        public RequestService(IRequestClient requestClient, IAccessPackageClient accessPackageClient, ResourceHelper resourceHelper)
         {
             _requestClient = requestClient;
+            _accessPackageClient = accessPackageClient;
             _resourceHelper = resourceHelper;
         }
 
@@ -53,6 +57,20 @@ namespace Altinn.AccessManagement.UI.Core.Services
         {
             PaginatedResult<RequestResourceDto> response = await _requestClient.GetReceivedRequests(party, from, status, "resource", cancellationToken);
             return await MapToEnrichedResourceRequestList(response.Items, languageCode);
+        }
+
+        /// <inheritdoc />
+        public async Task<IEnumerable<EnrichedPackageRequest>> GetEnrichedSentPackageRequests(Guid party, Guid? to, List<RequestStatus> status, string languageCode, CancellationToken cancellationToken)
+        {
+            PaginatedResult<RequestResourceDto> response = await _requestClient.GetSentRequests(party, to, status, "package", cancellationToken);
+            return await MapToEnrichedPackageRequestList(response.Items, languageCode);
+        }
+
+        /// <inheritdoc />
+        public async Task<IEnumerable<EnrichedPackageRequest>> GetEnrichedReceivedPackageRequests(Guid party, Guid? from, List<RequestStatus> status, string languageCode, CancellationToken cancellationToken)
+        {
+            PaginatedResult<RequestResourceDto> response = await _requestClient.GetReceivedRequests(party, from, status, "package", cancellationToken);
+            return await MapToEnrichedPackageRequestList(response.Items, languageCode);
         }
 
         /// <inheritdoc />
@@ -138,16 +156,16 @@ namespace Altinn.AccessManagement.UI.Core.Services
                 .Distinct();
             var resources = await _resourceHelper.EnrichResources(uniqueResourceIds, languageCode);
             resourceDictionary = resources.ToDictionary(r => r.Identifier);
-            
-            return list.Select(x => 
+
+            return list.Select(x =>
             {
                 RequestFE request = MapToRequestFE(x);
-                
+
                 if (!resourceDictionary.TryGetValue(request.ResourceId, out var resource))
                 {
                     throw new ResourceNotFoundException($"Resource not found for ID: {request.ResourceId}");
                 }
-                
+
                 return new EnrichedResourceRequest()
                 {
                     Id = request.Id,
@@ -158,6 +176,48 @@ namespace Altinn.AccessManagement.UI.Core.Services
                     ResourceId = request.ResourceId,
                     LastUpdated = request.LastUpdated,
                     Resource = resource
+                };
+            }).ToList();
+        }
+
+        private async Task<IEnumerable<EnrichedPackageRequest>> MapToEnrichedPackageRequestList(IEnumerable<RequestResourceDto> list, string languageCode)
+        {
+            Dictionary<Guid, AccessPackage> packageDictionary = [];
+            var uniquePackageIds = list
+                .Select(x => Guid.Parse(x.Resource.ReferenceId))
+                .Distinct();
+
+            foreach (var packageId in uniquePackageIds)
+            {
+                var package = await _accessPackageClient.GetAccessPackageById(languageCode, packageId);
+                if (package == null)
+                {
+                    throw new ResourceNotFoundException($"Access package not found for ID: {packageId}");
+                }
+
+                packageDictionary[packageId] = package;
+            }
+
+            return list.Select(x =>
+            {
+                RequestFE request = MapToRequestFE(x);
+                var packageId = Guid.Parse(x.Resource.ReferenceId);
+
+                if (!packageDictionary.TryGetValue(packageId, out var package))
+                {
+                    throw new ResourceNotFoundException($"Access package not found for ID: {packageId}");
+                }
+
+                return new EnrichedPackageRequest()
+                {
+                    Id = request.Id,
+                    From = request.From,
+                    To = request.To,
+                    Type = request.Type,
+                    Status = request.Status,
+                    ResourceId = request.ResourceId,
+                    LastUpdated = request.LastUpdated,
+                    Package = package
                 };
             }).ToList();
         }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/RequestService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/RequestService.cs
@@ -34,91 +34,91 @@ namespace Altinn.AccessManagement.UI.Core.Services
         /// <inheritdoc />
         public async Task<IEnumerable<RequestFE>> GetSentRequests(Guid party, Guid? to, List<RequestStatus> status, string type, CancellationToken cancellationToken)
         {
-            PaginatedResult<RequestResourceDto> response = await _requestClient.GetSentRequests(party, to, status, type, cancellationToken);
+            PaginatedResult<Request> response = await _requestClient.GetSentRequests(party, to, status, type, cancellationToken);
             return response.Items.Select(MapToRequestFE);
         }
 
         /// <inheritdoc />
         public async Task<IEnumerable<EnrichedResourceRequest>> GetEnrichedSentResourceRequests(Guid party, Guid? to, List<RequestStatus> status, string languageCode, CancellationToken cancellationToken)
         {
-            PaginatedResult<RequestResourceDto> response = await _requestClient.GetSentRequests(party, to, status, "resource", cancellationToken);
+            PaginatedResult<Request> response = await _requestClient.GetSentRequests(party, to, status, "resource", cancellationToken);
             return await MapToEnrichedResourceRequestList(response.Items, languageCode);
         }
 
         /// <inheritdoc />
         public async Task<IEnumerable<RequestFE>> GetReceivedRequests(Guid party, Guid? from, List<RequestStatus> status, string type, CancellationToken cancellationToken)
         {
-            PaginatedResult<RequestResourceDto> response = await _requestClient.GetReceivedRequests(party, from, status, type, cancellationToken);
+            PaginatedResult<Request> response = await _requestClient.GetReceivedRequests(party, from, status, type, cancellationToken);
             return response.Items.Select(MapToRequestFE);
         }
 
         /// <inheritdoc />
         public async Task<IEnumerable<EnrichedResourceRequest>> GetEnrichedReceivedResourceRequests(Guid party, Guid? from, List<RequestStatus> status, string languageCode, CancellationToken cancellationToken)
         {
-            PaginatedResult<RequestResourceDto> response = await _requestClient.GetReceivedRequests(party, from, status, "resource", cancellationToken);
+            PaginatedResult<Request> response = await _requestClient.GetReceivedRequests(party, from, status, "resource", cancellationToken);
             return await MapToEnrichedResourceRequestList(response.Items, languageCode);
         }
 
         /// <inheritdoc />
         public async Task<IEnumerable<EnrichedPackageRequest>> GetEnrichedSentPackageRequests(Guid party, Guid? to, List<RequestStatus> status, string languageCode, CancellationToken cancellationToken)
         {
-            PaginatedResult<RequestResourceDto> response = await _requestClient.GetSentRequests(party, to, status, "package", cancellationToken);
+            PaginatedResult<Request> response = await _requestClient.GetSentRequests(party, to, status, "package", cancellationToken);
             return await MapToEnrichedPackageRequestList(response.Items, languageCode);
         }
 
         /// <inheritdoc />
         public async Task<IEnumerable<EnrichedPackageRequest>> GetEnrichedReceivedPackageRequests(Guid party, Guid? from, List<RequestStatus> status, string languageCode, CancellationToken cancellationToken)
         {
-            PaginatedResult<RequestResourceDto> response = await _requestClient.GetReceivedRequests(party, from, status, "package", cancellationToken);
+            PaginatedResult<Request> response = await _requestClient.GetReceivedRequests(party, from, status, "package", cancellationToken);
             return await MapToEnrichedPackageRequestList(response.Items, languageCode);
         }
 
         /// <inheritdoc />
         public async Task<RequestFE> GetRequest(Guid party, Guid id, CancellationToken cancellationToken)
         {
-            RequestResourceDto response = await _requestClient.GetRequest(party, id, cancellationToken);
+            Request response = await _requestClient.GetRequest(party, id, cancellationToken);
             return MapToRequestFE(response);
         }
 
         /// <inheritdoc />
         public async Task<EnrichedResourceRequest> GetDraftRequest(Guid id, string languageCode, CancellationToken cancellationToken)
         {
-            RequestResourceDto response = await _requestClient.GetDraftRequest(id, cancellationToken);
+            Request response = await _requestClient.GetDraftRequest(id, cancellationToken);
             return (await MapToEnrichedResourceRequestList(new[] { response }, languageCode)).First();
         }
 
         /// <inheritdoc />
         public async Task<RequestFE> CreateResourceRequest(Guid party, Guid to, string resource, CancellationToken cancellationToken)
         {
-            RequestResourceDto response = await _requestClient.CreateResourceRequest(party, to, resource, cancellationToken);
+            Request response = await _requestClient.CreateResourceRequest(party, to, resource, cancellationToken);
             return MapToRequestFE(response);
         }
 
         /// <inheritdoc />
         public async Task<RequestFE> WithdrawRequest(Guid party, Guid id, CancellationToken cancellationToken)
         {
-            RequestResourceDto response = await _requestClient.WithdrawRequest(party, id, cancellationToken);
+            Request response = await _requestClient.WithdrawRequest(party, id, cancellationToken);
             return MapToRequestFE(response);
         }
 
         /// <inheritdoc />
         public async Task<RequestFE> ConfirmRequest(Guid party, Guid id, CancellationToken cancellationToken)
         {
-            RequestResourceDto response = await _requestClient.ConfirmRequest(party, id, cancellationToken);
+            Request response = await _requestClient.ConfirmRequest(party, id, cancellationToken);
             return MapToRequestFE(response);
         }
 
         /// <inheritdoc />
         public async Task<RequestFE> RejectRequest(Guid party, Guid id, CancellationToken cancellationToken)
         {
-            RequestResourceDto response = await _requestClient.RejectRequest(party, id, cancellationToken);
+            Request response = await _requestClient.RejectRequest(party, id, cancellationToken);
             return MapToRequestFE(response);
         }
 
         /// <inheritdoc />
         public async Task<RequestFE> ApproveRequest(Guid party, Guid id, CancellationToken cancellationToken)
         {
-            RequestResourceDto response = await _requestClient.ApproveRequest(party, id, cancellationToken);
+            Request response = await _requestClient.ApproveRequest(party, id, cancellationToken);
             return MapToRequestFE(response);
         }
 
@@ -134,7 +134,7 @@ namespace Altinn.AccessManagement.UI.Core.Services
             return await _requestClient.GetReceivedRequestsCount(party, from, status, cancellationToken);
         }
 
-        private static RequestFE MapToRequestFE(RequestResourceDto x)
+        private static RequestFE MapToRequestFE(Request x)
         {
             return new RequestFE()
             {
@@ -144,11 +144,12 @@ namespace Altinn.AccessManagement.UI.Core.Services
                 Type = x.Type,
                 Status = x.Status,
                 ResourceId = x.Resource?.ReferenceId,
+                PackageId = x.Package?.ReferenceId,
                 LastUpdated = x.LastUpdated
             };
         }
 
-        private async Task<IEnumerable<EnrichedResourceRequest>> MapToEnrichedResourceRequestList(IEnumerable<RequestResourceDto> list, string languageCode)
+        private async Task<IEnumerable<EnrichedResourceRequest>> MapToEnrichedResourceRequestList(IEnumerable<Request> list, string languageCode)
         {
             Dictionary<string, ServiceResourceFE> resourceDictionary = [];
             var uniqueResourceIds = list
@@ -180,11 +181,11 @@ namespace Altinn.AccessManagement.UI.Core.Services
             }).ToList();
         }
 
-        private async Task<IEnumerable<EnrichedPackageRequest>> MapToEnrichedPackageRequestList(IEnumerable<RequestResourceDto> list, string languageCode)
+        private async Task<IEnumerable<EnrichedPackageRequest>> MapToEnrichedPackageRequestList(IEnumerable<Request> list, string languageCode)
         {
             Dictionary<Guid, AccessPackage> packageDictionary = [];
             var uniquePackageIds = list
-                .Select(x => Guid.Parse(x.Resource.ReferenceId))
+                .Select(x => Guid.Parse(x.Package.ReferenceId))
                 .Distinct();
 
             foreach (var packageId in uniquePackageIds)
@@ -201,7 +202,7 @@ namespace Altinn.AccessManagement.UI.Core.Services
             return list.Select(x =>
             {
                 RequestFE request = MapToRequestFE(x);
-                var packageId = Guid.Parse(x.Resource.ReferenceId);
+                var packageId = Guid.Parse(x.Package.ReferenceId);
 
                 if (!packageDictionary.TryGetValue(packageId, out var package))
                 {
@@ -215,7 +216,7 @@ namespace Altinn.AccessManagement.UI.Core.Services
                     To = request.To,
                     Type = request.Type,
                     Status = request.Status,
-                    ResourceId = request.ResourceId,
+                    PackageId = request.PackageId,
                     LastUpdated = request.LastUpdated,
                     Package = package
                 };

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/RequestClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/RequestClient.cs
@@ -45,7 +45,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
         }
 
         /// <inheritdoc />
-        public async Task<PaginatedResult<RequestResourceDto>> GetSentRequests(Guid party, Guid? to, List<RequestStatus> status, string type, CancellationToken cancellationToken)
+        public async Task<PaginatedResult<Request>> GetSentRequests(Guid party, Guid? to, List<RequestStatus> status, string type, CancellationToken cancellationToken)
         {
             try
             {
@@ -60,17 +60,17 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
                 }
 
                 var statusParams = status?.Select(s => new KeyValuePair<string, string>("status", s.ToString())) ?? [];
-                
+
                 if (!string.IsNullOrEmpty(type))
                 {
                     queryParams.Add("type", type);
                 }
-                
+
                 string endpointUrl = QueryHelpers.AddQueryString("enduser/request/sent", queryParams.Concat(statusParams));
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
 
                 var httpResponse = await _client.GetAsync(token, endpointUrl);
-                return await ClientUtils.DeserializeIfSuccessfullStatusCode<PaginatedResult<RequestResourceDto>>(httpResponse);
+                return await ClientUtils.DeserializeIfSuccessfullStatusCode<PaginatedResult<Request>>(httpResponse);
             }
             catch (Exception ex)
             {
@@ -80,7 +80,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
         }
 
         /// <inheritdoc />
-        public async Task<PaginatedResult<RequestResourceDto>> GetReceivedRequests(Guid party, Guid? from, List<RequestStatus> status, string type, CancellationToken cancellationToken)
+        public async Task<PaginatedResult<Request>> GetReceivedRequests(Guid party, Guid? from, List<RequestStatus> status, string type, CancellationToken cancellationToken)
         {
             try
             {
@@ -95,17 +95,17 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
                 }
 
                 var statusParams = status?.Select(s => new KeyValuePair<string, string>("status", s.ToString())) ?? [];
-                
+
                 if (!string.IsNullOrEmpty(type))
                 {
                     queryParams.Add("type", type);
                 }
-                
+
                 string endpointUrl = QueryHelpers.AddQueryString("enduser/request/received", queryParams.Concat(statusParams));
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
 
                 var httpResponse = await _client.GetAsync(token, endpointUrl);
-                return await ClientUtils.DeserializeIfSuccessfullStatusCode<PaginatedResult<RequestResourceDto>>(httpResponse);
+                return await ClientUtils.DeserializeIfSuccessfullStatusCode<PaginatedResult<Request>>(httpResponse);
             }
             catch (Exception ex)
             {
@@ -115,7 +115,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
         }
 
         /// <inheritdoc />
-        public async Task<RequestResourceDto> GetRequest(Guid party, Guid id, CancellationToken cancellationToken)
+        public async Task<Request> GetRequest(Guid party, Guid id, CancellationToken cancellationToken)
         {
             try
             {
@@ -123,7 +123,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
 
                 var httpResponse = await _client.GetAsync(token, endpointUrl);
-                return await ClientUtils.DeserializeIfSuccessfullStatusCode<RequestResourceDto>(httpResponse);
+                return await ClientUtils.DeserializeIfSuccessfullStatusCode<Request>(httpResponse);
             }
             catch (Exception ex)
             {
@@ -133,7 +133,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
         }
 
         /// <inheritdoc />
-        public async Task<RequestResourceDto> GetDraftRequest(Guid id, CancellationToken cancellationToken)
+        public async Task<Request> GetDraftRequest(Guid id, CancellationToken cancellationToken)
         {
             try
             {
@@ -141,7 +141,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
 
                 var httpResponse = await _client.GetAsync(token, endpointUrl);
-                return await ClientUtils.DeserializeIfSuccessfullStatusCode<RequestResourceDto>(httpResponse);
+                return await ClientUtils.DeserializeIfSuccessfullStatusCode<Request>(httpResponse);
             }
             catch (Exception ex)
             {
@@ -151,7 +151,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
         }
 
         /// <inheritdoc />
-        public async Task<RequestResourceDto> CreateResourceRequest(Guid party, Guid to, string resource, CancellationToken cancellationToken)
+        public async Task<Request> CreateResourceRequest(Guid party, Guid to, string resource, CancellationToken cancellationToken)
         {
             try
             {
@@ -159,7 +159,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
 
                 var httpResponse = await _client.PostAsync(token, endpointUrl, null);
-                return await ClientUtils.DeserializeIfSuccessfullStatusCode<RequestResourceDto>(httpResponse);
+                return await ClientUtils.DeserializeIfSuccessfullStatusCode<Request>(httpResponse);
             }
             catch (Exception ex)
             {
@@ -169,7 +169,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
         }
 
         /// <inheritdoc />
-        public async Task<RequestResourceDto> WithdrawRequest(Guid party, Guid id, CancellationToken cancellationToken)
+        public async Task<Request> WithdrawRequest(Guid party, Guid id, CancellationToken cancellationToken)
         {
             try
             {
@@ -177,7 +177,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
 
                 var httpResponse = await _client.PutAsync(token, endpointUrl, null);
-                return await ClientUtils.DeserializeIfSuccessfullStatusCode<RequestResourceDto>(httpResponse);
+                return await ClientUtils.DeserializeIfSuccessfullStatusCode<Request>(httpResponse);
             }
             catch (Exception ex)
             {
@@ -187,7 +187,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
         }
 
         /// <inheritdoc />
-        public async Task<RequestResourceDto> ConfirmRequest(Guid party, Guid id, CancellationToken cancellationToken)
+        public async Task<Request> ConfirmRequest(Guid party, Guid id, CancellationToken cancellationToken)
         {
             try
             {
@@ -195,7 +195,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
 
                 var httpResponse = await _client.PutAsync(token, endpointUrl, null);
-                return await ClientUtils.DeserializeIfSuccessfullStatusCode<RequestResourceDto>(httpResponse);
+                return await ClientUtils.DeserializeIfSuccessfullStatusCode<Request>(httpResponse);
             }
             catch (Exception ex)
             {
@@ -205,7 +205,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
         }
 
         /// <inheritdoc />
-        public async Task<RequestResourceDto> RejectRequest(Guid party, Guid id, CancellationToken cancellationToken)
+        public async Task<Request> RejectRequest(Guid party, Guid id, CancellationToken cancellationToken)
         {
             try
             {
@@ -213,7 +213,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
 
                 var httpResponse = await _client.PutAsync(token, endpointUrl, null);
-                return await ClientUtils.DeserializeIfSuccessfullStatusCode<RequestResourceDto>(httpResponse);
+                return await ClientUtils.DeserializeIfSuccessfullStatusCode<Request>(httpResponse);
             }
             catch (Exception ex)
             {
@@ -223,7 +223,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
         }
 
         /// <inheritdoc />
-        public async Task<RequestResourceDto> ApproveRequest(Guid party, Guid id, CancellationToken cancellationToken)
+        public async Task<Request> ApproveRequest(Guid party, Guid id, CancellationToken cancellationToken)
         {
             try
             {
@@ -231,7 +231,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
 
                 var httpResponse = await _client.PutAsync(token, endpointUrl, null);
-                return await ClientUtils.DeserializeIfSuccessfullStatusCode<RequestResourceDto>(httpResponse);
+                return await ClientUtils.DeserializeIfSuccessfullStatusCode<Request>(httpResponse);
             }
             catch (Exception ex)
             {

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/Request/receivedPackageRequests.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/Request/receivedPackageRequests.json
@@ -1,0 +1,23 @@
+{
+    "data": [
+        {
+            "id": "da45b77b-a068-4d53-b6be-0837cc9c5a3f",
+            "type": "package",
+            "status": "Pending",
+            "to": {
+                "id": "feb51634-0042-4ab0-a9db-8705300141a6",
+                "name": "EKSTRA SUNN KATT DAGSMARSJ",
+                "type": "organization"
+            },
+            "from": {
+                "id": "167536b5-f8ed-4c5a-8f48-0279507e53ae",
+                "name": "SITRONGUL MEDALJONG",
+                "type": "person"
+            },
+            "resource": {
+                "referenceId": "1dba50d6-f604-48e9-bd41-82321b13e85c"
+            },
+            "lastUpdated": "2025-06-01T12:00:00+00:00"
+        }
+    ]
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/Request/receivedPackageRequests.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/Request/receivedPackageRequests.json
@@ -14,7 +14,7 @@
                 "name": "SITRONGUL MEDALJONG",
                 "type": "person"
             },
-            "resource": {
+            "package": {
                 "referenceId": "1dba50d6-f604-48e9-bd41-82321b13e85c"
             },
             "lastUpdated": "2025-06-01T12:00:00+00:00"

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/Request/receivedPackageRequestsInvalidPackage.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/Request/receivedPackageRequestsInvalidPackage.json
@@ -1,0 +1,23 @@
+{
+    "data": [
+        {
+            "id": "da45b77b-a068-4d53-b6be-0837cc9c5a3f",
+            "type": "package",
+            "status": "Pending",
+            "to": {
+                "id": "feb51634-0042-4ab0-a9db-8705300141a6",
+                "name": "EKSTRA SUNN KATT DAGSMARSJ",
+                "type": "organization"
+            },
+            "from": {
+                "id": "167536b5-f8ed-4c5a-8f48-0279507e53ae",
+                "name": "SITRONGUL MEDALJONG",
+                "type": "person"
+            },
+            "resource": {
+                "referenceId": "99999999-9999-9999-9999-999999999999"
+            },
+            "lastUpdated": "2025-06-01T12:00:00+00:00"
+        }
+    ]
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/Request/receivedPackageRequestsInvalidPackage.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/Request/receivedPackageRequestsInvalidPackage.json
@@ -14,7 +14,7 @@
                 "name": "SITRONGUL MEDALJONG",
                 "type": "person"
             },
-            "resource": {
+            "package": {
                 "referenceId": "99999999-9999-9999-9999-999999999999"
             },
             "lastUpdated": "2025-06-01T12:00:00+00:00"

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/Request/sentPackageRequests.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/Request/sentPackageRequests.json
@@ -1,0 +1,23 @@
+{
+    "data": [
+        {
+            "id": "da45b77b-a068-4d53-b6be-0837cc9c5a3f",
+            "type": "package",
+            "status": "Pending",
+            "to": {
+                "id": "feb51634-0042-4ab0-a9db-8705300141a6",
+                "name": "EKSTRA SUNN KATT DAGSMARSJ",
+                "type": "organization"
+            },
+            "from": {
+                "id": "167536b5-f8ed-4c5a-8f48-0279507e53ae",
+                "name": "SITRONGUL MEDALJONG",
+                "type": "person"
+            },
+            "resource": {
+                "referenceId": "1dba50d6-f604-48e9-bd41-82321b13e85c"
+            },
+            "lastUpdated": "2025-06-01T12:00:00+00:00"
+        }
+    ]
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/Request/sentPackageRequests.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/Request/sentPackageRequests.json
@@ -14,7 +14,7 @@
                 "name": "SITRONGUL MEDALJONG",
                 "type": "person"
             },
-            "resource": {
+            "package": {
                 "referenceId": "1dba50d6-f604-48e9-bd41-82321b13e85c"
             },
             "lastUpdated": "2025-06-01T12:00:00+00:00"

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/Request/sentPackageRequestsInvalidPackage.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/Request/sentPackageRequestsInvalidPackage.json
@@ -1,0 +1,23 @@
+{
+    "data": [
+        {
+            "id": "da45b77b-a068-4d53-b6be-0837cc9c5a3f",
+            "type": "package",
+            "status": "Pending",
+            "to": {
+                "id": "feb51634-0042-4ab0-a9db-8705300141a6",
+                "name": "EKSTRA SUNN KATT DAGSMARSJ",
+                "type": "organization"
+            },
+            "from": {
+                "id": "167536b5-f8ed-4c5a-8f48-0279507e53ae",
+                "name": "SITRONGUL MEDALJONG",
+                "type": "person"
+            },
+            "resource": {
+                "referenceId": "99999999-9999-9999-9999-999999999999"
+            },
+            "lastUpdated": "2025-06-01T12:00:00+00:00"
+        }
+    ]
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/Request/sentPackageRequestsInvalidPackage.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/Request/sentPackageRequestsInvalidPackage.json
@@ -14,7 +14,7 @@
                 "name": "SITRONGUL MEDALJONG",
                 "type": "person"
             },
-            "resource": {
+            "package": {
                 "referenceId": "99999999-9999-9999-9999-999999999999"
             },
             "lastUpdated": "2025-06-01T12:00:00+00:00"

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/RequestClientMock.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/RequestClientMock.cs
@@ -41,11 +41,20 @@ namespace Altinn.AccessManagement.UI.Mocks.Mocks
             ThrowExceptionIfTriggerParty(party.ToString());
             ThrowHttpStatusExceptionIfTriggerParty(party.ToString());
 
-            string dataPath = Path.Combine(dataFolder, "Request", "sentRequests.json");
-            if (party == Guid.Parse("22222222-2222-2222-2222-222222222222"))
+            string dataPath;
+            if (type == "package")
             {
-                dataPath = Path.Combine(dataFolder, "Request", "sentRequestsInvalidResource.json");
+                dataPath = party == Guid.Parse("22222222-2222-2222-2222-222222222222")
+                    ? Path.Combine(dataFolder, "Request", "sentPackageRequestsInvalidPackage.json")
+                    : Path.Combine(dataFolder, "Request", "sentPackageRequests.json");
             }
+            else
+            {
+                dataPath = party == Guid.Parse("22222222-2222-2222-2222-222222222222")
+                    ? Path.Combine(dataFolder, "Request", "sentRequestsInvalidResource.json")
+                    : Path.Combine(dataFolder, "Request", "sentRequests.json");
+            }
+
             return await Task.FromResult(Util.GetMockData<PaginatedResult<RequestResourceDto>>(dataPath));
         }
 
@@ -55,11 +64,20 @@ namespace Altinn.AccessManagement.UI.Mocks.Mocks
             ThrowExceptionIfTriggerParty(party.ToString());
             ThrowHttpStatusExceptionIfTriggerParty(party.ToString());
 
-            string dataPath = Path.Combine(dataFolder, "Request", "receivedRequests.json");
-            if (party == Guid.Parse("22222222-2222-2222-2222-222222222222"))
+            string dataPath;
+            if (type == "package")
             {
-                dataPath = Path.Combine(dataFolder, "Request", "receivedRequestsInvalidResource.json");
+                dataPath = party == Guid.Parse("22222222-2222-2222-2222-222222222222")
+                    ? Path.Combine(dataFolder, "Request", "receivedPackageRequestsInvalidPackage.json")
+                    : Path.Combine(dataFolder, "Request", "receivedPackageRequests.json");
             }
+            else
+            {
+                dataPath = party == Guid.Parse("22222222-2222-2222-2222-222222222222")
+                    ? Path.Combine(dataFolder, "Request", "receivedRequestsInvalidResource.json")
+                    : Path.Combine(dataFolder, "Request", "receivedRequests.json");
+            }
+
             return await Task.FromResult(Util.GetMockData<PaginatedResult<RequestResourceDto>>(dataPath));
         }
 

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/RequestClientMock.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/RequestClientMock.cs
@@ -36,7 +36,7 @@ namespace Altinn.AccessManagement.UI.Mocks.Mocks
         }
 
         /// <inheritdoc />
-        public async Task<PaginatedResult<RequestResourceDto>> GetSentRequests(Guid party, Guid? to, List<RequestStatus> status, string type, CancellationToken cancellationToken)
+        public async Task<PaginatedResult<Request>> GetSentRequests(Guid party, Guid? to, List<RequestStatus> status, string type, CancellationToken cancellationToken)
         {
             ThrowExceptionIfTriggerParty(party.ToString());
             ThrowHttpStatusExceptionIfTriggerParty(party.ToString());
@@ -55,11 +55,11 @@ namespace Altinn.AccessManagement.UI.Mocks.Mocks
                     : Path.Combine(dataFolder, "Request", "sentRequests.json");
             }
 
-            return await Task.FromResult(Util.GetMockData<PaginatedResult<RequestResourceDto>>(dataPath));
+            return await Task.FromResult(Util.GetMockData<PaginatedResult<Request>>(dataPath));
         }
 
         /// <inheritdoc />
-        public async Task<PaginatedResult<RequestResourceDto>> GetReceivedRequests(Guid party, Guid? from, List<RequestStatus> status, string type, CancellationToken cancellationToken)
+        public async Task<PaginatedResult<Request>> GetReceivedRequests(Guid party, Guid? from, List<RequestStatus> status, string type, CancellationToken cancellationToken)
         {
             ThrowExceptionIfTriggerParty(party.ToString());
             ThrowHttpStatusExceptionIfTriggerParty(party.ToString());
@@ -78,70 +78,70 @@ namespace Altinn.AccessManagement.UI.Mocks.Mocks
                     : Path.Combine(dataFolder, "Request", "receivedRequests.json");
             }
 
-            return await Task.FromResult(Util.GetMockData<PaginatedResult<RequestResourceDto>>(dataPath));
+            return await Task.FromResult(Util.GetMockData<PaginatedResult<Request>>(dataPath));
         }
 
         /// <inheritdoc />
-        public async Task<RequestResourceDto> GetRequest(Guid party, Guid id, CancellationToken cancellationToken)
+        public async Task<Request> GetRequest(Guid party, Guid id, CancellationToken cancellationToken)
         {
             ThrowExceptionIfTriggerParty(party.ToString());
             ThrowHttpStatusExceptionIfTriggerParty(party.ToString());
 
             string dataPath = Path.Combine(dataFolder, "Request", "singleRequest.json");
-            return await Task.FromResult(Util.GetMockData<RequestResourceDto>(dataPath));
+            return await Task.FromResult(Util.GetMockData<Request>(dataPath));
         }
 
         /// <inheritdoc />
-        public async Task<RequestResourceDto> CreateResourceRequest(Guid party, Guid to, string resource, CancellationToken cancellationToken)
+        public async Task<Request> CreateResourceRequest(Guid party, Guid to, string resource, CancellationToken cancellationToken)
         {
             ThrowExceptionIfTriggerParty(party.ToString());
             ThrowHttpStatusExceptionIfTriggerParty(party.ToString());
 
             string dataPath = Path.Combine(dataFolder, "Request", "singleRequest.json");
-            return await Task.FromResult(Util.GetMockData<RequestResourceDto>(dataPath));
+            return await Task.FromResult(Util.GetMockData<Request>(dataPath));
         }
 
         /// <inheritdoc />
-        public async Task<RequestResourceDto> WithdrawRequest(Guid party, Guid id, CancellationToken cancellationToken)
+        public async Task<Request> WithdrawRequest(Guid party, Guid id, CancellationToken cancellationToken)
         {
             ThrowExceptionIfTriggerParty(party.ToString());
             ThrowHttpStatusExceptionIfTriggerParty(party.ToString());
 
             string dataPath = Path.Combine(dataFolder, "Request", "singleRequest.json");
-            return await Task.FromResult(Util.GetMockData<RequestResourceDto>(dataPath));
+            return await Task.FromResult(Util.GetMockData<Request>(dataPath));
         }
 
         /// <inheritdoc />
-        public async Task<RequestResourceDto> ConfirmRequest(Guid party, Guid id, CancellationToken cancellationToken)
+        public async Task<Request> ConfirmRequest(Guid party, Guid id, CancellationToken cancellationToken)
         {
             ThrowExceptionIfTriggerParty(party.ToString());
             ThrowHttpStatusExceptionIfTriggerParty(party.ToString());
 
             string dataPath = Path.Combine(dataFolder, "Request", "singleRequest.json");
-            return await Task.FromResult(Util.GetMockData<RequestResourceDto>(dataPath));
+            return await Task.FromResult(Util.GetMockData<Request>(dataPath));
         }
 
         /// <inheritdoc />
-        public async Task<RequestResourceDto> RejectRequest(Guid party, Guid id, CancellationToken cancellationToken)
+        public async Task<Request> RejectRequest(Guid party, Guid id, CancellationToken cancellationToken)
         {
             ThrowExceptionIfTriggerParty(party.ToString());
             ThrowHttpStatusExceptionIfTriggerParty(party.ToString());
 
             string dataPath = Path.Combine(dataFolder, "Request", "singleRequest.json");
-            return await Task.FromResult(Util.GetMockData<RequestResourceDto>(dataPath));
+            return await Task.FromResult(Util.GetMockData<Request>(dataPath));
         }
 
         /// <inheritdoc />
-        public async Task<RequestResourceDto> ApproveRequest(Guid party, Guid id, CancellationToken cancellationToken)
+        public async Task<Request> ApproveRequest(Guid party, Guid id, CancellationToken cancellationToken)
         {
             ThrowExceptionIfTriggerParty(party.ToString());
             ThrowHttpStatusExceptionIfTriggerParty(party.ToString());
 
             string dataPath = Path.Combine(dataFolder, "Request", "singleRequest.json");
-            return await Task.FromResult(Util.GetMockData<RequestResourceDto>(dataPath));
+            return await Task.FromResult(Util.GetMockData<Request>(dataPath));
         }
 
-        public async Task<RequestResourceDto> GetDraftRequest(Guid id, CancellationToken cancellationToken)
+        public async Task<Request> GetDraftRequest(Guid id, CancellationToken cancellationToken)
         {
             ThrowExceptionIfTriggerParty(id.ToString());
             ThrowHttpStatusExceptionIfTriggerParty(id.ToString());
@@ -152,7 +152,7 @@ namespace Altinn.AccessManagement.UI.Mocks.Mocks
                 dataPath = Path.Combine(dataFolder, "Request", "draftRequestInvalidResource.json");
             }
 
-            return await Task.FromResult(Util.GetMockData<RequestResourceDto>(dataPath));
+            return await Task.FromResult(Util.GetMockData<Request>(dataPath));
         }
 
         /// <inheritdoc />

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/RequestControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/RequestControllerTest.cs
@@ -201,7 +201,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, httpResponse.StatusCode);
         }
-        
+
         /// <summary>
         ///     Test case: GetEnrichedReceivedResourceRequests encounters a NotFoundException due to invalid resource reference in request
         ///     Expected: Returns 404 Not Found
@@ -214,6 +214,152 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
 
             // Act
             HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/request/received/resource?party={party}");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.NotFound, httpResponse.StatusCode);
+        }
+
+        /// <summary>
+        ///     Test case: GetEnrichedSentPackageRequests returns sent package requests for party with package data included
+        ///     Expected: GetEnrichedSentPackageRequests returns the requests sent by a party with package data included
+        /// </summary>
+        [Fact]
+        public async Task GetEnrichedSentPackageRequests_ReturnsRequestsForParty()
+        {
+            // Arrange
+            string party = "167536b5-f8ed-4c5a-8f48-0279507e53ae";
+            string toParty = "feb51634-0042-4ab0-a9db-8705300141a6";
+            string path = Path.Combine(_expectedDataPath, "Request", "getEnrichedSentPackageRequests.json");
+            IEnumerable<EnrichedPackageRequest> expectedResponse = Util.GetMockData<IEnumerable<EnrichedPackageRequest>>(path);
+
+            // Act
+            HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/request/sent/package?party={party}&to={toParty}");
+            IEnumerable<EnrichedPackageRequest> actualResponse = await httpResponse.Content.ReadFromJsonAsync<IEnumerable<EnrichedPackageRequest>>();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, httpResponse.StatusCode);
+            AssertionUtil.AssertCollections(expectedResponse.ToList(), actualResponse.ToList(), AssertionUtil.AssertEqual);
+        }
+
+        /// <summary>
+        ///     Test case: GetEnrichedSentPackageRequests encounters an unexpected internal error
+        ///     Expected: Returns 500 Internal Server Error
+        /// </summary>
+        [Fact]
+        public async Task GetEnrichedSentPackageRequests_InternalServerError()
+        {
+            // Arrange
+            string party = "00000000-0000-0000-0000-000000000000";
+
+            // Act
+            HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/request/sent/package?party={party}");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.InternalServerError, httpResponse.StatusCode);
+        }
+
+        /// <summary>
+        ///     Test case: GetEnrichedSentPackageRequests encounters an HttpStatusException
+        ///     Expected: Returns the status code from the exception (BadRequest)
+        /// </summary>
+        [Fact]
+        public async Task GetEnrichedSentPackageRequests_HttpStatusException()
+        {
+            // Arrange
+            string party = "11111111-1111-1111-1111-111111111111";
+
+            // Act
+            HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/request/sent/package?party={party}");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, httpResponse.StatusCode);
+        }
+
+        /// <summary>
+        ///     Test case: GetEnrichedSentPackageRequests encounters a NotFoundException due to invalid package reference in request
+        ///     Expected: Returns 404 Not Found
+        /// </summary>
+        [Fact]
+        public async Task GetEnrichedSentPackageRequests_NotFoundException()
+        {
+            // Arrange
+            string party = "22222222-2222-2222-2222-222222222222";
+
+            // Act
+            HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/request/sent/package?party={party}");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.NotFound, httpResponse.StatusCode);
+        }
+
+        /// <summary>
+        ///     Test case: GetEnrichedReceivedPackageRequests returns received package requests for party with package data included
+        ///     Expected: GetEnrichedReceivedPackageRequests returns the requests received by a party with package data included
+        /// </summary>
+        [Fact]
+        public async Task GetEnrichedReceivedPackageRequests_ReturnsRequestsForParty()
+        {
+            // Arrange
+            string party = "167536b5-f8ed-4c5a-8f48-0279507e53ae";
+            string fromParty = "feb51634-0042-4ab0-a9db-8705300141a6";
+            string path = Path.Combine(_expectedDataPath, "Request", "getEnrichedReceivedPackageRequests.json");
+            IEnumerable<EnrichedPackageRequest> expectedResponse = Util.GetMockData<IEnumerable<EnrichedPackageRequest>>(path);
+
+            // Act
+            HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/request/received/package?party={party}&from={fromParty}");
+            IEnumerable<EnrichedPackageRequest> actualResponse = await httpResponse.Content.ReadFromJsonAsync<IEnumerable<EnrichedPackageRequest>>();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, httpResponse.StatusCode);
+            AssertionUtil.AssertCollections(expectedResponse.ToList(), actualResponse.ToList(), AssertionUtil.AssertEqual);
+        }
+
+        /// <summary>
+        ///     Test case: GetEnrichedReceivedPackageRequests encounters an unexpected internal error
+        ///     Expected: Returns 500 Internal Server Error
+        /// </summary>
+        [Fact]
+        public async Task GetEnrichedReceivedPackageRequests_InternalServerError()
+        {
+            // Arrange
+            string party = "00000000-0000-0000-0000-000000000000";
+
+            // Act
+            HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/request/received/package?party={party}");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.InternalServerError, httpResponse.StatusCode);
+        }
+
+        /// <summary>
+        ///     Test case: GetEnrichedReceivedPackageRequests encounters an HttpStatusException
+        ///     Expected: Returns the status code from the exception (BadRequest)
+        /// </summary>
+        [Fact]
+        public async Task GetEnrichedReceivedPackageRequests_HttpStatusException()
+        {
+            // Arrange
+            string party = "11111111-1111-1111-1111-111111111111";
+
+            // Act
+            HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/request/received/package?party={party}");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, httpResponse.StatusCode);
+        }
+
+        /// <summary>
+        ///     Test case: GetEnrichedReceivedPackageRequests encounters a NotFoundException due to invalid package reference in request
+        ///     Expected: Returns 404 Not Found
+        /// </summary>
+        [Fact]
+        public async Task GetEnrichedReceivedPackageRequests_NotFoundException()
+        {
+            // Arrange
+            string party = "22222222-2222-2222-2222-222222222222";
+
+            // Act
+            HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/request/received/package?party={party}");
 
             // Assert
             Assert.Equal(HttpStatusCode.NotFound, httpResponse.StatusCode);
@@ -295,7 +441,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, httpResponse.StatusCode);
         }
-        
+
         /// <summary>
         ///     Test case: GetDraftRequest encounters a NotFoundException from the backend
         ///     Expected: Returns the status code from the exception (NotFound)

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/Request/getEnrichedReceivedPackageRequests.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/Request/getEnrichedReceivedPackageRequests.json
@@ -13,7 +13,7 @@
             "name": "SITRONGUL MEDALJONG",
             "type": "person"
         },
-        "resourceId": "1dba50d6-f604-48e9-bd41-82321b13e85c",
+        "packageId": "1dba50d6-f604-48e9-bd41-82321b13e85c",
         "lastUpdated": "2025-06-01T12:00:00+00:00",
         "package": {
             "id": "1dba50d6-f604-48e9-bd41-82321b13e85c",

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/Request/getEnrichedReceivedPackageRequests.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/Request/getEnrichedReceivedPackageRequests.json
@@ -1,0 +1,43 @@
+[
+    {
+        "id": "da45b77b-a068-4d53-b6be-0837cc9c5a3f",
+        "type": "package",
+        "status": "Pending",
+        "to": {
+            "id": "feb51634-0042-4ab0-a9db-8705300141a6",
+            "name": "EKSTRA SUNN KATT DAGSMARSJ",
+            "type": "organization"
+        },
+        "from": {
+            "id": "167536b5-f8ed-4c5a-8f48-0279507e53ae",
+            "name": "SITRONGUL MEDALJONG",
+            "type": "person"
+        },
+        "resourceId": "1dba50d6-f604-48e9-bd41-82321b13e85c",
+        "lastUpdated": "2025-06-01T12:00:00+00:00",
+        "package": {
+            "id": "1dba50d6-f604-48e9-bd41-82321b13e85c",
+            "name": "Skatt næring",
+            "urn": "urn:altinn:accesspackage:skatt-naering",
+            "description": "Denne tilgangspakken gir fullmakter til tjenester knyttet til skatt for næringer. Ved regelverksendringer eller innføring av nye digitale tjenester kan det bli endringer i tilganger som fullmakten gir.",
+            "isDelegable": true,
+            "isAssignable": false,
+            "area": {
+                "group": {
+                    "id": "7e2a3af8-08cb-43a9-bdd7-7d5c7e377145",
+                    "name": "Allment",
+                    "description": "Standard gruppe",
+                    "entityTypeId": "8c216e2f-afdd-4234-9ba2-691c727bb33d",
+                    "urn": null
+                },
+                "id": "7d32591d-34b7-4afc-8afa-013722f8c05d",
+                "name": "Skatt, avgift, regnskap og toll",
+                "description": "Dette fullmaktsområdet omfatter tilgangspakker knyttet til skatt, avgift, regnskap og toll.",
+                "iconUrl": "Money_SackKroner",
+                "groupId": "7e2a3af8-08cb-43a9-bdd7-7d5c7e377145",
+                "urn": "accesspackage:area:skatt_avgift_regnskap_og_toll"
+            },
+            "resources": []
+        }
+    }
+]

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/Request/getEnrichedSentPackageRequests.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/Request/getEnrichedSentPackageRequests.json
@@ -13,7 +13,7 @@
             "name": "SITRONGUL MEDALJONG",
             "type": "person"
         },
-        "resourceId": "1dba50d6-f604-48e9-bd41-82321b13e85c",
+        "packageId": "1dba50d6-f604-48e9-bd41-82321b13e85c",
         "lastUpdated": "2025-06-01T12:00:00+00:00",
         "package": {
             "id": "1dba50d6-f604-48e9-bd41-82321b13e85c",

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/Request/getEnrichedSentPackageRequests.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/Request/getEnrichedSentPackageRequests.json
@@ -1,0 +1,43 @@
+[
+    {
+        "id": "da45b77b-a068-4d53-b6be-0837cc9c5a3f",
+        "type": "package",
+        "status": "Pending",
+        "to": {
+            "id": "feb51634-0042-4ab0-a9db-8705300141a6",
+            "name": "EKSTRA SUNN KATT DAGSMARSJ",
+            "type": "organization"
+        },
+        "from": {
+            "id": "167536b5-f8ed-4c5a-8f48-0279507e53ae",
+            "name": "SITRONGUL MEDALJONG",
+            "type": "person"
+        },
+        "resourceId": "1dba50d6-f604-48e9-bd41-82321b13e85c",
+        "lastUpdated": "2025-06-01T12:00:00+00:00",
+        "package": {
+            "id": "1dba50d6-f604-48e9-bd41-82321b13e85c",
+            "name": "Skatt næring",
+            "urn": "urn:altinn:accesspackage:skatt-naering",
+            "description": "Denne tilgangspakken gir fullmakter til tjenester knyttet til skatt for næringer. Ved regelverksendringer eller innføring av nye digitale tjenester kan det bli endringer i tilganger som fullmakten gir.",
+            "isDelegable": true,
+            "isAssignable": false,
+            "area": {
+                "group": {
+                    "id": "7e2a3af8-08cb-43a9-bdd7-7d5c7e377145",
+                    "name": "Allment",
+                    "description": "Standard gruppe",
+                    "entityTypeId": "8c216e2f-afdd-4234-9ba2-691c727bb33d",
+                    "urn": null
+                },
+                "id": "7d32591d-34b7-4afc-8afa-013722f8c05d",
+                "name": "Skatt, avgift, regnskap og toll",
+                "description": "Dette fullmaktsområdet omfatter tilgangspakker knyttet til skatt, avgift, regnskap og toll.",
+                "iconUrl": "Money_SackKroner",
+                "groupId": "7e2a3af8-08cb-43a9-bdd7-7d5c7e377145",
+                "urn": "accesspackage:area:skatt_avgift_regnskap_og_toll"
+            },
+            "resources": []
+        }
+    }
+]

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Utils/AssertionUtil.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Utils/AssertionUtil.cs
@@ -1066,6 +1066,24 @@ namespace Altinn.AccessManagement.UI.Tests.Utils
             AssertEqual(expected.Resource, actual.Resource);
         }
 
+        public static void AssertEqual(EnrichedPackageRequest expected, EnrichedPackageRequest actual)
+        {
+            Assert.NotNull(actual);
+            Assert.NotNull(expected);
+
+            Assert.Equal(expected.Id, actual.Id);
+            Assert.Equal(expected.From.Id, actual.From.Id);
+            Assert.Equal(expected.To.Id, actual.To.Id);
+            Assert.Equal(expected.ResourceId, actual.ResourceId);
+            Assert.Equal(expected.Type, actual.Type);
+            Assert.Equal(expected.Status, actual.Status);
+            Assert.Equal(expected.LastUpdated, actual.LastUpdated);
+            Assert.NotNull(actual.Package);
+            Assert.Equal(expected.Package.Id, actual.Package.Id);
+            Assert.Equal(expected.Package.Name, actual.Package.Name);
+            Assert.Equal(expected.Package.Urn, actual.Package.Urn);
+        }
+
         private static void AssertEqual(Provider expected, Provider actual)
         {
             if (expected == null)

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Utils/AssertionUtil.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Utils/AssertionUtil.cs
@@ -1046,6 +1046,7 @@ namespace Altinn.AccessManagement.UI.Tests.Utils
             Assert.Equal(expected.From.Id, actual.From.Id);
             Assert.Equal(expected.To.Id, actual.To.Id);
             Assert.Equal(expected.ResourceId, actual.ResourceId);
+            Assert.Equal(expected.PackageId, actual.PackageId);
             Assert.Equal(expected.Type, actual.Type);
             Assert.Equal(expected.LastUpdated, actual.LastUpdated);
             Assert.Equal(expected.Status, actual.Status);
@@ -1074,7 +1075,7 @@ namespace Altinn.AccessManagement.UI.Tests.Utils
             Assert.Equal(expected.Id, actual.Id);
             Assert.Equal(expected.From.Id, actual.From.Id);
             Assert.Equal(expected.To.Id, actual.To.Id);
-            Assert.Equal(expected.ResourceId, actual.ResourceId);
+            Assert.Equal(expected.PackageId, actual.PackageId);
             Assert.Equal(expected.Type, actual.Type);
             Assert.Equal(expected.Status, actual.Status);
             Assert.Equal(expected.LastUpdated, actual.LastUpdated);

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Utils/SetupUtils.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Utils/SetupUtils.cs
@@ -575,6 +575,7 @@ namespace Altinn.AccessManagement.UI.Tests.Utils
                 builder.ConfigureTestServices(services =>
                 {
                     services.AddTransient<IRequestClient, RequestClientMock>();
+                    services.AddTransient<IAccessPackageClient, AccessPackageClientMock>();
                     services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
                     services.AddSingleton<IPostConfigureOptions<JwtCookieOptions>, JwtCookiePostConfigureOptionsStub>();
                 });

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/RequestController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/RequestController.cs
@@ -103,6 +103,42 @@ namespace Altinn.AccessManagement.UI.Controllers
         }
 
         /// <summary>
+        ///     Endpoint for getting enriched package requests sent by a party
+        /// </summary>
+        /// <param name="party">The acting party</param>
+        /// <param name="to">The party the requests were sent to</param>
+        /// <param name="status">Status filter</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <response code="400">Bad Request</response>
+        /// <response code="500">Internal Server Error</response>
+        [HttpGet]
+        [Authorize]
+        [Route("sent/package")]
+        public async Task<ActionResult> GetEnrichedSentPackageRequests([FromQuery] Guid party, [FromQuery] Guid? to, [FromQuery] List<RequestStatus> status, CancellationToken cancellationToken)
+        {
+            try
+            {
+                var languageCode = LanguageHelper.GetSelectedLanguageCookieValueBackendStandard(HttpContext);
+                var returnVal = await _requestService.GetEnrichedSentPackageRequests(party, to, status, languageCode, cancellationToken);
+                return Ok(returnVal);
+            }
+            catch (ResourceNotFoundException ex)
+            {
+                return NotFound(ProblemDetailsFactory.CreateProblemDetails(HttpContext, (int?)StatusCodes.Status404NotFound, "Access package not found", detail: ex.Message));
+            }
+            catch (HttpStatusException statusEx)
+            {
+                string responseContent = statusEx.Message;
+                return new ObjectResult(ProblemDetailsFactory.CreateProblemDetails(HttpContext, (int?)statusEx.StatusCode, "Unexpected HttpStatus response from backend", detail: responseContent));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Unexpected exception occurred during GetEnrichedSentPackageRequests: {Message}", ex.Message);
+                return new ObjectResult(ProblemDetailsFactory.CreateProblemDetails(HttpContext));
+            }
+        }
+
+        /// <summary>
         ///     Endpoint for getting requests received by a party
         /// </summary>
         /// <param name="party">The acting party</param>
@@ -166,6 +202,42 @@ namespace Altinn.AccessManagement.UI.Controllers
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Unexpected exception occurred during GetEnrichedReceivedResourceRequests: {Message}", ex.Message);
+                return new ObjectResult(ProblemDetailsFactory.CreateProblemDetails(HttpContext));
+            }
+        }
+
+        /// <summary>
+        ///     Endpoint for getting enriched package requests received by a party
+        /// </summary>
+        /// <param name="party">The acting party</param>
+        /// <param name="from">The party who sent the requests</param>
+        /// <param name="status">Status filter</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <response code="400">Bad Request</response>
+        /// <response code="500">Internal Server Error</response>
+        [HttpGet]
+        [Authorize]
+        [Route("received/package")]
+        public async Task<ActionResult> GetEnrichedReceivedPackageRequests([FromQuery] Guid party, [FromQuery] Guid? from, [FromQuery] List<RequestStatus> status, CancellationToken cancellationToken)
+        {
+            try
+            {
+                var languageCode = LanguageHelper.GetSelectedLanguageCookieValueBackendStandard(HttpContext);
+                var returnVal = await _requestService.GetEnrichedReceivedPackageRequests(party, from, status, languageCode, cancellationToken);
+                return Ok(returnVal);
+            }
+            catch (ResourceNotFoundException ex)
+            {
+                return NotFound(ProblemDetailsFactory.CreateProblemDetails(HttpContext, (int?)StatusCodes.Status404NotFound, "Access package not found", detail: ex.Message));
+            }
+            catch (HttpStatusException statusEx)
+            {
+                string responseContent = statusEx.Message;
+                return new ObjectResult(ProblemDetailsFactory.CreateProblemDetails(HttpContext, (int?)statusEx.StatusCode, "Unexpected HttpStatus response from backend", detail: responseContent));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Unexpected exception occurred during GetEnrichedReceivedPackageRequests: {Message}", ex.Message);
                 return new ObjectResult(ProblemDetailsFactory.CreateProblemDetails(HttpContext));
             }
         }

--- a/src/features/amUI/requestPage/RequestReviewModal/useRequestReview.ts
+++ b/src/features/amUI/requestPage/RequestReviewModal/useRequestReview.ts
@@ -8,6 +8,7 @@ import {
   useRejectRequestMutation,
   useGetEnrichedReceivedResourceRequestsQuery,
   type EnrichedRequestDto,
+  useGetEnrichedReceivedPackageRequestsQuery,
 } from '@/rtk/features/requestApi';
 import {
   useLazyDelegationCheckQuery,
@@ -28,6 +29,14 @@ export const useRequestReview = (request: Request | null, onClose: () => void) =
     isLoading: isLoadingRequests,
     isFetching: isFetchingRequests,
   } = useGetEnrichedReceivedResourceRequestsQuery(
+    { party: actingParty?.partyUuid || '', from: request?.partyUuid || '', status: ['Pending'] },
+    { skip: !actingParty?.partyUuid || !request?.partyUuid },
+  );
+  const {
+    data: packageRequests,
+    isLoading: isLoadingPackageRequests,
+    isFetching: isFetchingPackageRequests,
+  } = useGetEnrichedReceivedPackageRequestsQuery(
     { party: actingParty?.partyUuid || '', from: request?.partyUuid || '', status: ['Pending'] },
     { skip: !actingParty?.partyUuid || !request?.partyUuid },
   );

--- a/src/rtk/features/requestApi.ts
+++ b/src/rtk/features/requestApi.ts
@@ -14,6 +14,7 @@ export interface RequestDto {
   to: Entity;
   lastUpdated: string;
   resourceId?: string;
+  packageId?: string;
 }
 
 export interface EnrichedRequestDto extends RequestDto {

--- a/src/rtk/features/requestApi.ts
+++ b/src/rtk/features/requestApi.ts
@@ -139,7 +139,6 @@ export const requestApi = createApi({
       invalidatesTags: [
         'sentRequests',
         'enrichedSentResourceRequests',
-        'enrichedSentPackageRequests',
       ],
     }),
     withdrawRequest: builder.mutation<RequestDto, { party: string; id: string }>({

--- a/src/rtk/features/requestApi.ts
+++ b/src/rtk/features/requestApi.ts
@@ -2,6 +2,7 @@ import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 import { getCookie } from '@/resources/Cookie/CookieMethods';
 import type { Entity } from '@/dataObjects/dtos/Common';
 import { ServiceResource } from './singleRights/singleRightsApi';
+import type { AccessPackage } from './accessPackageApi';
 
 export type RequestStatus = 'None' | 'Draft' | 'Pending' | 'Approved' | 'Rejected' | 'Withdrawn';
 
@@ -17,6 +18,10 @@ export interface RequestDto {
 
 export interface EnrichedRequestDto extends RequestDto {
   resource: ServiceResource;
+}
+
+export interface EnrichedPackageRequestDto extends RequestDto {
+  package: AccessPackage;
 }
 
 const baseUrl = `${import.meta.env.BASE_URL}accessmanagement/api/v1/request`;
@@ -37,6 +42,8 @@ export const requestApi = createApi({
     'request',
     'enrichedSentResourceRequests',
     'enrichedReceivedResourceRequests',
+    'enrichedSentPackageRequests',
+    'enrichedReceivedPackageRequests',
   ],
   endpoints: (builder) => ({
     // requests page queries
@@ -96,6 +103,30 @@ export const requestApi = createApi({
       },
       providesTags: ['enrichedReceivedResourceRequests'],
     }),
+    getEnrichedSentPackageRequests: builder.query<
+      EnrichedPackageRequestDto[],
+      { party: string; to?: string; status?: RequestStatus[] }
+    >({
+      query: ({ party, to, status = [] }) => {
+        let params = `?party=${party}`;
+        if (to) params += `&to=${to}`;
+        for (const s of status) params += `&status=${s}`;
+        return `sent/package${params}`;
+      },
+      providesTags: ['enrichedSentPackageRequests'],
+    }),
+    getEnrichedReceivedPackageRequests: builder.query<
+      EnrichedPackageRequestDto[],
+      { party: string; from?: string; status?: RequestStatus[] }
+    >({
+      query: ({ party, from, status = [] }) => {
+        let params = `?party=${party}`;
+        if (from) params += `&from=${from}`;
+        for (const s of status) params += `&status=${s}`;
+        return `received/package${params}`;
+      },
+      providesTags: ['enrichedReceivedPackageRequests'],
+    }),
     createResourceRequest: builder.mutation<
       RequestDto,
       { party: string; to: string; resource: string }
@@ -104,28 +135,44 @@ export const requestApi = createApi({
         url: `resource?party=${party}&to=${to}&resource=${encodeURIComponent(resource)}`,
         method: 'POST',
       }),
-      invalidatesTags: ['sentRequests', 'enrichedSentResourceRequests'],
+      invalidatesTags: [
+        'sentRequests',
+        'enrichedSentResourceRequests',
+        'enrichedSentPackageRequests',
+      ],
     }),
     withdrawRequest: builder.mutation<RequestDto, { party: string; id: string }>({
       query: ({ party, id }) => ({
         url: `sent/withdraw?party=${party}&id=${id}`,
         method: 'DELETE',
       }),
-      invalidatesTags: ['sentRequests', 'enrichedSentResourceRequests'],
+      invalidatesTags: [
+        'sentRequests',
+        'enrichedSentResourceRequests',
+        'enrichedSentPackageRequests',
+      ],
     }),
     rejectRequest: builder.mutation<RequestDto, { party: string; id: string }>({
       query: ({ party, id }) => ({
         url: `received/reject?party=${party}&id=${id}`,
         method: 'PUT',
       }),
-      invalidatesTags: ['receivedRequests', 'enrichedReceivedResourceRequests'],
+      invalidatesTags: [
+        'receivedRequests',
+        'enrichedReceivedResourceRequests',
+        'enrichedReceivedPackageRequests',
+      ],
     }),
     approveRequest: builder.mutation<RequestDto, { party: string; id: string }>({
       query: ({ party, id }) => ({
         url: `received/approve?party=${party}&id=${id}`,
         method: 'PUT',
       }),
-      invalidatesTags: ['receivedRequests', 'enrichedReceivedResourceRequests'],
+      invalidatesTags: [
+        'receivedRequests',
+        'enrichedReceivedResourceRequests',
+        'enrichedReceivedPackageRequests',
+      ],
     }),
 
     // count queries
@@ -158,7 +205,11 @@ export const requestApi = createApi({
         url: `draft/confirm?party=${party}&id=${id}`,
         method: 'PUT',
       }),
-      invalidatesTags: ['sentRequests', 'enrichedSentResourceRequests'],
+      invalidatesTags: [
+        'sentRequests',
+        'enrichedSentResourceRequests',
+        'enrichedSentPackageRequests',
+      ],
     }),
   }),
 });
@@ -174,6 +225,8 @@ export const {
   useApproveRequestMutation,
   useGetEnrichedSentResourceRequestsQuery,
   useGetEnrichedReceivedResourceRequestsQuery,
+  useGetEnrichedSentPackageRequestsQuery,
+  useGetEnrichedReceivedPackageRequestsQuery,
   useGetEnrichedDraftRequestQuery,
   useGetSentRequestsCountQuery,
   useGetReceivedRequestsCountQuery,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR creates the BFF endpoints for fetching packageRequests with package data. For use both on the users page and on the request page. This PR is only the BFF code, made in preparation for the UI.

Note that this also changes the basic return model of requests to include packages.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API endpoints for retrieving enriched sent and received package requests with complete package metadata
  * Backend service now fetches and enriches package request data with full access package information
  * Implemented frontend RTK Query hooks for seamless integration with new package request endpoints
  * Added comprehensive test coverage and error handling for package request functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->