### PR TITLE
Add maskinporten itegration with get suppliers / consumers endpoints

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/ClientInterfaces/IMaskinportenClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/ClientInterfaces/IMaskinportenClient.cs
@@ -1,0 +1,26 @@
+using Altinn.AccessManagement.UI.Core.Models.Maskinporten;
+
+namespace Altinn.AccessManagement.UI.Core.ClientInterfaces
+{
+    /// <summary>
+    /// Interface for Maskinporten administration API client.
+    /// </summary>
+    public interface IMaskinportenClient
+    {
+        /// <summary>
+        /// Gets all Maskinporten suppliers for a party.
+        /// </summary>
+        /// <param name="party">The party uuid.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A collection of suppliers.</returns>
+        Task<IEnumerable<MaskinportenConnection>> GetSuppliers(Guid party, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Gets all Maskinporten consumers for a party.
+        /// </summary>
+        /// <param name="party">The party uuid.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A collection of consumers.</returns>
+        Task<IEnumerable<MaskinportenConnection>> GetConsumers(Guid party, CancellationToken cancellationToken = default);
+    }
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Configuration/MockSettings.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Configuration/MockSettings.cs
@@ -106,6 +106,11 @@ namespace Altinn.AccessManagement.UI.Core.Configuration
         public bool Dialogporten { get; set; }
 
         /// <summary>
+        /// Set to mock MaskinportenClient during runtime
+        /// </summary>
+        public bool Maskinporten { get; set; }
+
+        /// <summary>
         /// Default constructor
         /// </summary>
         public MockSettings()
@@ -118,7 +123,7 @@ namespace Altinn.AccessManagement.UI.Core.Configuration
         /// <param name="value">The boolean value to which all memebers will be set</param>
         public MockSettings(bool value)
         {
-            AccessManagement = AccessManagement_V0 = AccessPackage = SingleRights = Instance = Profile = Register = ResourceRegistry = KeyVault = ClientDelegation = Dialogporten = value;
+            AccessManagement = AccessManagement_V0 = AccessPackage = SingleRights = Instance = Profile = Register = ResourceRegistry = KeyVault = ClientDelegation = Dialogporten = Maskinporten = value;
         }
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Extensions/HttpClientExtension.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Extensions/HttpClientExtension.cs
@@ -82,6 +82,21 @@ namespace Altinn.AccessManagement.UI.Core.Extensions
         /// <returns>A HttpResponseMessage.</returns>
         public static Task<HttpResponseMessage> GetAsync(this HttpClient httpClient, string authorizationToken, string requestUri, string platformAccessToken = null, string languageCode = null)
         {
+            return httpClient.GetAsync(authorizationToken, requestUri, CancellationToken.None, platformAccessToken, languageCode);
+        }
+
+        /// <summary>
+        /// Extension that add authorization header to request.
+        /// </summary>
+        /// <param name="httpClient">The HttpClient.</param>
+        /// <param name="authorizationToken">the authorization token (jwt).</param>
+        /// <param name="requestUri">The request Uri.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <param name="platformAccessToken">The platformAccess tokens.</param>
+        /// <param name="languageCode">The language code.</param>
+        /// <returns>A HttpResponseMessage.</returns>
+        public static Task<HttpResponseMessage> GetAsync(this HttpClient httpClient, string authorizationToken, string requestUri, CancellationToken cancellationToken, string platformAccessToken = null, string languageCode = null)
+        {
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, requestUri);
             request.Headers.Add("Authorization", "Bearer " + authorizationToken);
             if (!string.IsNullOrEmpty(languageCode))
@@ -94,7 +109,7 @@ namespace Altinn.AccessManagement.UI.Core.Extensions
                 request.Headers.Add("PlatformAccessToken", platformAccessToken);
             }
 
-            return httpClient.SendAsync(request, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+            return httpClient.SendAsync(request, HttpCompletionOption.ResponseContentRead, cancellationToken);
         }
 
         /// <summary>

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Extensions/HttpClientExtension.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Extensions/HttpClientExtension.cs
@@ -72,7 +72,7 @@ namespace Altinn.AccessManagement.UI.Core.Extensions
         }
 
         /// <summary>
-        /// Extension that add authorization header to request.
+        /// Extension that adds authorization header and cancellation token to request.
         /// </summary>
         /// <param name="httpClient">The HttpClient.</param>
         /// <param name="authorizationToken">the authorization token (jwt).</param>
@@ -86,7 +86,7 @@ namespace Altinn.AccessManagement.UI.Core.Extensions
         }
 
         /// <summary>
-        /// Extension that add authorization header to request.
+        /// Extension that adds authorization header and cancellation token to request.
         /// </summary>
         /// <param name="httpClient">The HttpClient.</param>
         /// <param name="authorizationToken">the authorization token (jwt).</param>

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/Maskinporten/MaskinportenConnection.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/Maskinporten/MaskinportenConnection.cs
@@ -1,0 +1,25 @@
+using Altinn.AccessManagement.UI.Core.Models.Common;
+
+namespace Altinn.AccessManagement.UI.Core.Models.Maskinporten
+{
+    /// <summary>
+    /// Maskinporten connection between the selected party and a supplier or consumer.
+    /// </summary>
+    public class MaskinportenConnection
+    {
+        /// <summary>
+        /// The connected party.
+        /// </summary>
+        public CompactEntity Party { get; set; } = new();
+
+        /// <summary>
+        /// The roles that apply to the connected party.
+        /// </summary>
+        public List<CompactRole> Roles { get; set; } = new();
+
+        /// <summary>
+        /// Sub-connections for the same access.
+        /// </summary>
+        public List<MaskinportenConnection> Connections { get; set; } = new();
+    }
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/Interfaces/IMaskinportenService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/Interfaces/IMaskinportenService.cs
@@ -1,0 +1,26 @@
+using Altinn.AccessManagement.UI.Core.Models.Maskinporten;
+
+namespace Altinn.AccessManagement.UI.Core.Services.Interfaces
+{
+    /// <summary>
+    /// Service for Maskinporten administration operations.
+    /// </summary>
+    public interface IMaskinportenService
+    {
+        /// <summary>
+        /// Gets all Maskinporten suppliers for a party.
+        /// </summary>
+        /// <param name="party">The party uuid.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A collection of suppliers.</returns>
+        Task<IEnumerable<MaskinportenConnection>> GetSuppliers(Guid party, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Gets all Maskinporten consumers for a party.
+        /// </summary>
+        /// <param name="party">The party uuid.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A collection of consumers.</returns>
+        Task<IEnumerable<MaskinportenConnection>> GetConsumers(Guid party, CancellationToken cancellationToken = default);
+    }
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/MaskinportenService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/MaskinportenService.cs
@@ -1,0 +1,35 @@
+using Altinn.AccessManagement.UI.Core.ClientInterfaces;
+using Altinn.AccessManagement.UI.Core.Models.Maskinporten;
+using Altinn.AccessManagement.UI.Core.Services.Interfaces;
+
+namespace Altinn.AccessManagement.UI.Core.Services
+{
+    /// <summary>
+    /// Service that integrates with the Maskinporten administration API.
+    /// </summary>
+    public class MaskinportenService : IMaskinportenService
+    {
+        private readonly IMaskinportenClient _maskinportenClient;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MaskinportenService"/> class.
+        /// </summary>
+        /// <param name="maskinportenClient">Maskinporten client.</param>
+        public MaskinportenService(IMaskinportenClient maskinportenClient)
+        {
+            _maskinportenClient = maskinportenClient;
+        }
+
+        /// <inheritdoc />
+        public async Task<IEnumerable<MaskinportenConnection>> GetSuppliers(Guid party, CancellationToken cancellationToken = default)
+        {
+            return await _maskinportenClient.GetSuppliers(party, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public async Task<IEnumerable<MaskinportenConnection>> GetConsumers(Guid party, CancellationToken cancellationToken = default)
+        {
+            return await _maskinportenClient.GetConsumers(party, cancellationToken);
+        }
+    }
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/MaskinportenClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/MaskinportenClient.cs
@@ -1,0 +1,67 @@
+using Altinn.AccessManagement.UI.Core.ClientInterfaces;
+using Altinn.AccessManagement.UI.Core.Extensions;
+using Altinn.AccessManagement.UI.Core.Helpers;
+using Altinn.AccessManagement.UI.Core.Models.Maskinporten;
+using Altinn.AccessManagement.UI.Integration.Configuration;
+using Altinn.AccessManagement.UI.Integration.Util;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Altinn.AccessManagement.UI.Integration.Clients
+{
+    /// <summary>
+    /// Client for interacting with Maskinporten administration endpoints.
+    /// </summary>
+    public class MaskinportenClient : IMaskinportenClient
+    {
+        private readonly ILogger _logger;
+        private readonly HttpClient _client;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly PlatformSettings _platformSettings;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MaskinportenClient"/> class.
+        /// </summary>
+        /// <param name="httpClient">The http client.</param>
+        /// <param name="logger">The logger.</param>
+        /// <param name="httpContextAccessor">The http context accessor.</param>
+        /// <param name="platformSettings">Platform settings configuration.</param>
+        public MaskinportenClient(
+            HttpClient httpClient,
+            ILogger<MaskinportenClient> logger,
+            IHttpContextAccessor httpContextAccessor,
+            IOptions<PlatformSettings> platformSettings)
+        {
+            _logger = logger;
+            _platformSettings = platformSettings.Value;
+            httpClient.BaseAddress = new Uri(_platformSettings.ApiAccessManagementEndpoint);
+            httpClient.DefaultRequestHeaders.Add(_platformSettings.SubscriptionKeyHeaderName, _platformSettings.SubscriptionKey);
+            _client = httpClient;
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        /// <inheritdoc />
+        public async Task<IEnumerable<MaskinportenConnection>> GetSuppliers(Guid party, CancellationToken cancellationToken = default)
+        {
+            return await GetConnections($"enduser/maskinportensuppliers?party={party}", "MaskinportenClient.GetSuppliers", cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public async Task<IEnumerable<MaskinportenConnection>> GetConsumers(Guid party, CancellationToken cancellationToken = default)
+        {
+            return await GetConnections($"enduser/maskinportenconsumers?party={party}", "MaskinportenClient.GetConsumers", cancellationToken);
+        }
+
+        private async Task<IEnumerable<MaskinportenConnection>> GetConnections(string endpointUrl, string clientMethodName, CancellationToken cancellationToken)
+        {
+            string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
+
+            HttpResponseMessage response = await _client.GetAsync(token, endpointUrl);
+            IEnumerable<MaskinportenConnection> connections =
+                await ClientUtils.DeserializeIfSuccessfullStatusCode<IEnumerable<MaskinportenConnection>>(response, _logger, clientMethodName);
+
+            return connections ?? Enumerable.Empty<MaskinportenConnection>();
+        }
+    }
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/MaskinportenClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/MaskinportenClient.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Altinn.AccessManagement.UI.Core.ClientInterfaces;
 using Altinn.AccessManagement.UI.Core.Extensions;
 using Altinn.AccessManagement.UI.Core.Helpers;
@@ -44,24 +45,35 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
         /// <inheritdoc />
         public async Task<IEnumerable<MaskinportenConnection>> GetSuppliers(Guid party, CancellationToken cancellationToken = default)
         {
-            return await GetConnections($"enduser/maskinportensuppliers?party={party}", "MaskinportenClient.GetSuppliers", cancellationToken);
+            var token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
+            var endpointUrl = $"enduser/maskinportensuppliers?party={party}";
+            try
+            {
+                HttpResponseMessage response = await _client.GetAsync(token, endpointUrl, cancellationToken);
+                return await ClientUtils.DeserializeIfSuccessfullStatusCode<IEnumerable<MaskinportenConnection>>(response, _logger, "MaskinportenClient.GetSuppliers");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error while getting right holders");
+                throw new HttpStatusException("Unexpected http response.", "Unexpected http response.", HttpStatusCode.InternalServerError, null, ex.Message);
+            }
         }
 
         /// <inheritdoc />
         public async Task<IEnumerable<MaskinportenConnection>> GetConsumers(Guid party, CancellationToken cancellationToken = default)
         {
-            return await GetConnections($"enduser/maskinportenconsumers?party={party}", "MaskinportenClient.GetConsumers", cancellationToken);
-        }
-
-        private async Task<IEnumerable<MaskinportenConnection>> GetConnections(string endpointUrl, string clientMethodName, CancellationToken cancellationToken)
-        {
-            string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
-
-            HttpResponseMessage response = await _client.GetAsync(token, endpointUrl);
-            IEnumerable<MaskinportenConnection> connections =
-                await ClientUtils.DeserializeIfSuccessfullStatusCode<IEnumerable<MaskinportenConnection>>(response, _logger, clientMethodName);
-
-            return connections ?? Enumerable.Empty<MaskinportenConnection>();
+            var token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
+            var endpointUrl = $"enduser/maskinportenconsumers?party={party}";
+            try
+            {
+                HttpResponseMessage response = await _client.GetAsync(token, endpointUrl, cancellationToken);
+                return await ClientUtils.DeserializeIfSuccessfullStatusCode<IEnumerable<MaskinportenConnection>>(response, _logger, "MaskinportenClient.GetConsumers");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error while getting right holders");
+                throw new HttpStatusException("Unexpected http response.", "Unexpected http response.", HttpStatusCode.InternalServerError, null, ex.Message);
+            }
         }
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/Maskinporten/consumers.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/Maskinporten/consumers.json
@@ -16,8 +16,8 @@
     "roles": [
       {
         "id": "5f9856ac-35bb-4b7c-8db3-7cb549ec23f4",
-        "code": "supplier",
-        "urn": "altinn:role:maskinporten-supplier",
+        "code": "consumer",
+        "urn": "altinn:role:maskinporten-consumer",
         "legacyUrn": null,
         "children": null
       }
@@ -41,8 +41,8 @@
     "roles": [
       {
         "id": "5f9856ac-35bb-4b7c-8db3-7cb549ec23f4",
-        "code": "supplier",
-        "urn": "altinn:role:maskinporten-supplier",
+        "code": "consumer",
+        "urn": "altinn:role:maskinporten-consumer",
         "legacyUrn": null,
         "children": null
       }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/Maskinporten/consumers.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/Maskinporten/consumers.json
@@ -1,0 +1,52 @@
+[
+  {
+    "party": {
+      "id": "63c567e0-bdc8-4136-afc5-2b5065074877",
+      "name": "Kundeorganisasjon AS",
+      "type": "Organization",
+      "variant": "Enterprise",
+      "parent": null,
+      "children": null,
+      "partyId": 500201,
+      "organizationIdentifier": "313261334",
+      "dateOfBirth": null,
+      "isDeleted": false,
+      "deletedAt": null
+    },
+    "roles": [
+      {
+        "id": "5f9856ac-35bb-4b7c-8db3-7cb549ec23f4",
+        "code": "supplier",
+        "urn": "altinn:role:maskinporten-supplier",
+        "legacyUrn": null,
+        "children": null
+      }
+    ],
+    "connections": []
+  },
+  {
+    "party": {
+      "id": "d3f1b6b2-9200-46d0-aae2-8eab463df6b6",
+      "name": "Demo Kunde ANS",
+      "type": "Organization",
+      "variant": "Enterprise",
+      "parent": null,
+      "children": null,
+      "partyId": 500202,
+      "organizationIdentifier": "910258028",
+      "dateOfBirth": null,
+      "isDeleted": false,
+      "deletedAt": null
+    },
+    "roles": [
+      {
+        "id": "5f9856ac-35bb-4b7c-8db3-7cb549ec23f4",
+        "code": "supplier",
+        "urn": "altinn:role:maskinporten-supplier",
+        "legacyUrn": null,
+        "children": null
+      }
+    ],
+    "connections": []
+  }
+]

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/Maskinporten/suppliers.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/Maskinporten/suppliers.json
@@ -1,0 +1,52 @@
+[
+  {
+    "party": {
+      "id": "18d7bf5a-0c7c-4d7f-94e7-6ac09b8b5d01",
+      "name": "Testleverandor AS",
+      "type": "Organization",
+      "variant": "Enterprise",
+      "parent": null,
+      "children": null,
+      "partyId": 500101,
+      "organizationIdentifier": "312605031",
+      "dateOfBirth": null,
+      "isDeleted": false,
+      "deletedAt": null
+    },
+    "roles": [
+      {
+        "id": "5f9856ac-35bb-4b7c-8db3-7cb549ec23f4",
+        "code": "supplier",
+        "urn": "altinn:role:maskinporten-supplier",
+        "legacyUrn": null,
+        "children": null
+      }
+    ],
+    "connections": []
+  },
+  {
+    "party": {
+      "id": "73deed97-7990-4c9b-86ea-7f48154683c6",
+      "name": "Eksempel Systempartner AS",
+      "type": "Organization",
+      "variant": "Enterprise",
+      "parent": null,
+      "children": null,
+      "partyId": 500102,
+      "organizationIdentifier": "910753614",
+      "dateOfBirth": null,
+      "isDeleted": false,
+      "deletedAt": null
+    },
+    "roles": [
+      {
+        "id": "5f9856ac-35bb-4b7c-8db3-7cb549ec23f4",
+        "code": "supplier",
+        "urn": "altinn:role:maskinporten-supplier",
+        "legacyUrn": null,
+        "children": null
+      }
+    ],
+    "connections": []
+  }
+]

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/MaskinportenClientMock.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/MaskinportenClientMock.cs
@@ -1,0 +1,42 @@
+using Altinn.AccessManagement.UI.Core.ClientInterfaces;
+using Altinn.AccessManagement.UI.Core.Models.Maskinporten;
+using Altinn.AccessManagement.UI.Mocks.Utils;
+
+namespace Altinn.AccessManagement.UI.Mocks.Mocks
+{
+    /// <summary>
+    /// Mock class for <see cref="IMaskinportenClient"/>.
+    /// </summary>
+    public class MaskinportenClientMock : IMaskinportenClient
+    {
+        private readonly string dataFolder;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MaskinportenClientMock"/> class.
+        /// </summary>
+        public MaskinportenClientMock()
+        {
+            dataFolder = Path.Combine(Path.GetDirectoryName(new Uri(typeof(MaskinportenClientMock).Assembly.Location).LocalPath), "Data");
+        }
+
+        /// <inheritdoc />
+        public Task<IEnumerable<MaskinportenConnection>> GetSuppliers(Guid party, CancellationToken cancellationToken = default)
+        {
+            Util.ThrowExceptionIfTriggerParty(party.ToString());
+
+            string dataPath = Path.Combine(dataFolder, "Maskinporten", "suppliers.json");
+            IEnumerable<MaskinportenConnection> suppliers = Util.GetMockData<List<MaskinportenConnection>>(dataPath);
+            return Task.FromResult(suppliers);
+        }
+
+        /// <inheritdoc />
+        public Task<IEnumerable<MaskinportenConnection>> GetConsumers(Guid party, CancellationToken cancellationToken = default)
+        {
+            Util.ThrowExceptionIfTriggerParty(party.ToString());
+
+            string dataPath = Path.Combine(dataFolder, "Maskinporten", "consumers.json");
+            IEnumerable<MaskinportenConnection> consumers = Util.GetMockData<List<MaskinportenConnection>>(dataPath);
+            return Task.FromResult(consumers);
+        }
+    }
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/MaskinportenControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/MaskinportenControllerTest.cs
@@ -50,9 +50,10 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             SetAuthHeader();
 
             HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/maskinporten/suppliers?party={party}");
-            List<MaskinportenConnection> actualResponse = await response.Content.ReadFromJsonAsync<List<MaskinportenConnection>>();
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            List<MaskinportenConnection> actualResponse = await response.Content.ReadFromJsonAsync<List<MaskinportenConnection>>();
+
             Assert.NotNull(actualResponse);
             Assert.Equivalent(expectedResponse, actualResponse);
         }
@@ -69,9 +70,10 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             SetAuthHeader();
 
             HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/maskinporten/consumers?party={party}");
-            List<MaskinportenConnection> actualResponse = await response.Content.ReadFromJsonAsync<List<MaskinportenConnection>>();
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            List<MaskinportenConnection> actualResponse = await response.Content.ReadFromJsonAsync<List<MaskinportenConnection>>();
+
             Assert.NotNull(actualResponse);
             Assert.Equivalent(expectedResponse, actualResponse);
         }
@@ -112,9 +114,10 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             SetAuthHeader();
 
             HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/maskinporten/suppliers?party={party}");
-            ProblemDetails problemDetails = await response.Content.ReadFromJsonAsync<ProblemDetails>();
 
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+            ProblemDetails problemDetails = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+
             Assert.NotNull(problemDetails);
             Assert.Equal((int)HttpStatusCode.NotFound, problemDetails.Status);
             Assert.Equal("Unexpected HttpStatus response", problemDetails.Title);
@@ -145,9 +148,10 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             SetAuthHeader();
 
             HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/maskinporten/consumers?party={party}");
-            ProblemDetails problemDetails = await response.Content.ReadFromJsonAsync<ProblemDetails>();
 
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+            ProblemDetails problemDetails = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+
             Assert.NotNull(problemDetails);
             Assert.Equal((int)HttpStatusCode.NotFound, problemDetails.Status);
             Assert.Equal("Unexpected HttpStatus response", problemDetails.Title);

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/MaskinportenControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/MaskinportenControllerTest.cs
@@ -1,0 +1,171 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using Altinn.AccessManagement.UI.Controllers;
+using Altinn.AccessManagement.UI.Core.Models.Maskinporten;
+using Altinn.AccessManagement.UI.Mocks.Utils;
+using Altinn.AccessManagement.UI.Tests.Utils;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Altinn.AccessManagement.UI.Tests.Controllers
+{
+    /// <summary>
+    /// Test class for <see cref="MaskinportenController"/>.
+    /// </summary>
+    [Collection("MaskinportenController Tests")]
+    public class MaskinportenControllerTest : IClassFixture<CustomWebApplicationFactory<MaskinportenController>>
+    {
+        private readonly HttpClient _client;
+        private readonly string _testDataFolder;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MaskinportenControllerTest"/> class.
+        /// </summary>
+        /// <param name="factory">CustomWebApplicationFactory</param>
+        public MaskinportenControllerTest(CustomWebApplicationFactory<MaskinportenController> factory)
+        {
+            _client = SetupUtils.GetTestClient(factory);
+            _testDataFolder = Path.Combine(
+                Path.GetDirectoryName(new Uri(typeof(MaskinportenControllerTest).Assembly.Location).LocalPath),
+                "Data",
+                "ExpectedResults",
+                "Maskinporten");
+        }
+
+        private void SetAuthHeader()
+        {
+            string token = PrincipalUtil.GetToken(1234, 1234, 2);
+            _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        }
+
+        /// <summary>
+        /// Test case: GetSuppliers returns the expected suppliers for a party.
+        /// </summary>
+        [Fact]
+        public async Task GetSuppliers_ReturnsSuppliers()
+        {
+            Guid party = Guid.Parse("cd35779b-b174-4ecc-bbef-ece13611be7f");
+            string path = Path.Combine(_testDataFolder, "suppliers.json");
+            List<MaskinportenConnection> expectedResponse = Util.GetMockData<List<MaskinportenConnection>>(path);
+            SetAuthHeader();
+
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/maskinporten/suppliers?party={party}");
+            List<MaskinportenConnection> actualResponse = await response.Content.ReadFromJsonAsync<List<MaskinportenConnection>>();
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.NotNull(actualResponse);
+            Assert.Equivalent(expectedResponse, actualResponse);
+        }
+
+        /// <summary>
+        /// Test case: GetConsumers returns the expected consumers for a party.
+        /// </summary>
+        [Fact]
+        public async Task GetConsumers_ReturnsConsumers()
+        {
+            Guid party = Guid.Parse("cd35779b-b174-4ecc-bbef-ece13611be7f");
+            string path = Path.Combine(_testDataFolder, "consumers.json");
+            List<MaskinportenConnection> expectedResponse = Util.GetMockData<List<MaskinportenConnection>>(path);
+            SetAuthHeader();
+
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/maskinporten/consumers?party={party}");
+            List<MaskinportenConnection> actualResponse = await response.Content.ReadFromJsonAsync<List<MaskinportenConnection>>();
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.NotNull(actualResponse);
+            Assert.Equivalent(expectedResponse, actualResponse);
+        }
+
+        /// <summary>
+        /// Test case: GetSuppliers with invalid party format returns bad request.
+        /// </summary>
+        [Fact]
+        public async Task GetSuppliers_InvalidParty_ReturnsBadRequest()
+        {
+            SetAuthHeader();
+
+            HttpResponseMessage response = await _client.GetAsync("accessmanagement/api/v1/maskinporten/suppliers?party=not-a-guid");
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        }
+
+        /// <summary>
+        /// Test case: GetConsumers with invalid party format returns bad request.
+        /// </summary>
+        [Fact]
+        public async Task GetConsumers_InvalidParty_ReturnsBadRequest()
+        {
+            SetAuthHeader();
+
+            HttpResponseMessage response = await _client.GetAsync("accessmanagement/api/v1/maskinporten/consumers?party=not-a-guid");
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        }
+
+        /// <summary>
+        /// Test case: GetSuppliers returns the backend status code and problem details when service throws HttpStatusException.
+        /// </summary>
+        [Fact]
+        public async Task GetSuppliers_ServiceThrowsHttpStatusException_ReturnsProblemDetails()
+        {
+            Guid party = Guid.Parse("00000000-0000-0000-0000-000000000404");
+            SetAuthHeader();
+
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/maskinporten/suppliers?party={party}");
+            ProblemDetails problemDetails = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+            Assert.NotNull(problemDetails);
+            Assert.Equal((int)HttpStatusCode.NotFound, problemDetails.Status);
+            Assert.Equal("Unexpected HttpStatus response", problemDetails.Title);
+            Assert.Equal("Downstream message", problemDetails.Detail);
+        }
+
+        /// <summary>
+        /// Test case: GetSuppliers returns internal server error when service throws.
+        /// </summary>
+        [Fact]
+        public async Task GetSuppliers_ServiceThrowsException_ReturnsInternalServerError()
+        {
+            Guid party = Guid.Empty;
+            SetAuthHeader();
+
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/maskinporten/suppliers?party={party}");
+
+            Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+        }
+
+        /// <summary>
+        /// Test case: GetConsumers returns the backend status code and problem details when service throws HttpStatusException.
+        /// </summary>
+        [Fact]
+        public async Task GetConsumers_ServiceThrowsHttpStatusException_ReturnsProblemDetails()
+        {
+            Guid party = Guid.Parse("00000000-0000-0000-0000-000000000404");
+            SetAuthHeader();
+
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/maskinporten/consumers?party={party}");
+            ProblemDetails problemDetails = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+            Assert.NotNull(problemDetails);
+            Assert.Equal((int)HttpStatusCode.NotFound, problemDetails.Status);
+            Assert.Equal("Unexpected HttpStatus response", problemDetails.Title);
+            Assert.Equal("Downstream message", problemDetails.Detail);
+        }
+
+        /// <summary>
+        /// Test case: GetConsumers returns internal server error when service throws.
+        /// </summary>
+        [Fact]
+        public async Task GetConsumers_ServiceThrowsException_ReturnsInternalServerError()
+        {
+            Guid party = Guid.Empty;
+            SetAuthHeader();
+
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/maskinporten/consumers?party={party}");
+
+            Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+        }
+    }
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/Maskinporten/consumers.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/Maskinporten/consumers.json
@@ -16,8 +16,8 @@
     "roles": [
       {
         "id": "5f9856ac-35bb-4b7c-8db3-7cb549ec23f4",
-        "code": "supplier",
-        "urn": "altinn:role:maskinporten-supplier",
+        "code": "consumer",
+        "urn": "altinn:role:maskinporten-consumer",
         "legacyUrn": null,
         "children": null
       }
@@ -41,8 +41,8 @@
     "roles": [
       {
         "id": "5f9856ac-35bb-4b7c-8db3-7cb549ec23f4",
-        "code": "supplier",
-        "urn": "altinn:role:maskinporten-supplier",
+        "code": "consumer",
+        "urn": "altinn:role:maskinporten-consumer",
         "legacyUrn": null,
         "children": null
       }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/Maskinporten/consumers.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/Maskinporten/consumers.json
@@ -1,0 +1,52 @@
+[
+  {
+    "party": {
+      "id": "63c567e0-bdc8-4136-afc5-2b5065074877",
+      "name": "Kundeorganisasjon AS",
+      "type": "Organization",
+      "variant": "Enterprise",
+      "parent": null,
+      "children": null,
+      "partyId": 500201,
+      "organizationIdentifier": "313261334",
+      "dateOfBirth": null,
+      "isDeleted": false,
+      "deletedAt": null
+    },
+    "roles": [
+      {
+        "id": "5f9856ac-35bb-4b7c-8db3-7cb549ec23f4",
+        "code": "supplier",
+        "urn": "altinn:role:maskinporten-supplier",
+        "legacyUrn": null,
+        "children": null
+      }
+    ],
+    "connections": []
+  },
+  {
+    "party": {
+      "id": "d3f1b6b2-9200-46d0-aae2-8eab463df6b6",
+      "name": "Demo Kunde ANS",
+      "type": "Organization",
+      "variant": "Enterprise",
+      "parent": null,
+      "children": null,
+      "partyId": 500202,
+      "organizationIdentifier": "910258028",
+      "dateOfBirth": null,
+      "isDeleted": false,
+      "deletedAt": null
+    },
+    "roles": [
+      {
+        "id": "5f9856ac-35bb-4b7c-8db3-7cb549ec23f4",
+        "code": "supplier",
+        "urn": "altinn:role:maskinporten-supplier",
+        "legacyUrn": null,
+        "children": null
+      }
+    ],
+    "connections": []
+  }
+]

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/Maskinporten/suppliers.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/Maskinporten/suppliers.json
@@ -1,0 +1,52 @@
+[
+  {
+    "party": {
+      "id": "18d7bf5a-0c7c-4d7f-94e7-6ac09b8b5d01",
+      "name": "Testleverandor AS",
+      "type": "Organization",
+      "variant": "Enterprise",
+      "parent": null,
+      "children": null,
+      "partyId": 500101,
+      "organizationIdentifier": "312605031",
+      "dateOfBirth": null,
+      "isDeleted": false,
+      "deletedAt": null
+    },
+    "roles": [
+      {
+        "id": "5f9856ac-35bb-4b7c-8db3-7cb549ec23f4",
+        "code": "supplier",
+        "urn": "altinn:role:maskinporten-supplier",
+        "legacyUrn": null,
+        "children": null
+      }
+    ],
+    "connections": []
+  },
+  {
+    "party": {
+      "id": "73deed97-7990-4c9b-86ea-7f48154683c6",
+      "name": "Eksempel Systempartner AS",
+      "type": "Organization",
+      "variant": "Enterprise",
+      "parent": null,
+      "children": null,
+      "partyId": 500102,
+      "organizationIdentifier": "910753614",
+      "dateOfBirth": null,
+      "isDeleted": false,
+      "deletedAt": null
+    },
+    "roles": [
+      {
+        "id": "5f9856ac-35bb-4b7c-8db3-7cb549ec23f4",
+        "code": "supplier",
+        "urn": "altinn:role:maskinporten-supplier",
+        "legacyUrn": null,
+        "children": null
+      }
+    ],
+    "connections": []
+  }
+]

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Utils/SetupUtils.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Utils/SetupUtils.cs
@@ -568,6 +568,30 @@ namespace Altinn.AccessManagement.UI.Tests.Utils
         }
 
         /// <summary>
+        /// Gets a HttpClient for unittests testing for MaskinportenController
+        /// </summary>
+        /// <param name="customFactory">Web app factory to configure test services for MaskinportenController tests</param>
+        /// <returns>HttpClient</returns>
+        internal static HttpClient GetTestClient(CustomWebApplicationFactory<MaskinportenController> customFactory)
+        {
+            WebApplicationFactory<MaskinportenController> factory = customFactory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.AddTransient<IMaskinportenClient, MaskinportenClientMock>();
+                    services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+                    services.AddSingleton<IPostConfigureOptions<JwtCookieOptions>, JwtCookiePostConfigureOptionsStub>();
+                });
+            });
+            WebApplicationFactoryClientOptions opts = new WebApplicationFactoryClientOptions
+            {
+                AllowAutoRedirect = false,
+            };
+            factory.Server.AllowSynchronousIO = true;
+            return factory.CreateClient(opts);
+        }
+
+        /// <summary>
         ///     Gets a HttpClient for unittests testing
         /// </summary>
         /// <param name="customFactory">Web app factory to configure test services for RequestController tests</param>

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/MaskinportenController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/MaskinportenController.cs
@@ -1,0 +1,99 @@
+using System.Collections.Generic;
+using System.Net;
+using Altinn.AccessManagement.UI.Core.Helpers;
+using Altinn.AccessManagement.UI.Core.Models.Maskinporten;
+using Altinn.AccessManagement.UI.Core.Services.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Altinn.AccessManagement.UI.Controllers
+{
+    /// <summary>
+    /// The <see cref="MaskinportenController"/> provides API endpoints related to Maskinporten administration.
+    /// </summary>
+    [Route("accessmanagement/api/v1/maskinporten")]
+    public class MaskinportenController : ControllerBase
+    {
+        private readonly IMaskinportenService _maskinportenService;
+        private readonly ILogger _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MaskinportenController"/> class.
+        /// </summary>
+        /// <param name="maskinportenService">Maskinporten service.</param>
+        /// <param name="logger">Logger.</param>
+        public MaskinportenController(
+            IMaskinportenService maskinportenService,
+            ILogger<MaskinportenController> logger)
+        {
+            _maskinportenService = maskinportenService;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Endpoint for retrieving Maskinporten suppliers for a party.
+        /// </summary>
+        /// <param name="party">The uuid for the party.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>List of suppliers.</returns>
+        [HttpGet]
+        [Authorize]
+        [Route("suppliers")]
+        public async Task<ActionResult<IEnumerable<MaskinportenConnection>>> GetSuppliers([FromQuery] Guid party, CancellationToken cancellationToken = default)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            try
+            {
+                IEnumerable<MaskinportenConnection> suppliers = await _maskinportenService.GetSuppliers(party, cancellationToken);
+                return Ok(suppliers);
+            }
+            catch (HttpStatusException ex)
+            {
+                string responseContent = ex.Message;
+                return new ObjectResult(ProblemDetailsFactory.CreateProblemDetails(HttpContext, (int?)ex.StatusCode, "Unexpected HttpStatus response", detail: responseContent));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "GetSuppliers failed unexpectedly");
+                return StatusCode((int)HttpStatusCode.InternalServerError);
+            }
+        }
+
+        /// <summary>
+        /// Endpoint for retrieving Maskinporten consumers for a party.
+        /// </summary>
+        /// <param name="party">The uuid for the party.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>List of consumers.</returns>
+        [HttpGet]
+        [Authorize]
+        [Route("consumers")]
+        public async Task<ActionResult<IEnumerable<MaskinportenConnection>>> GetConsumers([FromQuery] Guid party, CancellationToken cancellationToken = default)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            try
+            {
+                IEnumerable<MaskinportenConnection> consumers = await _maskinportenService.GetConsumers(party, cancellationToken);
+                return Ok(consumers);
+            }
+            catch (HttpStatusException ex)
+            {
+                string responseContent = ex.Message;
+                return new ObjectResult(ProblemDetailsFactory.CreateProblemDetails(HttpContext, (int?)ex.StatusCode, "Unexpected HttpStatus response", detail: responseContent));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "GetConsumers failed unexpectedly");
+                return StatusCode((int)HttpStatusCode.InternalServerError);
+            }
+        }
+    }
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Program.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Program.cs
@@ -508,6 +508,6 @@ void ConfigureMockableClients(IServiceCollection services, IConfiguration config
     }
     else
     {
-        services.AddSingleton<IMaskinportenClient, MaskinportenClient>();
+        services.AddHttpClient<IMaskinportenClient, MaskinportenClient>();
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Program.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Program.cs
@@ -242,6 +242,7 @@ void ConfigureServices(IServiceCollection services, IConfiguration config)
     services.AddSingleton<IConsentService, ConsentService>();
     services.AddSingleton<IEncryptionService, EncryptionService>();
     services.AddSingleton<IRoleService, RoleService>();
+    services.AddSingleton<IMaskinportenService, MaskinportenService>();
     services.AddTransient<ISigningCredentialsResolver, SigningCredentialsResolver>();
     services.AddTransient<ResourceHelper, ResourceHelper>();
     services.AddTransient<IAltinnCdnService, AltinnCdnService>();
@@ -499,5 +500,14 @@ void ConfigureMockableClients(IServiceCollection services, IConfiguration config
     else
     {
         services.AddSingleton<IConsentClient, ConsentClient>();
+    }
+
+    if (mockSettings.Maskinporten)
+    {
+        services.AddSingleton<IMaskinportenClient, MaskinportenClientMock>();
+    }
+    else
+    {
+        services.AddSingleton<IMaskinportenClient, MaskinportenClient>();
     }
 }

--- a/src/rtk/app/store.ts
+++ b/src/rtk/app/store.ts
@@ -20,6 +20,7 @@ import { connectionApi } from '../features/connectionApi';
 import { clientApi } from '../features/clientApi';
 import { instanceApi } from '../features/instanceApi';
 import { requestApi } from '../features/requestApi';
+import { maskinportenApi } from '../features/maskinportenApi';
 
 const store = configureStore({
   reducer: {
@@ -42,6 +43,7 @@ const store = configureStore({
     [altinnCdnApi.reducerPath]: altinnCdnApi.reducer,
     [instanceApi.reducerPath]: instanceApi.reducer,
     [requestApi.reducerPath]: requestApi.reducer,
+    [maskinportenApi.reducerPath]: maskinportenApi.reducer,
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware().concat(
@@ -61,6 +63,7 @@ const store = configureStore({
       instanceApi.middleware,
       settingsApi.middleware,
       requestApi.middleware,
+      maskinportenApi.middleware,
     ),
 });
 

--- a/src/rtk/features/maskinportenApi.ts
+++ b/src/rtk/features/maskinportenApi.ts
@@ -1,0 +1,40 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+
+import type { CompactRole, Entity } from '@/dataObjects/dtos/Common';
+import { getCookie } from '@/resources/Cookie/CookieMethods';
+
+export interface MaskinportenConnection {
+  party: Entity;
+  roles: CompactRole[];
+  connections: MaskinportenConnection[];
+}
+
+const baseUrl = `${import.meta.env.BASE_URL}accessmanagement/api/v1/maskinporten`;
+
+export const maskinportenApi = createApi({
+  reducerPath: 'maskinportenApi',
+  baseQuery: fetchBaseQuery({
+    baseUrl,
+    prepareHeaders: (headers) => {
+      headers.set('content-type', 'application/json; charset=utf-8');
+      headers.set('X-XSRF-TOKEN', getCookie('XSRF-TOKEN'));
+      return headers;
+    },
+  }),
+  tagTypes: ['maskinportenSuppliers', 'maskinportenConsumers'],
+  endpoints: (builder) => ({
+    getMaskinportenSuppliers: builder.query<MaskinportenConnection[], { party?: string } | void>({
+      query: (args) => `suppliers?party=${args?.party ?? getCookie('AltinnPartyUuid')}`,
+      providesTags: ['maskinportenSuppliers'],
+    }),
+    getMaskinportenConsumers: builder.query<MaskinportenConnection[], { party?: string } | void>({
+      query: (args) => `consumers?party=${args?.party ?? getCookie('AltinnPartyUuid')}`,
+      providesTags: ['maskinportenConsumers'],
+    }),
+  }),
+});
+
+export const { useGetMaskinportenSuppliersQuery, useGetMaskinportenConsumersQuery } =
+  maskinportenApi;
+
+export const { endpoints, reducerPath, reducer, middleware } = maskinportenApi;

--- a/src/rtk/features/maskinportenApi.ts
+++ b/src/rtk/features/maskinportenApi.ts
@@ -1,10 +1,10 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 
-import type { CompactRole, Entity } from '@/dataObjects/dtos/Common';
+import type { CompactRole, CompactEntity } from '@/dataObjects/dtos/Common';
 import { getCookie } from '@/resources/Cookie/CookieMethods';
 
 export interface MaskinportenConnection {
-  party: Entity;
+  party: CompactEntity;
   roles: CompactRole[];
   connections: MaskinportenConnection[];
 }


### PR DESCRIPTION
Add BFF endpoints for fetching maskinporten suppliers / consumers from the backend. 

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Maskinporten administration endpoints to list suppliers and consumers and a service + client integration to fetch them.
  * Frontend integrated Maskinporten API slice with RTK Query and exported hooks for use in the UI.

* **Tests**
  * Added integration tests and expected-response fixtures covering success, validation, and error scenarios.

* **Chores**
  * Added mock support and mock data for Maskinporten and DI registration for mock vs real client.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->