### PR TITLE
Delete sent package requests from request page

### DIFF
--- a/src/features/amUI/common/PartyRepresentationContext/PartyRepresentationContext.tsx
+++ b/src/features/amUI/common/PartyRepresentationContext/PartyRepresentationContext.tsx
@@ -98,11 +98,14 @@ export const PartyRepresentationProvider = ({
   const { party: reportee, isLoading: reporteeIsLoading } = useReporteeParty();
   const { data: authorizedPartyReportee } = useGetReporteeQuery();
 
+  const isLoadingInitialState = externalIsLoading || currentUserIsLoading || reporteeIsLoading;
+
   const { party: fromConnectedParty, isLoading: fromPartyIsLoading } = useConnectedParty({
     fromPartyUuid,
     skip:
       !fromPartyUuid ||
       fromPartyUuid === actingPartyUuid ||
+      isLoadingInitialState ||
       fromPartyUuid === currentUser?.partyUuid ||
       fromPartyUuid === reportee?.partyUuid ||
       !!fromPartyOverride, // Skip if fromPartyOverride is provided, since that means the consumer is providing the fromParty data themselves
@@ -113,6 +116,7 @@ export const PartyRepresentationProvider = ({
     skip:
       !toPartyUuid ||
       toPartyUuid === actingPartyUuid ||
+      isLoadingInitialState ||
       toPartyUuid === currentUser?.partyUuid ||
       toPartyUuid === reportee?.partyUuid ||
       !!toPartyOverride, // Skip if toPartyOverride is provided, since that means the consumer is providing the toParty data themselves

--- a/src/features/amUI/requestPage/SentRequestsCombinedModal.module.css
+++ b/src/features/amUI/requestPage/SentRequestsCombinedModal.module.css
@@ -1,0 +1,26 @@
+.dialog {
+  max-width: 992px;
+  max-height: calc(100vh - var(--ds-spacing-8));
+  overflow-y: auto;
+}
+
+.heading {
+  padding-bottom: var(--ds-spacing-2);
+}
+
+.requestList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-spacing-2);
+  margin-bottom: var(--ds-spacing-2);
+}
+
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-spacing-2);
+}
+
+.closeButton {
+  margin-top: var(--ds-spacing-4);
+}

--- a/src/features/amUI/requestPage/SentRequestsCombinedModal.tsx
+++ b/src/features/amUI/requestPage/SentRequestsCombinedModal.tsx
@@ -1,0 +1,127 @@
+import React, { useState } from 'react';
+import {
+  DsButton,
+  DsDialog,
+  DsHeading,
+  Snackbar,
+  SnackbarProvider,
+} from '@altinn/altinn-components';
+import { useTranslation } from 'react-i18next';
+import { ServiceResource } from '@/rtk/features/singleRights/singleRightsApi';
+import { useGetSentRequestsQuery, type EnrichedPackageRequest } from '@/rtk/features/requestApi';
+import { PendingRequestsList } from '../userRightsPage/SingleRightsSection/PendingRequests';
+import { PendingPackageRequestsList } from '../userRightsPage/AccessPackageSection/PendingPackageRequests/RequestsList';
+import { DelegationModalProvider } from '../common/DelegationModal/DelegationModalContext';
+import classes from './SentRequestsCombinedModal.module.css';
+import { usePartyRepresentation } from '../common/PartyRepresentationContext/PartyRepresentationContext';
+
+interface SentRequestsCombinedModalProps {
+  modalRef: React.RefObject<HTMLDialogElement | null>;
+  isModalOpen: boolean;
+  heading: string;
+  onClose: () => void;
+}
+
+export const SentRequestsCombinedModal = ({
+  modalRef,
+  isModalOpen,
+  heading,
+  onClose,
+}: SentRequestsCombinedModalProps) => {
+  const { t } = useTranslation();
+  const [selectedResource, setSelectedResource] = useState<ServiceResource | null>(null);
+  const [selectedPackageRequest, setSelectedPackageRequest] =
+    useState<EnrichedPackageRequest | null>(null);
+
+  const hasDetailView = !!selectedResource || !!selectedPackageRequest;
+
+  const { actingParty, fromParty } = usePartyRepresentation();
+  const { data: pendingSentAccessRequests } = useGetSentRequestsQuery(
+    { party: actingParty?.partyUuid || '', status: ['Pending'], to: fromParty?.partyUuid || '' },
+    { skip: !actingParty?.partyUuid },
+  );
+
+  const hasPendingSentResourceRequests = pendingSentAccessRequests
+    ? pendingSentAccessRequests.some((request) => request.resourceId)
+    : false;
+  const hasPendingSentPackageRequests = pendingSentAccessRequests
+    ? pendingSentAccessRequests.some((request) => request.packageId)
+    : false;
+
+  return (
+    <DsDialog
+      ref={modalRef}
+      closedby='any'
+      onClose={() => {
+        setSelectedResource(null);
+        setSelectedPackageRequest(null);
+        onClose();
+      }}
+      className={classes.dialog}
+    >
+      <SnackbarProvider>
+        {isModalOpen && (
+          <div className={classes.container}>
+            {!hasDetailView && (
+              <DsHeading
+                data-size='xs'
+                level={1}
+                className={classes.heading}
+              >
+                {heading}
+              </DsHeading>
+            )}
+            {hasPendingSentPackageRequests && (
+              <div className={classes.requestList}>
+                {!hasDetailView && (
+                  <DsHeading
+                    data-size='2xs'
+                    level={2}
+                  >
+                    {t('request_page.package_list_title')}
+                  </DsHeading>
+                )}
+                {!selectedResource && hasPendingSentPackageRequests && (
+                  <DelegationModalProvider>
+                    <PendingPackageRequestsList
+                      selectedRequest={selectedPackageRequest}
+                      setSelectedRequest={setSelectedPackageRequest}
+                    />
+                  </DelegationModalProvider>
+                )}
+              </div>
+            )}
+            {hasPendingSentResourceRequests && (
+              <div className={classes.requestList}>
+                {!hasDetailView && (
+                  <DsHeading
+                    data-size='2xs'
+                    level={2}
+                  >
+                    {t('request_page.resource_list_title')}
+                  </DsHeading>
+                )}
+                {!selectedPackageRequest && hasPendingSentResourceRequests && (
+                  <PendingRequestsList
+                    selectedResource={selectedResource}
+                    setSelectedResource={setSelectedResource}
+                  />
+                )}
+              </div>
+            )}
+          </div>
+        )}
+        <Snackbar />
+      </SnackbarProvider>
+      {!hasDetailView && (
+        <DsButton
+          variant='primary'
+          className={classes.closeButton}
+          onClick={() => modalRef.current?.close()}
+        >
+          {t('common.close')}
+        </DsButton>
+      )}
+    </DsDialog>
+  );
+};

--- a/src/features/amUI/requestPage/SentRequestsCombinedModal.tsx
+++ b/src/features/amUI/requestPage/SentRequestsCombinedModal.tsx
@@ -37,8 +37,8 @@ export const SentRequestsCombinedModal = ({
 
   const { actingParty, fromParty } = usePartyRepresentation();
   const { data: pendingSentAccessRequests } = useGetSentRequestsQuery(
-    { party: actingParty?.partyUuid || '', status: ['Pending'], to: fromParty?.partyUuid || '' },
-    { skip: !actingParty?.partyUuid },
+    { party: actingParty?.partyUuid || '', status: ['Pending'], to: fromParty?.partyUuid },
+    { skip: !isModalOpen || !actingParty?.partyUuid || !fromParty?.partyUuid },
   );
 
   const hasPendingSentResourceRequests = pendingSentAccessRequests

--- a/src/features/amUI/requestPage/SentRequestsTabPanel.tsx
+++ b/src/features/amUI/requestPage/SentRequestsTabPanel.tsx
@@ -5,7 +5,7 @@ import { Request } from './types';
 
 import classes from './RequestPage.module.css';
 import { useRef, useState } from 'react';
-import { SentRequestsModal } from '../userRightsPage/SingleRightsSection/PendingRequests';
+import { SentRequestsCombinedModal } from './SentRequestsCombinedModal';
 import { PartyRepresentationProvider } from '../common/PartyRepresentationContext/PartyRepresentationContext';
 import { getCookie } from '@/resources/Cookie/CookieMethods';
 import { PartyType } from '@/rtk/features/userInfoApi';
@@ -64,7 +64,7 @@ export const SentRequestsTabPanel = ({ pendingRequests }: SentRequestsTabPanelPr
         toPartyUuid={getCookie('AltinnPartyUuid')}
         actingPartyUuid={getCookie('AltinnPartyUuid')}
       >
-        <SentRequestsModal
+        <SentRequestsCombinedModal
           modalRef={modalRef}
           heading={t('delegation_modal.request.sent_requests_modal_header', {
             partyName: formatDisplayName({

--- a/src/features/amUI/userRightsPage/AccessPackageSection/PendingPackageRequests/RequestsList.tsx
+++ b/src/features/amUI/userRightsPage/AccessPackageSection/PendingPackageRequests/RequestsList.tsx
@@ -26,7 +26,7 @@ import { DelegationAction } from '../../../common/DelegationModal/EditModal';
 import classes from './Requests.module.css';
 
 interface PendingPackageRequestsListProps {
-  heading: string;
+  heading?: string;
   selectedRequest: EnrichedPackageRequest | null;
   setSelectedRequest: (request: EnrichedPackageRequest | null) => void;
 }
@@ -91,7 +91,7 @@ export const PendingPackageRequestsList = ({
   };
 
   return (
-    <>
+    <div>
       {selectedRequest ? (
         <>
           <DsButton
@@ -110,15 +110,17 @@ export const PendingPackageRequestsList = ({
         </>
       ) : (
         <>
-          <DsHeading
-            ref={headingRef}
-            tabIndex={-1}
-            data-size='xs'
-            level={1}
-            className={classes.heading}
-          >
-            {heading}
-          </DsHeading>
+          {heading && (
+            <DsHeading
+              ref={headingRef}
+              tabIndex={-1}
+              data-size='xs'
+              level={1}
+              className={classes.heading}
+            >
+              {heading}
+            </DsHeading>
+          )}
           {isLoading ? (
             <SkeletonAccessPackageList />
           ) : (
@@ -154,6 +156,6 @@ export const PendingPackageRequestsList = ({
           )}
         </>
       )}
-    </>
+    </div>
   );
 };

--- a/src/features/amUI/userRightsPage/SingleRightsSection/PendingRequests.tsx
+++ b/src/features/amUI/userRightsPage/SingleRightsSection/PendingRequests.tsx
@@ -126,11 +126,11 @@ export const SentRequestsModal = ({
 
 interface PendingRequestsListProps {
   selectedResource: ServiceResource | null;
-  heading: string;
+  heading?: string;
   setSelectedResource: (resource: ServiceResource | null) => void;
 }
 
-const PendingRequestsList = ({
+export const PendingRequestsList = ({
   selectedResource,
   heading,
   setSelectedResource,
@@ -157,7 +157,7 @@ const PendingRequestsList = ({
   });
 
   return (
-    <>
+    <div>
       {selectedResource ? (
         <>
           <DsButton
@@ -175,13 +175,15 @@ const PendingRequestsList = ({
         </>
       ) : (
         <>
-          <DsHeading
-            data-size='xs'
-            level={1}
-            className={classes.pendingRequestsHeading}
-          >
-            {heading}
-          </DsHeading>
+          {heading && (
+            <DsHeading
+              data-size='xs'
+              level={1}
+              className={classes.pendingRequestsHeading}
+            >
+              {heading}
+            </DsHeading>
+          )}
           <ResourceList
             isLoading={isLoadingRequests}
             size={isSmallScreen ? 'sm' : 'md'}
@@ -208,6 +210,6 @@ const PendingRequestsList = ({
           />
         </>
       )}
-    </>
+    </div>
   );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<img width="1289" height="534" alt="image" src="https://github.com/user-attachments/assets/ddbf76ba-6ffd-40b6-8238-e4e1660a5264" />

## Description
<!--- Describe your changes in detail -->
Combined deletion modal content for both resources and packages into one for display on the requests page.

Note that this PR also makes a small change to the PartyRepresentationProvider to stop unnecessary calls that were firing during setup of the init state.

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/2860

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned sent requests modal interface with combined view for unified access request management, enabling streamlined browsing of both package and resource requests.

* **Performance Improvements**
  * Optimized loading behavior to prevent unnecessary query execution during initial setup, deferring data fetches until prerequisite states are fully resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->