### PR TITLE
Persist user language preference

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Helpers/LanguageHelper.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Helpers/LanguageHelper.cs
@@ -42,7 +42,7 @@ namespace Altinn.AccessManagement.UI.Core.Helpers
         /// <returns>The backend standard language code.</returns>
         public static string GetBackendStandardLanguage(string languageCode)
         {
-            return LanguageMappings.Find(m => languageCode.Contains(m.Altinn2Standard) || m.FrontendStandard == languageCode).BackendStandard;
+            return LanguageMappings.Find(m => languageCode.Contains(m.Altinn2Standard) || m.FrontendStandard == languageCode || m.BackendStandard == languageCode).BackendStandard;
         }
 
         /// <summary>

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Helpers/LanguageHelper.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Helpers/LanguageHelper.cs
@@ -42,6 +42,11 @@ namespace Altinn.AccessManagement.UI.Core.Helpers
         /// <returns>The backend standard language code.</returns>
         public static string GetBackendStandardLanguage(string languageCode)
         {
+            if (string.IsNullOrEmpty(languageCode))
+            {
+                return string.Empty;
+            }
+
             return LanguageMappings.Find(m => languageCode.Contains(m.Altinn2Standard) || m.FrontendStandard == languageCode || m.BackendStandard == languageCode).BackendStandard;
         }
 

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/Interfaces/IUserService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/Interfaces/IUserService.cs
@@ -25,6 +25,12 @@ namespace Altinn.AccessManagement.UI.Core.Services.Interfaces
         Task<ProfileSettingPreference> SetShowDeletedProfileSetting(bool shouldShowDeletedEntities);
 
         /// <summary>
+        /// Updates the current user's language preference in altinn profile
+        /// </summary>
+        /// <param name="languageCode">Frontend standard language code (e.g. "no_nb", "no_nn", "en")</param>
+        Task SetLanguageProfileSetting(string languageCode);
+
+        /// <summary>
         /// Get the reportees for the user 
         /// </summary>
         /// <param name="userId">The user id</param>

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/UserService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/UserService.cs
@@ -1,4 +1,5 @@
 ﻿using Altinn.AccessManagement.UI.Core.ClientInterfaces;
+using Altinn.AccessManagement.UI.Core.Helpers;
 using Altinn.AccessManagement.UI.Core.Models;
 using Altinn.AccessManagement.UI.Core.Models.AccessManagement;
 using Altinn.AccessManagement.UI.Core.Models.Profile;
@@ -55,7 +56,15 @@ namespace Altinn.AccessManagement.UI.Core.Services
             {
                 ShouldShowDeletedEntities = shouldShowDeletedEntities
             };
-            return await _profileClient.PatchCurrentUserProfileSetting(change); 
+            return await _profileClient.PatchCurrentUserProfileSetting(change);
+        }
+
+        /// <inheritdoc/>
+        public async Task SetLanguageProfileSetting(string languageCode)
+        {
+            string backendLanguage = LanguageHelper.GetBackendStandardLanguage(languageCode);
+            ProfileSettingPreference change = new ProfileSettingPreference { Language = backendLanguage };
+            await _profileClient.PatchCurrentUserProfileSetting(change);
         }
 
         /// <inheritdoc/>        

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/UserService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/UserService.cs
@@ -63,6 +63,11 @@ namespace Altinn.AccessManagement.UI.Core.Services
         public async Task SetLanguageProfileSetting(string languageCode)
         {
             string backendLanguage = LanguageHelper.GetBackendStandardLanguage(languageCode);
+            if (string.IsNullOrEmpty(backendLanguage))
+            {
+                throw new ArgumentException($"Unsupported language code: {languageCode}", nameof(languageCode));
+            }
+
             ProfileSettingPreference change = new ProfileSettingPreference { Language = backendLanguage };
             await _profileClient.PatchCurrentUserProfileSetting(change);
         }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/Profile/userprofiles.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/Profile/userprofiles.json
@@ -149,6 +149,32 @@
     }
   },
   {
+    "UserId": 20099001,
+    "UserUuid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "UserName": "EnglishUser",
+    "PhoneNumber": "90001234",
+    "Email": "english@altinnstudiotestusers.com",
+    "PartyId": 51000001,
+    "Party": {
+      "PartyId": 51000001,
+      "PartyUuid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "PartyTypeName": 1,
+      "OrgNumber": null,
+      "Ssn": "01010112345",
+      "UnitType": null,
+      "Name": "ENGLISH TEST USER",
+      "IsDeleted": false,
+      "OnlyHierarchyElementWithNoAccess": false,
+      "Person": null,
+      "Organisation": null,
+      "ChildParties": null
+    },
+    "UserType": 1,
+    "ProfileSettingPreference": {
+      "Language": "en"
+    }
+  },
+  {
     "UserId": 20012465,
     "UserUuid": "eb0e874b-5f37-44cc-b648-f9a902a82c89",
     "UserName": "FilmLover42",

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/ProfileClientMock.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/ProfileClientMock.cs
@@ -35,6 +35,11 @@ namespace Altinn.AccessManagement.UI.Mocks.Mocks
         /// <inheritdoc />
         public async Task<UserProfile> GetUserProfile(int userId)
         {
+            if (userId == 500)
+            {
+                throw new HttpRequestException("Internal server error");
+            }
+
             UserProfile profile = null;
             string path = GetDataPathForProfiles();
             if (File.Exists(path))

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/HomeControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/HomeControllerTest.cs
@@ -276,5 +276,80 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             Assert.Single(cookieHeaders, c => c.StartsWith("AltinnPartyId"));
             Assert.Single(cookieHeaders, c => c.StartsWith("AltinnPartyUuid"));
         }
+
+        /// <summary>
+        /// Test case: Profile has Language "nb" → selectedLanguage cookie must be "no_nb"
+        /// Expected: selectedLanguage=no_nb is set from profile, ignoring any legacy cookie
+        /// </summary>
+        [Fact]
+        public async Task Index_ProfileHasNbLanguage_SetsSelectedLanguageCookieToNoNb()
+        {
+            // Arrange — userId 20004938 has Language "nb" in profile fixture
+            string token = PrincipalUtil.GetToken(20004938, 50019992);
+            HttpClient client = SetupUtils.GetTestClient(_factory, false);
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "accessmanagement/");
+            SetupUtils.AddAuthCookie(request, token, "AltinnStudioRuntime");
+            request.Headers.Add("Cookie", "AltinnPartyId=50019992");
+            request.Headers.Add("Cookie", "AltinnPartyUuid=cd772c20-f780-43f6-819f-2d9f23fc0a1a");
+
+            // Act
+            HttpResponseMessage response = await client.SendAsync(request);
+            IEnumerable<string> cookieHeaders = response.Headers.GetValues("Set-Cookie");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Contains(cookieHeaders, c => c.StartsWith("selectedLanguage=no_nb"));
+        }
+
+        /// <summary>
+        /// Test case: Profile has Language "en" → selectedLanguage cookie must be "en"
+        /// Expected: selectedLanguage=en is set from profile
+        /// </summary>
+        [Fact]
+        public async Task Index_ProfileHasEnLanguage_SetsSelectedLanguageCookieToEn()
+        {
+            // Arrange — userId 20099001 has Language "en" in profile fixture
+            string token = PrincipalUtil.GetToken(20099001, 51000001);
+            HttpClient client = SetupUtils.GetTestClient(_factory, false);
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "accessmanagement/");
+            SetupUtils.AddAuthCookie(request, token, "AltinnStudioRuntime");
+            request.Headers.Add("Cookie", "AltinnPartyId=51000001");
+            request.Headers.Add("Cookie", "AltinnPartyUuid=a1b2c3d4-e5f6-7890-abcd-ef1234567890");
+
+            // Act
+            HttpResponseMessage response = await client.SendAsync(request);
+            IEnumerable<string> cookieHeaders = response.Headers.GetValues("Set-Cookie");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Contains(cookieHeaders, c => c.StartsWith("selectedLanguage=en"));
+        }
+
+        /// <summary>
+        /// Test case: Profile API returns an error → selectedLanguage cookie defaults to "no_nb"
+        /// Expected: Page still loads with selectedLanguage=no_nb, error does not propagate
+        /// </summary>
+        [Fact]
+        public async Task Index_ProfileApiError_SetsSelectedLanguageCookieToDefaultNoNb()
+        {
+            // Arrange — userId 500 triggers HttpRequestException in ProfileClientMock
+            string token = PrincipalUtil.GetToken(500, 50000500);
+            HttpClient client = SetupUtils.GetTestClient(_factory, false);
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "accessmanagement/");
+            SetupUtils.AddAuthCookie(request, token, "AltinnStudioRuntime");
+            request.Headers.Add("Cookie", "AltinnPartyId=50000500");
+            request.Headers.Add("Cookie", "AltinnPartyUuid=00000000-0000-0000-0000-000000000500");
+
+            // Act
+            HttpResponseMessage response = await client.SendAsync(request);
+            IEnumerable<string> cookieHeaders = response.Headers.GetValues("Set-Cookie");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Contains(cookieHeaders, c => c.StartsWith("selectedLanguage=no_nb"));
+        }
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/SettingsControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/SettingsControllerTest.cs
@@ -10,6 +10,8 @@ using Microsoft.Net.Http.Headers;
 using Altinn.AccessManagement.UI.Controllers;
 using Altinn.AccessManagement.UI.Core.ClientInterfaces;
 using Altinn.AccessManagement.UI.Core.Models.Profile;
+using Altinn.AccessManagement.UI.Core.Services;
+using Altinn.AccessManagement.UI.Core.Services.Interfaces;
 using Altinn.AccessManagement.UI.Mocks.Mocks;
 using Altinn.AccessManagement.UI.Mocks.Utils;
 using Altinn.AccessManagement.UI.Tests.Utils;
@@ -537,6 +539,26 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         }
 
         /// <summary>
+        ///     Test case: Valid language code updates both cookie and profile setting
+        ///     Expected: Returns OK — profile patch did not fail
+        /// </summary>
+        [Theory]
+        [InlineData("no_nb")]
+        [InlineData("no_nn")]
+        [InlineData("en")]
+        public async Task UpdateSelectedLanguage_ValidLanguageCode_AlsoPatchesProfileSetting(string languageCode)
+        {
+            // Arrange
+            var request = new { LanguageCode = languageCode };
+
+            // Act
+            HttpResponseMessage response = await _client.PostAsJsonAsync("accessmanagement/api/v1/settings/language/selectedLanguage", request);
+
+            // Assert — profile patch is called (via ProfileClientMock) and does not throw, so OK is returned
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        /// <summary>
         ///     Test case: POST with auth cookie present but X-XSRF-TOKEN header missing
         ///     Expected: Antiforgery filter rejects the request with 400 Bad Request
         /// </summary>
@@ -606,10 +628,14 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
                 builder.ConfigureTestServices(services =>
                 {
                     services.AddTransient<IProfileClient, ProfileClientMock>();
+                    services.AddTransient<IAccessManagementClient, AccessManagementClientMock>();
+                    services.AddTransient<IAccessManagementClientV0, AccessManagementClientV0Mock>();
+                    services.AddTransient<IConnectionClient, ConnectionClientMock>();
+                    services.AddTransient<IUserService, UserService>();
                     services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
                     services.AddSingleton<IPostConfigureOptions<JwtCookieOptions>, JwtCookiePostConfigureOptionsStub>();
                 });
-            }).CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+            }).CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false, HandleCookies = true });
         }
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/UserControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/UserControllerTest.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Altinn.AccessManagement.UI.Core.Services;
 using Altinn.AccessManagement.UI.Core.Services.Interfaces;
 using Moq;
 using User = Altinn.AccessManagement.UI.Core.Models.User.User;
@@ -1072,6 +1073,31 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
 
             // Assert
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+
+        [Theory]
+        [InlineData("no_nb", "nb")]
+        [InlineData("no_nn", "nn")]
+        [InlineData("en", "en")]
+        public async Task SetLanguageProfileSetting_ConvertsToBackendStandard_CallsProfileClient(string frontendCode, string expectedBackendCode)
+        {
+            var profileClientMock = new Mock<IProfileClient>();
+            profileClientMock
+                .Setup(c => c.PatchCurrentUserProfileSetting(It.IsAny<ProfileSettingPreference>()))
+                .ReturnsAsync(new ProfileSettingPreference());
+
+            var service = new UserService(
+                Mock.Of<ILogger<IAPIDelegationService>>(),
+                profileClientMock.Object,
+                Mock.Of<IAccessManagementClient>(),
+                Mock.Of<IAccessManagementClientV0>(),
+                Mock.Of<IConnectionClient>());
+
+            await service.SetLanguageProfileSetting(frontendCode);
+
+            profileClientMock.Verify(
+                c => c.PatchCurrentUserProfileSetting(It.Is<ProfileSettingPreference>(p => p.Language == expectedBackendCode)),
+                Times.Once);
         }
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/UserControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/UserControllerTest.cs
@@ -1074,30 +1074,5 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             // Assert
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
         }
-
-        [Theory]
-        [InlineData("no_nb", "nb")]
-        [InlineData("no_nn", "nn")]
-        [InlineData("en", "en")]
-        public async Task SetLanguageProfileSetting_ConvertsToBackendStandard_CallsProfileClient(string frontendCode, string expectedBackendCode)
-        {
-            var profileClientMock = new Mock<IProfileClient>();
-            profileClientMock
-                .Setup(c => c.PatchCurrentUserProfileSetting(It.IsAny<ProfileSettingPreference>()))
-                .ReturnsAsync(new ProfileSettingPreference());
-
-            var service = new UserService(
-                Mock.Of<ILogger<IAPIDelegationService>>(),
-                profileClientMock.Object,
-                Mock.Of<IAccessManagementClient>(),
-                Mock.Of<IAccessManagementClientV0>(),
-                Mock.Of<IConnectionClient>());
-
-            await service.SetLanguageProfileSetting(frontendCode);
-
-            profileClientMock.Verify(
-                c => c.PatchCurrentUserProfileSetting(It.Is<ProfileSettingPreference>(p => p.Language == expectedBackendCode)),
-                Times.Once);
-        }
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Utils/SetupUtils.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Utils/SetupUtils.cs
@@ -233,6 +233,10 @@ namespace Altinn.AccessManagement.UI.Tests.Utils
                 builder.ConfigureTestServices(services =>
                 {
                     services.AddTransient<IProfileClient, ProfileClientMock>();
+                    services.AddTransient<IAccessManagementClient, AccessManagementClientMock>();
+                    services.AddTransient<IAccessManagementClientV0, AccessManagementClientV0Mock>();
+                    services.AddTransient<IConnectionClient, ConnectionClientMock>();
+                    services.AddTransient<IUserService, UserService>();
                     services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
                     services.AddSingleton<IPostConfigureOptions<JwtCookieOptions>, JwtCookiePostConfigureOptionsStub>();
                 });

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/HomeController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/HomeController.cs
@@ -6,6 +6,7 @@ using Altinn.AccessManagement.UI.Core.Services.Interfaces;
 using Altinn.AccessManagement.UI.Integration.Configuration;
 using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Altinn.AccessManagement.UI.Controllers
@@ -25,6 +26,7 @@ namespace Altinn.AccessManagement.UI.Controllers
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly PlatformSettings _platformSettings;
         private readonly IUserService _userService;
+        private readonly ILogger<HomeController> _logger;
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="HomeController" /> class.
@@ -45,7 +47,8 @@ namespace Altinn.AccessManagement.UI.Controllers
             IHttpContextAccessor httpContextAccessor,
             IOptions<GeneralSettings> generalSettings,
             IOptions<FeatureFlags> featureFlags,
-            IUserService userService)
+            IUserService userService,
+            ILogger<HomeController> logger)
         {
             _antiforgery = antiforgery;
             _platformSettings = platformSettings.Value;
@@ -54,6 +57,7 @@ namespace Altinn.AccessManagement.UI.Controllers
             _generalSettings = generalSettings.Value;
             _featureFlags = featureFlags.Value;
             _userService = userService;
+            _logger = logger;
         }
 
         /// <summary>
@@ -116,9 +120,9 @@ namespace Altinn.AccessManagement.UI.Controllers
                         }
                     }
                 }
-                catch
+                catch (Exception ex)
                 {
-                    // Fall back to default language if profile lookup fails
+                    _logger.LogWarning(ex, "Failed to read language preference from profile for userId {UserId}. Falling back to default.", userId);
                 }
             }
 

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/HomeController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/HomeController.cs
@@ -96,36 +96,30 @@ namespace Altinn.AccessManagement.UI.Controllers
             return Redirect(redirectUrl);
         }
 
-        private Task SetLanguageCookie()
+        private async Task SetLanguageCookie()
         {
-            var httpContext = _httpContextAccessor.HttpContext;
+            string languageCode = "no_nb";
 
-            string languageCode = LanguageHelper.GetAltinnPersistenceCookieValueFrontendStandard(httpContext);
-
-            if (string.IsNullOrEmpty(languageCode))
+            int userId = AuthenticationHelper.GetUserId(HttpContext);
+            if (userId > 0)
             {
-                languageCode = httpContext?.Request.Cookies["selectedLanguage"];
+                var profile = await _userService.GetUserProfile(userId);
+                string profileLanguage = profile?.ProfileSettingPreference?.Language;
+                if (!string.IsNullOrEmpty(profileLanguage))
+                {
+                    string frontendCode = LanguageHelper.GetFrontendStandardLanguage(profileLanguage);
+                    if (!string.IsNullOrEmpty(frontendCode))
+                    {
+                        languageCode = frontendCode;
+                    }
+                }
             }
 
-            if (string.IsNullOrEmpty(languageCode))
-            {
-                languageCode = "no_nb";
-            }
-
-            string frontendLanguage = LanguageHelper.GetFrontendStandardLanguage(languageCode);
-
-            if (string.IsNullOrEmpty(frontendLanguage))
-            {
-                frontendLanguage = "no_nb";
-            }
-
-            HttpContext.Response.Cookies.Append("selectedLanguage", frontendLanguage, new CookieOptions
+            HttpContext.Response.Cookies.Append("selectedLanguage", languageCode, new CookieOptions
             {
                 // Make this cookie readable by Javascript.
                 HttpOnly = false,
             });
-
-            return Task.CompletedTask;
         }
 
         private async Task CheckAndSetPartyRepresentationCookies()

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/HomeController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/HomeController.cs
@@ -39,6 +39,7 @@ namespace Altinn.AccessManagement.UI.Controllers
         /// <param name="generalSettings">general settings</param>
         /// <param name="featureFlags">feature flags</param>
         /// <param name="userService">user service to look up things about the user</param>
+        /// <param name="logger">the logger</param>
         public HomeController(
             IOptions<FrontEndEntryPointOptions> frontEndEntrypoints,
             IAntiforgery antiforgery,

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/HomeController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/HomeController.cs
@@ -103,15 +103,22 @@ namespace Altinn.AccessManagement.UI.Controllers
             int userId = AuthenticationHelper.GetUserId(HttpContext);
             if (userId > 0)
             {
-                var profile = await _userService.GetUserProfile(userId);
-                string profileLanguage = profile?.ProfileSettingPreference?.Language;
-                if (!string.IsNullOrEmpty(profileLanguage))
+                try
                 {
-                    string frontendCode = LanguageHelper.GetFrontendStandardLanguage(profileLanguage);
-                    if (!string.IsNullOrEmpty(frontendCode))
+                    var profile = await _userService.GetUserProfile(userId);
+                    string profileLanguage = profile?.ProfileSettingPreference?.Language;
+                    if (!string.IsNullOrEmpty(profileLanguage))
                     {
-                        languageCode = frontendCode;
+                        string frontendCode = LanguageHelper.GetFrontendStandardLanguage(profileLanguage);
+                        if (!string.IsNullOrEmpty(frontendCode))
+                        {
+                            languageCode = frontendCode;
+                        }
                     }
+                }
+                catch
+                {
+                    // Fall back to default language if profile lookup fails
                 }
             }
 

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/SettingsController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/SettingsController.cs
@@ -22,6 +22,7 @@ namespace Altinn.AccessManagement.UI.Controllers
     {
         private readonly ILogger _logger;
         private readonly ISettingsService _settingsService;
+        private readonly IUserService _userService;
         private readonly GeneralSettings _generalSettings;
 
         /// <summary>
@@ -29,14 +30,17 @@ namespace Altinn.AccessManagement.UI.Controllers
         /// </summary>
         /// <param name="logger">the logger.</param>
         /// <param name="settingsService">service implementation for settings</param>
+        /// <param name="userService">service for user profile operations</param>
         /// <param name="generalSettings">general settings</param>
         public SettingsController(
             ILogger<SettingsController> logger,
             ISettingsService settingsService,
+            IUserService userService,
             IOptions<GeneralSettings> generalSettings)
         {
             _logger = logger;
             _settingsService = settingsService;
+            _userService = userService;
             _generalSettings = generalSettings.Value;
         }
 
@@ -57,7 +61,7 @@ namespace Altinn.AccessManagement.UI.Controllers
         [HttpPost]
         [Authorize]
         [Route("language/selectedLanguage")]
-        public IActionResult UpdateSelectedLanguage([FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Allow)] UpdateSelectedLanguageRequest request)
+        public async Task<IActionResult> UpdateSelectedLanguage([FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Allow)] UpdateSelectedLanguageRequest request)
         {
             if (request == null || string.IsNullOrWhiteSpace(request.LanguageCode))
             {
@@ -85,6 +89,8 @@ namespace Altinn.AccessManagement.UI.Controllers
             }
 
             Response.Headers.Append(HeaderNames.SetCookie, cookie.ToString());
+
+            await _userService.SetLanguageProfileSetting(request.LanguageCode);
 
             return Ok();
         }

--- a/src/rtk/features/settingsApi.ts
+++ b/src/rtk/features/settingsApi.ts
@@ -1,4 +1,5 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import { userInfoApi } from './userInfoApi';
 
 import { getCookie } from '@/resources/Cookie/CookieMethods';
 
@@ -74,6 +75,10 @@ export const settingsApi = createApi({
         method: 'POST',
         body: { languageCode },
       }),
+      async onQueryStarted(_, { dispatch, queryFulfilled }) {
+        await queryFulfilled;
+        dispatch(userInfoApi.util.invalidateTags(['UserProfile']));
+      },
     }),
   }),
 });


### PR DESCRIPTION
- Save the selected language to your profile when you change it. 
- Read the preferred language from your profile when you load it.  
- Keep the cookie for apps and other related services.  

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
https://github.com/Altinn/altinn-authorization-tmp/issues/2807

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Language preferences are now persisted to your user profile, ensuring consistent settings across sessions
  * The app automatically loads and applies your language preference from your profile when you visit

* **Tests**
  * Added tests to verify language preference persistence and profile-based language loading functionality
<!-- end of auto-generated comment: release notes by coderabbit.ai -->