### PR TITLE
Unique key for consent TimelineSegment component

### DIFF
--- a/src/features/amUI/consent/ConsentHistoryPage/ConsentTimeline.tsx
+++ b/src/features/amUI/consent/ConsentHistoryPage/ConsentTimeline.tsx
@@ -64,7 +64,7 @@ export const ConsentTimeline = ({ consentLog, showConsentDetails }: ConsentTimel
             <TimelineSegment
               data-color={reportee?.type === 'Person' ? 'person' : 'company'}
               borderColor={reportee?.type === 'Person' ? 'person' : 'company'}
-              key={item.consentEventId}
+              key={`${item.consentId}-${item.consentEventId}`}
             >
               <TimelineActivity byline={item.bylineText}>
                 <div className={classes.timelineContent}>


### PR DESCRIPTION
## Description
- Since Expired consent events all have empty guid as consentEventId, using consentEventId as key causes multiple items to have the same key. The key must be unique.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
