### PR TITLE
Small visual improvements for system user display on narrow screens

### DIFF
--- a/src/features/amUI/systemUser/SystemUserAgentDelegationPage/CustomerList.tsx
+++ b/src/features/amUI/systemUser/SystemUserAgentDelegationPage/CustomerList.tsx
@@ -19,6 +19,7 @@ import type { AgentDelegation, AgentDelegationCustomer } from '../types';
 import classes from './CustomerList.module.css';
 import { formatOrgNr } from '@/resources/utils/reporteeUtils';
 import { addAllSystemuserCustomers } from '@/resources/utils/featureFlagUtils';
+import { useIsMobileOrSmaller } from '@/resources/utils/screensizeUtils';
 
 const filterCustomerList = (
   list: AgentDelegationCustomer[],
@@ -180,6 +181,7 @@ const ListControls = ({
   selfButton,
 }: ListControlsProps): React.ReactNode => {
   const { t } = useTranslation();
+  const isSmall = useIsMobileOrSmaller();
 
   return (
     <div className={classes.listControls}>
@@ -211,7 +213,7 @@ const ListControls = ({
           })}
           onClick={() => onRemoveCustomer(delegation, customer.name)}
         >
-          <MinusCircleIcon /> {t('systemuser_agent_delegation.remove_from_system_user')}
+          <MinusCircleIcon /> {!isSmall && t('systemuser_agent_delegation.remove_from_system_user')}
         </DsButton>
       )}
       {!isLoading && !delegation && onAddCustomer && (
@@ -223,7 +225,7 @@ const ListControls = ({
           })}
           onClick={() => onAddCustomer(customer)}
         >
-          <PlusCircleIcon /> {t('systemuser_agent_delegation.add_to_system_user')}
+          <PlusCircleIcon /> {!isSmall && t('systemuser_agent_delegation.add_to_system_user')}
         </DsButton>
       )}
       {customer.isSelfOrg && (

--- a/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPageContent.tsx
+++ b/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPageContent.tsx
@@ -30,6 +30,7 @@ import { useGetIsAdminQuery, useGetIsClientAdminQuery } from '@/rtk/features/use
 import { AddAllCustomers } from './AddAllCustomers';
 import { DelegationCheckError } from '../components/DelegationCheckError/DelegationCheckError';
 import { enableAddSelfToSystemuser } from '@/resources/utils/featureFlagUtils';
+import { useIsMobileOrSmaller } from '@/resources/utils/screensizeUtils';
 
 const getAssignedCustomers = (
   customers: AgentDelegationCustomer[],
@@ -55,6 +56,7 @@ export const SystemUserAgentDelegationPageContent = ({
 
   const { id } = useParams();
   const modalRef = useRef<HTMLDialogElement>(null);
+  const isSmall = useIsMobileOrSmaller();
 
   const [delegations, setDelegations] = useState<AgentDelegation[]>(existingAgentDelegations);
   const [loadingIds, setLoadingIds] = useState<string[]>([]);
@@ -387,7 +389,8 @@ export const SystemUserAgentDelegationPageContent = ({
                     disabled={isLoadingSelf}
                     onClick={assignSelfToSystemUser}
                   >
-                    <PlusCircleIcon /> {t('systemuser_agent_delegation.add_own_organization_list')}
+                    <PlusCircleIcon />
+                    {!isSmall && t('systemuser_agent_delegation.add_own_organization_list')}
                   </DsButton>
                 )}
                 {hasAddSelfPermission && isSelfAdded && (
@@ -399,7 +402,8 @@ export const SystemUserAgentDelegationPageContent = ({
                     disabled={isLoadingSelf}
                     onClick={removeSelfFromSystemuser}
                   >
-                    <MinusCircleIcon /> {t('systemuser_agent_delegation.remove')}
+                    <MinusCircleIcon />
+                    {!isSmall && t('systemuser_agent_delegation.remove')}
                   </DsButton>
                 )}
               </>

--- a/src/features/amUI/systemUser/components/RightsList/AccessPackageInfo.tsx
+++ b/src/features/amUI/systemUser/components/RightsList/AccessPackageInfo.tsx
@@ -22,7 +22,7 @@ export const AccessPackageInfo = ({
   const { getProviderLogoUrl } = useProviderLogoUrl();
 
   return (
-    <div className={classes.accessPackages}>
+    <>
       <div className={classes.resourceInfoHeader}>
         <PackageIcon fontSize={28} />
         <DsHeading
@@ -32,36 +32,38 @@ export const AccessPackageInfo = ({
           {accessPackage.name}
         </DsHeading>
       </div>
-      <DsParagraph data-size='sm'>{accessPackage.description}</DsParagraph>
-      <DsHeading
-        data-size='2xs'
-        level={2}
-      >
-        {accessPackage.resources.length === 1
-          ? t('systemuser_detailpage.accesspackage_resources_singular')
-          : t('systemuser_detailpage.accesspackage_resources_plural', {
-              resourcesCount: accessPackage.resources.length,
-            })}
-      </DsHeading>
-      <List>
-        {accessPackage.resources.map((resource) => {
-          const emblem = getProviderLogoUrl(resource.resourceOwnerOrgcode ?? '');
-          return (
-            <ResourceListItem
-              key={resource.identifier}
-              id={resource.identifier}
-              as='button'
-              titleAs='h3'
-              size='xs'
-              ownerLogoUrl={emblem ?? resource.resourceOwnerLogoUrl}
-              ownerLogoUrlAlt={resource.resourceOwnerName ?? ''}
-              ownerName={resource.resourceOwnerName ?? ''}
-              resourceName={resource.title}
-              onClick={() => onSelectResource(resource)}
-            />
-          );
-        })}
-      </List>
-    </div>
+      <div className={classes.accessPackages}>
+        <DsParagraph data-size='sm'>{accessPackage.description}</DsParagraph>
+        <DsHeading
+          data-size='2xs'
+          level={2}
+        >
+          {accessPackage.resources.length === 1
+            ? t('systemuser_detailpage.accesspackage_resources_singular')
+            : t('systemuser_detailpage.accesspackage_resources_plural', {
+                resourcesCount: accessPackage.resources.length,
+              })}
+        </DsHeading>
+        <List>
+          {accessPackage.resources.map((resource) => {
+            const emblem = getProviderLogoUrl(resource.resourceOwnerOrgcode ?? '');
+            return (
+              <ResourceListItem
+                key={resource.identifier}
+                id={resource.identifier}
+                as='button'
+                titleAs='h3'
+                size='xs'
+                ownerLogoUrl={emblem ?? resource.resourceOwnerLogoUrl}
+                ownerLogoUrlAlt={resource.resourceOwnerName ?? ''}
+                ownerName={resource.resourceOwnerName ?? ''}
+                resourceName={resource.title}
+                onClick={() => onSelectResource(resource)}
+              />
+            );
+          })}
+        </List>
+      </div>
+    </>
   );
 };

--- a/src/features/amUI/systemUser/components/RightsList/ResourceDetails.tsx
+++ b/src/features/amUI/systemUser/components/RightsList/ResourceDetails.tsx
@@ -4,19 +4,22 @@ import { Avatar, DsHeading, DsParagraph } from '@altinn/altinn-components';
 import type { ServiceResource } from '@/rtk/features/singleRights/singleRightsApi';
 
 import classes from './RightsList.module.css';
+import { useProviderLogoUrl } from '@/resources/hooks/useProviderLogoUrl';
 
 interface ResourceDetailsProps {
   resource: ServiceResource;
 }
 
 export const ResourceDetails = ({ resource }: ResourceDetailsProps): React.ReactNode => {
+  const { getProviderLogoUrl } = useProviderLogoUrl();
+  const emblem = getProviderLogoUrl(resource.resourceOwnerOrgcode ?? '');
   return (
     <>
       <div className={classes.resourceInfoHeader}>
         <Avatar
           size='lg'
           type='company'
-          imageUrl={resource.resourceOwnerLogoUrl}
+          imageUrl={emblem || resource.resourceOwnerLogoUrl}
           imageUrlAlt={resource.resourceOwnerName}
           name={resource.resourceOwnerName ?? ''}
           className={classes.resourceInfoIcon}

--- a/src/features/amUI/systemUser/components/RightsList/ResourceDetails.tsx
+++ b/src/features/amUI/systemUser/components/RightsList/ResourceDetails.tsx
@@ -1,40 +1,23 @@
 import React from 'react';
-import { Avatar, DsHeading, DsParagraph } from '@altinn/altinn-components';
-
-import type { ServiceResource } from '@/rtk/features/singleRights/singleRightsApi';
-
+import { DsParagraph } from '@altinn/altinn-components';
 import classes from './RightsList.module.css';
-import { useProviderLogoUrl } from '@/resources/hooks/useProviderLogoUrl';
+import type { ServiceResource } from '@/rtk/features/singleRights/singleRightsApi';
+import { ResourceHeading } from '@/features/amUI/common/DelegationModal/SingleRights/ResourceHeading';
 
 interface ResourceDetailsProps {
   resource: ServiceResource;
 }
 
 export const ResourceDetails = ({ resource }: ResourceDetailsProps): React.ReactNode => {
-  const { getProviderLogoUrl } = useProviderLogoUrl();
-  const emblem = getProviderLogoUrl(resource.resourceOwnerOrgcode ?? '');
   return (
-    <>
-      <div className={classes.resourceInfoHeader}>
-        <Avatar
-          size='lg'
-          type='company'
-          imageUrl={emblem || resource.resourceOwnerLogoUrl}
-          imageUrlAlt={resource.resourceOwnerName}
-          name={resource.resourceOwnerName ?? ''}
-          className={classes.resourceInfoIcon}
-        />
-        <div className={classes.resourceInfoText}>
-          <DsHeading
-            level={1}
-            data-size='xs'
-          >
-            {resource.title}
-          </DsHeading>
-          <DsParagraph data-size='xs'>{resource.resourceOwnerName}</DsParagraph>
-        </div>
-      </div>
-      <DsParagraph data-size='sm'>{resource.description}</DsParagraph>
-    </>
+    <div>
+      <ResourceHeading resource={resource} />
+      <DsParagraph
+        data-size='sm'
+        className={classes.resourceInfoText}
+      >
+        {resource.description}
+      </DsParagraph>
+    </div>
   );
 };

--- a/src/features/amUI/systemUser/components/RightsList/RightsList.module.css
+++ b/src/features/amUI/systemUser/components/RightsList/RightsList.module.css
@@ -11,15 +11,9 @@
   gap: var(--ds-size-4);
   margin-bottom: var(--ds-size-5);
 }
-.resourceInfoIcon {
-  font-size: var(--ds-font-size-8);
-}
-.resourceInfoText {
-  flex: 1;
-}
 
-.resourceInfoAvatar {
-  font-size: var(--ds-heading-lg-font-size);
+.resourceInfoText {
+  margin-top: var(--ds-size-4);
 }
 
 .accessPackages {

--- a/src/features/amUI/systemUser/components/RightsList/RightsList.module.css
+++ b/src/features/amUI/systemUser/components/RightsList/RightsList.module.css
@@ -9,7 +9,7 @@
   flex-direction: row;
   align-items: center;
   gap: var(--ds-size-4);
-  margin-bottom: var(--ds-size-4);
+  margin-bottom: var(--ds-size-5);
 }
 .resourceInfoIcon {
   font-size: var(--ds-font-size-8);


### PR DESCRIPTION
## Description
- Listitem-related fixes for systemuser on narrow screens
- Use full width of modal for access package info view

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Enhanced button layouts on mobile and smaller devices by displaying icons only while preserving full labels on larger screens for improved space efficiency
  * Refined spacing in resource information sections for better visual hierarchy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->