### PR TITLE
Avoid modal content disappearing when deleting last resource/package in detailView

### DIFF
--- a/src/features/amUI/requestPage/SentRequestsCombinedModal.tsx
+++ b/src/features/amUI/requestPage/SentRequestsCombinedModal.tsx
@@ -71,7 +71,7 @@ export const SentRequestsCombinedModal = ({
                 {heading}
               </DsHeading>
             )}
-            {hasPendingSentPackageRequests && (
+            {(hasPendingSentPackageRequests || selectedPackageRequest) && (
               <div className={classes.requestList}>
                 {!hasDetailView && (
                   <DsHeading
@@ -81,7 +81,7 @@ export const SentRequestsCombinedModal = ({
                     {t('request_page.package_list_title')}
                   </DsHeading>
                 )}
-                {!selectedResource && hasPendingSentPackageRequests && (
+                {!selectedResource && (
                   <DelegationModalProvider>
                     <PendingPackageRequestsList
                       selectedRequest={selectedPackageRequest}
@@ -91,7 +91,7 @@ export const SentRequestsCombinedModal = ({
                 )}
               </div>
             )}
-            {hasPendingSentResourceRequests && (
+            {(hasPendingSentResourceRequests || selectedResource) && (
               <div className={classes.requestList}>
                 {!hasDetailView && (
                   <DsHeading
@@ -101,7 +101,7 @@ export const SentRequestsCombinedModal = ({
                     {t('request_page.resource_list_title')}
                   </DsHeading>
                 )}
-                {!selectedPackageRequest && hasPendingSentResourceRequests && (
+                {!selectedPackageRequest && (
                   <PendingRequestsList
                     selectedResource={selectedResource}
                     setSelectedResource={setSelectedResource}

--- a/src/features/amUI/requestPage/SentRequestsCombinedModal.tsx
+++ b/src/features/amUI/requestPage/SentRequestsCombinedModal.tsx
@@ -71,7 +71,7 @@ export const SentRequestsCombinedModal = ({
                 {heading}
               </DsHeading>
             )}
-            {(hasPendingSentPackageRequests || selectedPackageRequest) && (
+            {(hasPendingSentPackageRequests || selectedPackageRequest) && !selectedResource && (
               <div className={classes.requestList}>
                 {!hasDetailView && (
                   <DsHeading
@@ -81,17 +81,16 @@ export const SentRequestsCombinedModal = ({
                     {t('request_page.package_list_title')}
                   </DsHeading>
                 )}
-                {!selectedResource && (
-                  <DelegationModalProvider>
-                    <PendingPackageRequestsList
-                      selectedRequest={selectedPackageRequest}
-                      setSelectedRequest={setSelectedPackageRequest}
-                    />
-                  </DelegationModalProvider>
-                )}
+
+                <DelegationModalProvider>
+                  <PendingPackageRequestsList
+                    selectedRequest={selectedPackageRequest}
+                    setSelectedRequest={setSelectedPackageRequest}
+                  />
+                </DelegationModalProvider>
               </div>
             )}
-            {(hasPendingSentResourceRequests || selectedResource) && (
+            {(hasPendingSentResourceRequests || selectedResource) && !selectedPackageRequest && (
               <div className={classes.requestList}>
                 {!hasDetailView && (
                   <DsHeading
@@ -101,12 +100,10 @@ export const SentRequestsCombinedModal = ({
                     {t('request_page.resource_list_title')}
                   </DsHeading>
                 )}
-                {!selectedPackageRequest && (
-                  <PendingRequestsList
-                    selectedResource={selectedResource}
-                    setSelectedResource={setSelectedResource}
-                  />
-                )}
+                <PendingRequestsList
+                  selectedResource={selectedResource}
+                  setSelectedResource={setSelectedResource}
+                />
               </div>
             )}
           </div>


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<img width="1307" height="632" alt="image" src="https://github.com/user-attachments/assets/a66b6493-bfbf-4736-b13e-36ff5ecc4c4b" />

## Description
<!--- Describe your changes in detail -->

Discovered a bug where, if you delete the last package or resource, the content of the modal disappeared.
This was due to a logical error, where the detailView was displayed only when there were some active requests of its type.
This has now been corrected.

Before fix, after deleting the last package or resource:
<img width="1353" height="758" alt="image" src="https://github.com/user-attachments/assets/a5da077d-c431-4bd4-89ae-4a1dbb32f230" />



## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed request lists in the modal to remain visible when viewing request details, ensuring consistent display regardless of pending request status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->