### PR TITLE
Enable confirmation of multiple draft resource requests

### DIFF
--- a/src/features/amUI/requestPage/DraftRequestPage/DraftRequestHeader.tsx
+++ b/src/features/amUI/requestPage/DraftRequestPage/DraftRequestHeader.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Trans } from 'react-i18next';
+import { DsHeading } from '@altinn/altinn-components';
+
+interface DraftRequestHeaderProps {
+  headerTextKey: string;
+  toName: string;
+}
+
+export const DraftRequestHeader = ({ headerTextKey, toName }: DraftRequestHeaderProps) => {
+  return (
+    <DsHeading
+      level={1}
+      data-size='md'
+    >
+      <Trans
+        i18nKey={headerTextKey}
+        components={{ b: <strong /> }}
+        values={{ to_name: toName }}
+      />
+    </DsHeading>
+  );
+};

--- a/src/features/amUI/requestPage/DraftRequestPage/DraftRequestPage.module.css
+++ b/src/features/amUI/requestPage/DraftRequestPage/DraftRequestPage.module.css
@@ -15,3 +15,21 @@
   font-weight: var(--ds-font-weight-semibold);
   margin-top: var(--ds-size-6);
 }
+
+.backButton {
+  margin-bottom: var(--ds-size-2);
+  translate: -1rem 0;
+}
+
+.multipleDraftRequests {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-size-2);
+}
+
+.seeDetails {
+  display: flex;
+  align-items: center;
+  gap: var(--ds-size-2);
+  color: var(--ds-color-text-subtle);
+}

--- a/src/features/amUI/requestPage/DraftRequestPage/DraftRequestPage.module.css
+++ b/src/features/amUI/requestPage/DraftRequestPage/DraftRequestPage.module.css
@@ -18,7 +18,7 @@
 
 .backButton {
   margin-bottom: var(--ds-size-2);
-  translate: -1rem 0;
+  transform: translate(-1rem, 0);
 }
 
 .multipleDraftRequests {

--- a/src/features/amUI/requestPage/DraftRequestPage/DraftRequestPage.tsx
+++ b/src/features/amUI/requestPage/DraftRequestPage/DraftRequestPage.tsx
@@ -1,28 +1,23 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-import {
-  DsAlert,
-  DsButton,
-  DsHeading,
-  DsParagraph,
-  formatDisplayName,
-} from '@altinn/altinn-components';
+import { DsAlert, DsParagraph, DsSpinner, formatDisplayName } from '@altinn/altinn-components';
 import {
   useConfirmRequestMutation,
   useGetEnrichedDraftRequestQuery,
   useWithdrawRequestMutation,
   type EnrichedResourceRequest,
 } from '@/rtk/features/requestApi';
-import classes from './DraftRequestPage.module.css';
-import { PartyRepresentationProvider } from '../../common/PartyRepresentationContext/PartyRepresentationContext';
 import { useSearchParams } from 'react-router';
 import { redirectToChangeReporteeAndRedirect } from '@/resources/utils/changeReporteeUtils';
 import { getCookie } from '@/resources/Cookie/CookieMethods';
 import { RequestPageLayout } from '../../common/RequestPageLayout/RequestPageLayout';
-import { DraftRequestBody } from './DraftRequestBody';
+import { PartyRepresentationProvider } from '../../common/PartyRepresentationContext/PartyRepresentationContext';
 import { useDocumentTitle } from '@/resources/hooks/useDocumentTitle';
 import { useMultipleDraftRequests } from './useMultipleDraftRequests';
 import { MultipleDraftRequestsView, type BatchActionType } from './MultipleDraftRequestsView';
+import { DraftRequestHeader } from './DraftRequestHeader';
+import { RequestReceiptBody } from './RequestReceiptBody';
+import { SingleDraftRequestView } from './SingleDraftRequestView';
 
 export const DraftRequestPage = () => {
   const { t } = useTranslation();
@@ -33,13 +28,11 @@ export const DraftRequestPage = () => {
   const requestIds = searchParams.getAll('requestId');
   const isMultiMode = requestIds.length > 1;
   const [batchCompleteAction, setBatchCompleteAction] = useState<BatchActionType>(null);
-  let fromError = false;
 
   const onBatchComplete: (actionType: BatchActionType) => void = useCallback((actionType) => {
     setBatchCompleteAction(actionType);
   }, []);
 
-  // Single mode: use the first (only) ID
   const singleRequestId = requestIds[0] ?? '';
 
   const {
@@ -48,15 +41,11 @@ export const DraftRequestPage = () => {
     error: loadRequestError,
   } = useGetEnrichedDraftRequestQuery(
     { id: singleRequestId },
-    {
-      skip: !singleRequestId || isMultiMode,
-    },
+    { skip: !singleRequestId || isMultiMode },
   );
 
-  // Multi mode: fetch all request IDs
   const stableMultiIds = useMemo(
     () => (isMultiMode ? requestIds : []),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [isMultiMode, requestIds.join(',')],
   );
   const {
@@ -65,15 +54,12 @@ export const DraftRequestPage = () => {
     loadError: multiLoadError,
   } = useMultipleDraftRequests(stableMultiIds);
 
-  // For multi mode, derive a representative request for account/heading info
   const representativeRequest: EnrichedResourceRequest | undefined = isMultiMode
     ? multiRequests[0]
     : request;
 
-  if (isMultiMode && multiRequests.some((r) => r.from.id !== representativeRequest?.from.id)) {
-    // If the requests are from different users, we can't show them together - show an error instead
-    fromError = true;
-  }
+  const fromError =
+    isMultiMode && multiRequests.some((r) => r.from.id !== representativeRequest?.from.id);
 
   const [
     confirmRequest,
@@ -99,7 +85,6 @@ export const DraftRequestPage = () => {
   };
 
   useEffect(() => {
-    // If the request is for a different user than the one currently logged in, redirect to the correct reportee
     const fromId = representativeRequest?.from.id;
     if (fromId && fromId !== partyUuid) {
       redirectToChangeReporteeAndRedirect(fromId, window.location.href);
@@ -119,49 +104,61 @@ export const DraftRequestPage = () => {
     type: representativeRequest?.from.type === 'Person' ? 'person' : 'company',
   });
 
+  // Normalise the completed action across single and multi modes
+  const receiptAction: 'confirm' | 'withdraw' | null = isMultiMode
+    ? batchCompleteAction
+    : confirmResponse
+      ? 'confirm'
+      : withdrawResponse
+        ? 'withdraw'
+        : null;
+
   let heading: React.ReactNode = null;
   let body: React.ReactNode = null;
   let error: React.ReactNode = null;
 
-  const generateHeading = (headerTextKey: string) => (
-    <DraftRequestHeader
-      headerTextKey={headerTextKey}
-      toName={toName}
-    />
-  );
-  const generateReceiptBody = (bodyTextKey: string) => (
-    <RequestReceiptBody
-      bodyTextKey={bodyTextKey}
-      toName={toName}
-    />
-  );
+  if (receiptAction) {
+    const isConfirm = receiptAction === 'confirm';
+    heading = (
+      <DraftRequestHeader
+        headerTextKey={
+          isConfirm ? 'draft_request_page.request_approved' : 'draft_request_page.request_withdrawn'
+        }
+        toName={toName}
+      />
+    );
+    body = (
+      <RequestReceiptBody
+        bodyTextKey={
+          isConfirm
+            ? 'draft_request_page.request_approved_info'
+            : 'draft_request_page.request_withdrawn_info'
+        }
+        toName={toName}
+      />
+    );
+  } else if (!isInitialLoad && representativeRequest) {
+    heading = (
+      <>
+        <DraftRequestHeader
+          headerTextKey='draft_request_page.heading'
+          toName={toName}
+        />
+        <DsParagraph>
+          <Trans
+            i18nKey={
+              partyUuid === representativeRequest.from.id
+                ? 'draft_request_page.intro_person'
+                : 'draft_request_page.intro_company'
+            }
+            components={{ b: <strong /> }}
+            values={{ to_name: toName, from_name: fromName }}
+          />
+        </DsParagraph>
+      </>
+    );
 
-  if (isMultiMode) {
-    // Multi-request mode
-    if (batchCompleteAction === 'confirm') {
-      heading = generateHeading('draft_request_page.request_approved');
-      body = generateReceiptBody('draft_request_page.request_approved_info');
-    } else if (batchCompleteAction === 'withdraw') {
-      heading = generateHeading('draft_request_page.request_withdrawn');
-      body = generateReceiptBody('draft_request_page.request_withdrawn_info');
-    } else if (!isInitialLoad && multiRequests.length > 0) {
-      heading = (
-        <>
-          {generateHeading('draft_request_page.heading')}
-          <DsParagraph>
-            <Trans
-              i18nKey={
-                partyUuid === multiRequests[0].from.id
-                  ? 'draft_request_page.intro_person'
-                  : 'draft_request_page.intro_company'
-              }
-              components={{ b: <strong /> }}
-              values={{ to_name: toName, from_name: fromName }}
-            />
-          </DsParagraph>
-        </>
-      );
-
+    if (isMultiMode && multiRequests.length > 0) {
       body = (
         <PartyRepresentationProvider
           fromPartyUuid={partyUuid}
@@ -175,89 +172,40 @@ export const DraftRequestPage = () => {
           />
         </PartyRepresentationProvider>
       );
+    } else if (request) {
+      body = (
+        <SingleDraftRequestView
+          request={request}
+          fromName={fromName}
+          partyUuid={partyUuid}
+          onConfirmRequest={onConfirmRequest}
+          onWithdrawRequest={onWithdrawRequest}
+          isConfirmingRequest={isConfirmingRequest}
+          isWithdrawingRequest={isWithdrawingRequest}
+          confirmRequestError={confirmRequestError}
+          withdrawRequestError={withdrawRequestError}
+        />
+      );
     }
+  }
 
-    if (multiLoadError && fromError) {
+  if (isMultiMode) {
+    if (multiLoadError || fromError) {
       error = <DsAlert data-color='danger'>{t('draft_request_page.load_request_error')}</DsAlert>;
-      body = null; // Don't show the page if there was an error loading
+      body = null;
     }
   } else {
-    // Single-request mode
-    if (confirmResponse) {
-      heading = generateHeading('draft_request_page.request_approved');
-      body = generateReceiptBody('draft_request_page.request_approved_info');
-    } else if (withdrawResponse) {
-      heading = generateHeading('draft_request_page.request_withdrawn');
-      body = generateReceiptBody('draft_request_page.request_withdrawn_info');
-    } else if (request && !isInitialLoad) {
-      heading = (
-        <>
-          {generateHeading('draft_request_page.heading')}
-          <DsParagraph>
-            <Trans
-              i18nKey={
-                partyUuid === request.from.id
-                  ? 'draft_request_page.intro_person'
-                  : 'draft_request_page.intro_company'
-              }
-              components={{ b: <strong /> }}
-              values={{ to_name: toName, from_name: fromName }}
-            />
-          </DsParagraph>
-        </>
-      );
-
-      body = (
-        <>
-          {confirmRequestError && (
-            <DsAlert data-color='danger'>{t('draft_request_page.approve_request_error')}</DsAlert>
-          )}
-          {withdrawRequestError && (
-            <DsAlert data-color='danger'>{t('draft_request_page.withdraw_request_error')}</DsAlert>
-          )}
-          <PartyRepresentationProvider
-            fromPartyUuid={partyUuid}
-            actingPartyUuid={partyUuid}
-            toPartyUuid={''}
-          >
-            <DraftRequestBody
-              request={request}
-              fromName={fromName}
-            />
-          </PartyRepresentationProvider>
-          <div className={classes.buttonRow}>
-            <DsButton
-              variant='primary'
-              aria-disabled={isConfirmingRequest || isWithdrawingRequest}
-              loading={isConfirmingRequest}
-              onClick={onConfirmRequest}
-            >
-              {t('draft_request_page.confirm_request')}
-            </DsButton>
-            <DsButton
-              variant='primary'
-              aria-disabled={isConfirmingRequest || isWithdrawingRequest}
-              loading={isWithdrawingRequest}
-              onClick={onWithdrawRequest}
-            >
-              {t('draft_request_page.withdraw_request')}
-            </DsButton>
-          </div>
-        </>
-      );
-    }
-
     if (!singleRequestId) {
       error = <DsAlert data-color='warning'>{t('draft_request_page.missing_request_id')}</DsAlert>;
     } else if (loadRequestError) {
       error = <DsAlert data-color='danger'>{t('draft_request_page.load_request_error')}</DsAlert>;
-      body = null; // Don't show the page if there was an error loading
+      body = null;
     }
   }
 
   if (requestIds.length === 0) {
     error = <DsAlert data-color='warning'>{t('draft_request_page.missing_request_id')}</DsAlert>;
-    body = null; // Don't show the page if there was an error loading
+    body = null;
   }
 
   return (
@@ -271,48 +219,5 @@ export const DraftRequestPage = () => {
       heading={heading}
       body={body}
     />
-  );
-};
-
-interface DraftRequestHeaderProps {
-  headerTextKey: string;
-  toName: string;
-}
-
-const DraftRequestHeader = ({ headerTextKey, toName }: DraftRequestHeaderProps) => {
-  return (
-    <DsHeading
-      level={1}
-      data-size='md'
-    >
-      <Trans
-        i18nKey={headerTextKey}
-        components={{ b: <strong /> }}
-        values={{ to_name: toName }}
-      />
-    </DsHeading>
-  );
-};
-
-interface RequestReceiptBodyProps {
-  bodyTextKey: string;
-  toName: string;
-}
-const RequestReceiptBody = ({ bodyTextKey, toName }: RequestReceiptBodyProps) => {
-  const { t } = useTranslation();
-
-  return (
-    <>
-      <DsParagraph>
-        <Trans
-          i18nKey={bodyTextKey}
-          components={{ b: <strong /> }}
-          values={{ to_name: toName }}
-        />
-      </DsParagraph>
-      <DsParagraph className={classes.closeWindowInfo}>
-        {t('draft_request_page.close_window_info')}
-      </DsParagraph>
-    </>
   );
 };

--- a/src/features/amUI/requestPage/DraftRequestPage/DraftRequestPage.tsx
+++ b/src/features/amUI/requestPage/DraftRequestPage/DraftRequestPage.tsx
@@ -197,15 +197,11 @@ export const DraftRequestPage = () => {
   } else {
     if (!singleRequestId) {
       error = <DsAlert data-color='warning'>{t('draft_request_page.missing_request_id')}</DsAlert>;
+      body = null;
     } else if (loadRequestError) {
       error = <DsAlert data-color='danger'>{t('draft_request_page.load_request_error')}</DsAlert>;
       body = null;
     }
-  }
-
-  if (requestIds.length === 0) {
-    error = <DsAlert data-color='warning'>{t('draft_request_page.missing_request_id')}</DsAlert>;
-    body = null;
   }
 
   return (

--- a/src/features/amUI/requestPage/DraftRequestPage/DraftRequestPage.tsx
+++ b/src/features/amUI/requestPage/DraftRequestPage/DraftRequestPage.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-import { DsAlert, DsParagraph, DsSpinner, formatDisplayName } from '@altinn/altinn-components';
+import { DsAlert, DsParagraph, formatDisplayName } from '@altinn/altinn-components';
 import {
   useConfirmRequestMutation,
   useGetEnrichedDraftRequestQuery,

--- a/src/features/amUI/requestPage/DraftRequestPage/DraftRequestPage.tsx
+++ b/src/features/amUI/requestPage/DraftRequestPage/DraftRequestPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import {
   DsAlert,
@@ -11,6 +11,7 @@ import {
   useConfirmRequestMutation,
   useGetEnrichedDraftRequestQuery,
   useWithdrawRequestMutation,
+  type EnrichedResourceRequest,
 } from '@/rtk/features/requestApi';
 import classes from './DraftRequestPage.module.css';
 import { PartyRepresentationProvider } from '../../common/PartyRepresentationContext/PartyRepresentationContext';
@@ -20,6 +21,8 @@ import { getCookie } from '@/resources/Cookie/CookieMethods';
 import { RequestPageLayout } from '../../common/RequestPageLayout/RequestPageLayout';
 import { DraftRequestBody } from './DraftRequestBody';
 import { useDocumentTitle } from '@/resources/hooks/useDocumentTitle';
+import { useMultipleDraftRequests } from './useMultipleDraftRequests';
+import { MultipleDraftRequestsView, type BatchActionType } from './MultipleDraftRequestsView';
 
 export const DraftRequestPage = () => {
   const { t } = useTranslation();
@@ -27,18 +30,50 @@ export const DraftRequestPage = () => {
   useDocumentTitle(t('draft_request_page.page_title'));
   const [searchParams] = useSearchParams();
   const partyUuid = getCookie('AltinnPartyUuid') || '';
-  const requestId = searchParams.get('requestId') ?? '';
+  const requestIds = searchParams.getAll('requestId');
+  const isMultiMode = requestIds.length > 1;
+  const [batchCompleteAction, setBatchCompleteAction] = useState<BatchActionType>(null);
+  let fromError = false;
+
+  const onBatchComplete: (actionType: BatchActionType) => void = useCallback((actionType) => {
+    setBatchCompleteAction(actionType);
+  }, []);
+
+  // Single mode: use the first (only) ID
+  const singleRequestId = requestIds[0] ?? '';
 
   const {
     data: request,
     isLoading: isLoadingRequest,
     error: loadRequestError,
   } = useGetEnrichedDraftRequestQuery(
-    { id: requestId },
+    { id: singleRequestId },
     {
-      skip: !requestId,
+      skip: !singleRequestId || isMultiMode,
     },
   );
+
+  // Multi mode: fetch all request IDs
+  const stableMultiIds = useMemo(
+    () => (isMultiMode ? requestIds : []),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [isMultiMode, requestIds.join(',')],
+  );
+  const {
+    requests: multiRequests,
+    isLoading: isLoadingMultiRequests,
+    loadError: multiLoadError,
+  } = useMultipleDraftRequests(stableMultiIds);
+
+  // For multi mode, derive a representative request for account/heading info
+  const representativeRequest: EnrichedResourceRequest | undefined = isMultiMode
+    ? multiRequests[0]
+    : request;
+
+  if (isMultiMode && multiRequests.some((r) => r.from.id !== representativeRequest?.from.id)) {
+    // If the requests are from different users, we can't show them together - show an error instead
+    fromError = true;
+  }
 
   const [
     confirmRequest,
@@ -65,19 +100,23 @@ export const DraftRequestPage = () => {
 
   useEffect(() => {
     // If the request is for a different user than the one currently logged in, redirect to the correct reportee
-    if (request?.from.id && request.from.id !== partyUuid) {
-      redirectToChangeReporteeAndRedirect(request?.from.id, window.location.href);
+    const fromId = representativeRequest?.from.id;
+    if (fromId && fromId !== partyUuid) {
+      redirectToChangeReporteeAndRedirect(fromId, window.location.href);
     }
-  }, [request, partyUuid]);
+  }, [representativeRequest, partyUuid]);
 
-  const isInitialLoad = isLoadingRequest || !!(request && request.from.id !== partyUuid);
+  const isInitialLoad = isMultiMode
+    ? isLoadingMultiRequests || !!(multiRequests[0] && multiRequests[0].from.id !== partyUuid)
+    : isLoadingRequest || !!(request && request.from.id !== partyUuid);
+
   const toName = formatDisplayName({
-    fullName: request?.to.name ?? '',
-    type: request?.to.type === 'Person' ? 'person' : 'company',
+    fullName: representativeRequest?.to.name ?? '',
+    type: representativeRequest?.to.type === 'Person' ? 'person' : 'company',
   });
   const fromName = formatDisplayName({
-    fullName: request?.from.name ?? '',
-    type: request?.from.type === 'Person' ? 'person' : 'company',
+    fullName: representativeRequest?.from.name ?? '',
+    type: representativeRequest?.from.type === 'Person' ? 'person' : 'company',
   });
 
   let heading: React.ReactNode = null;
@@ -97,81 +136,135 @@ export const DraftRequestPage = () => {
     />
   );
 
-  if (confirmResponse) {
-    heading = generateHeading('draft_request_page.request_approved');
-    body = generateReceiptBody('draft_request_page.request_approved_info');
-  } else if (withdrawResponse) {
-    heading = generateHeading('draft_request_page.request_withdrawn');
-    body = generateReceiptBody('draft_request_page.request_withdrawn_info');
-  } else if (request && !isInitialLoad) {
-    heading = (
-      <>
-        {generateHeading('draft_request_page.heading')}
-        <DsParagraph>
-          <Trans
-            i18nKey={
-              partyUuid === request.from.id
-                ? 'draft_request_page.intro_person'
-                : 'draft_request_page.intro_company'
-            }
-            components={{ b: <strong /> }}
-            values={{ to_name: toName, from_name: fromName }}
-          />
-        </DsParagraph>
-      </>
-    );
+  if (isMultiMode) {
+    // Multi-request mode
+    if (batchCompleteAction === 'confirm') {
+      heading = generateHeading('draft_request_page.request_approved');
+      body = generateReceiptBody('draft_request_page.request_approved_info');
+    } else if (batchCompleteAction === 'withdraw') {
+      heading = generateHeading('draft_request_page.request_withdrawn');
+      body = generateReceiptBody('draft_request_page.request_withdrawn_info');
+    } else if (!isInitialLoad && multiRequests.length > 0) {
+      heading = (
+        <>
+          {generateHeading('draft_request_page.heading')}
+          <DsParagraph>
+            <Trans
+              i18nKey={
+                partyUuid === multiRequests[0].from.id
+                  ? 'draft_request_page.intro_person'
+                  : 'draft_request_page.intro_company'
+              }
+              components={{ b: <strong /> }}
+              values={{ to_name: toName, from_name: fromName }}
+            />
+          </DsParagraph>
+        </>
+      );
 
-    body = (
-      <>
+      body = (
         <PartyRepresentationProvider
           fromPartyUuid={partyUuid}
           actingPartyUuid={partyUuid}
           toPartyUuid={''}
         >
-          <DraftRequestBody
-            request={request}
+          <MultipleDraftRequestsView
+            requests={multiRequests}
             fromName={fromName}
+            onBatchComplete={onBatchComplete}
           />
         </PartyRepresentationProvider>
-        {confirmRequestError && (
-          <DsAlert data-color='danger'>{t('draft_request_page.approve_request_error')}</DsAlert>
-        )}
-        {withdrawRequestError && (
-          <DsAlert data-color='danger'>{t('draft_request_page.withdraw_request_error')}</DsAlert>
-        )}
-        <div className={classes.buttonRow}>
-          <DsButton
-            variant='primary'
-            aria-disabled={isConfirmingRequest || isWithdrawingRequest}
-            loading={isConfirmingRequest}
-            onClick={onConfirmRequest}
+      );
+    }
+
+    if (multiLoadError && fromError) {
+      error = <DsAlert data-color='danger'>{t('draft_request_page.load_request_error')}</DsAlert>;
+      body = null; // Don't show the page if there was an error loading
+    }
+  } else {
+    // Single-request mode
+    if (confirmResponse) {
+      heading = generateHeading('draft_request_page.request_approved');
+      body = generateReceiptBody('draft_request_page.request_approved_info');
+    } else if (withdrawResponse) {
+      heading = generateHeading('draft_request_page.request_withdrawn');
+      body = generateReceiptBody('draft_request_page.request_withdrawn_info');
+    } else if (request && !isInitialLoad) {
+      heading = (
+        <>
+          {generateHeading('draft_request_page.heading')}
+          <DsParagraph>
+            <Trans
+              i18nKey={
+                partyUuid === request.from.id
+                  ? 'draft_request_page.intro_person'
+                  : 'draft_request_page.intro_company'
+              }
+              components={{ b: <strong /> }}
+              values={{ to_name: toName, from_name: fromName }}
+            />
+          </DsParagraph>
+        </>
+      );
+
+      body = (
+        <>
+          {confirmRequestError && (
+            <DsAlert data-color='danger'>{t('draft_request_page.approve_request_error')}</DsAlert>
+          )}
+          {withdrawRequestError && (
+            <DsAlert data-color='danger'>{t('draft_request_page.withdraw_request_error')}</DsAlert>
+          )}
+          <PartyRepresentationProvider
+            fromPartyUuid={partyUuid}
+            actingPartyUuid={partyUuid}
+            toPartyUuid={''}
           >
-            {t('draft_request_page.confirm_request')}
-          </DsButton>
-          <DsButton
-            variant='primary'
-            aria-disabled={isConfirmingRequest || isWithdrawingRequest}
-            loading={isWithdrawingRequest}
-            onClick={onWithdrawRequest}
-          >
-            {t('draft_request_page.withdraw_request')}
-          </DsButton>
-        </div>
-      </>
-    );
+            <DraftRequestBody
+              request={request}
+              fromName={fromName}
+            />
+          </PartyRepresentationProvider>
+          <div className={classes.buttonRow}>
+            <DsButton
+              variant='primary'
+              aria-disabled={isConfirmingRequest || isWithdrawingRequest}
+              loading={isConfirmingRequest}
+              onClick={onConfirmRequest}
+            >
+              {t('draft_request_page.confirm_request')}
+            </DsButton>
+            <DsButton
+              variant='primary'
+              aria-disabled={isConfirmingRequest || isWithdrawingRequest}
+              loading={isWithdrawingRequest}
+              onClick={onWithdrawRequest}
+            >
+              {t('draft_request_page.withdraw_request')}
+            </DsButton>
+          </div>
+        </>
+      );
+    }
+
+    if (!singleRequestId) {
+      error = <DsAlert data-color='warning'>{t('draft_request_page.missing_request_id')}</DsAlert>;
+    } else if (loadRequestError) {
+      error = <DsAlert data-color='danger'>{t('draft_request_page.load_request_error')}</DsAlert>;
+      body = null; // Don't show the page if there was an error loading
+    }
   }
 
-  if (!requestId) {
+  if (requestIds.length === 0) {
     error = <DsAlert data-color='warning'>{t('draft_request_page.missing_request_id')}</DsAlert>;
-  } else if (loadRequestError) {
-    error = <DsAlert data-color='danger'>{t('draft_request_page.load_request_error')}</DsAlert>;
+    body = null; // Don't show the page if there was an error loading
   }
 
   return (
     <RequestPageLayout
       account={{
-        name: request?.from.name ?? '',
-        type: request?.from.type === 'Person' ? 'person' : 'company',
+        name: representativeRequest?.from.name ?? '',
+        type: representativeRequest?.from.type === 'Person' ? 'person' : 'company',
       }}
       error={error}
       isLoading={isInitialLoad}

--- a/src/features/amUI/requestPage/DraftRequestPage/MultipleDraftRequestsView.tsx
+++ b/src/features/amUI/requestPage/DraftRequestPage/MultipleDraftRequestsView.tsx
@@ -32,7 +32,6 @@ export const MultipleDraftRequestsView = ({
   const {
     confirmAll: rawConfirmAll,
     withdrawAll: rawWithdrawAll,
-    retryFailed: rawRetryFailed,
     isProcessing,
     actionType,
     failedRequests,
@@ -59,12 +58,6 @@ export const MultipleDraftRequestsView = ({
     if (isProcessing) return;
     const succeeded = await rawWithdrawAll();
     if (succeeded) onBatchComplete('withdraw');
-  };
-
-  const retryFailed = async () => {
-    if (isProcessing) return;
-    const succeeded = await rawRetryFailed();
-    if (succeeded) onBatchComplete(actionType);
   };
 
   if (selectedRequest) {
@@ -137,7 +130,7 @@ export const MultipleDraftRequestsView = ({
           variant='primary'
           aria-disabled={isProcessing}
           loading={isProcessing && actionType === 'confirm'}
-          onClick={failedRequests.length > 0 ? retryFailed : confirmAll}
+          onClick={confirmAll}
         >
           {t('draft_request_page.confirm_request')}
         </DsButton>
@@ -145,7 +138,7 @@ export const MultipleDraftRequestsView = ({
           variant='primary'
           aria-disabled={isProcessing}
           loading={isProcessing && actionType === 'withdraw'}
-          onClick={failedRequests.length > 0 ? retryFailed : withdrawAll}
+          onClick={withdrawAll}
         >
           {t('draft_request_page.withdraw_request')}
         </DsButton>

--- a/src/features/amUI/requestPage/DraftRequestPage/MultipleDraftRequestsView.tsx
+++ b/src/features/amUI/requestPage/DraftRequestPage/MultipleDraftRequestsView.tsx
@@ -50,16 +50,19 @@ export const MultipleDraftRequestsView = ({
   };
 
   const confirmAll = async () => {
+    if (isProcessing) return;
     const succeeded = await rawConfirmAll();
     if (succeeded) onBatchComplete('confirm');
   };
 
   const withdrawAll = async () => {
+    if (isProcessing) return;
     const succeeded = await rawWithdrawAll();
     if (succeeded) onBatchComplete('withdraw');
   };
 
   const retryFailed = async () => {
+    if (isProcessing) return;
     const succeeded = await rawRetryFailed();
     if (succeeded) onBatchComplete(actionType);
   };
@@ -86,13 +89,15 @@ export const MultipleDraftRequestsView = ({
 
   return (
     <div className={classes.multipleDraftRequests}>
-      {failedRequests.length > 0 && (
-        <DsAlert data-color='danger'>
-          {t('draft_request_page.batch_partial_error', {
-            resources: failedRequests.map((f) => f.resourceName).join(', '),
-          })}
-        </DsAlert>
-      )}
+      <div aria-live='polite'>
+        {failedRequests.length > 0 && (
+          <DsAlert data-color='danger'>
+            {t('draft_request_page.batch_partial_error', {
+              resources: failedRequests.map((f) => f.resourceName).join(', '),
+            })}
+          </DsAlert>
+        )}
+      </div>
       <DsHeading
         data-size='sm'
         level={2}
@@ -114,7 +119,9 @@ export const MultipleDraftRequestsView = ({
         showDetails={false}
         resources={
           failedRequests.length > 0
-            ? resources.filter((r) => failedRequests.some((f) => f.resourceName === r.title))
+            ? resources.filter((r) =>
+                failedRequests.some((f) => f.request.resourceId === r.identifier),
+              )
             : resources
         }
         onSelect={handleSelect}

--- a/src/features/amUI/requestPage/DraftRequestPage/MultipleDraftRequestsView.tsx
+++ b/src/features/amUI/requestPage/DraftRequestPage/MultipleDraftRequestsView.tsx
@@ -11,7 +11,6 @@ import { useBatchRequestAction } from './useBatchRequestAction';
 
 import classes from './DraftRequestPage.module.css';
 import { usePartyRepresentation } from '../../common/PartyRepresentationContext/PartyRepresentationContext';
-import common from 'mocha/lib/interfaces/common';
 
 export type BatchActionType = 'confirm' | 'withdraw' | null;
 

--- a/src/features/amUI/requestPage/DraftRequestPage/MultipleDraftRequestsView.tsx
+++ b/src/features/amUI/requestPage/DraftRequestPage/MultipleDraftRequestsView.tsx
@@ -1,0 +1,149 @@
+import React, { useState } from 'react';
+import { Trans, useTranslation } from 'react-i18next';
+import { DsAlert, DsButton, DsHeading } from '@altinn/altinn-components';
+import { ArrowLeftIcon, ChevronRightIcon } from '@navikt/aksel-icons';
+
+import type { EnrichedResourceRequest } from '@/rtk/features/requestApi';
+import { useAutoFocusRef } from '@/resources/hooks/useAutoFocusRef';
+import { ResourceList } from '../../common/ResourceList/ResourceList';
+import { DraftRequestBody } from './DraftRequestBody';
+import { useBatchRequestAction } from './useBatchRequestAction';
+
+import classes from './DraftRequestPage.module.css';
+import { usePartyRepresentation } from '../../common/PartyRepresentationContext/PartyRepresentationContext';
+import common from 'mocha/lib/interfaces/common';
+
+export type BatchActionType = 'confirm' | 'withdraw' | null;
+
+interface MultipleDraftRequestsViewProps {
+  requests: EnrichedResourceRequest[];
+  fromName: string;
+  onBatchComplete: (actionType: BatchActionType) => void;
+}
+
+export const MultipleDraftRequestsView = ({
+  requests,
+  fromName,
+  onBatchComplete,
+}: MultipleDraftRequestsViewProps) => {
+  const { t } = useTranslation();
+  const [selectedRequest, setSelectedRequest] = useState<EnrichedResourceRequest | null>(null);
+  const { selfParty } = usePartyRepresentation();
+
+  const {
+    confirmAll: rawConfirmAll,
+    withdrawAll: rawWithdrawAll,
+    retryFailed: rawRetryFailed,
+    isProcessing,
+    actionType,
+    failedRequests,
+  } = useBatchRequestAction(requests);
+
+  const backButtonRef = useAutoFocusRef<HTMLButtonElement>();
+
+  const resources = requests.map((r) => r.resource);
+
+  const handleSelect = (resource: (typeof resources)[number]) => {
+    const match = requests.find((r) => r.resource.identifier === resource.identifier);
+    if (match) {
+      setSelectedRequest(match);
+    }
+  };
+
+  const confirmAll = async () => {
+    const succeeded = await rawConfirmAll();
+    if (succeeded) onBatchComplete('confirm');
+  };
+
+  const withdrawAll = async () => {
+    const succeeded = await rawWithdrawAll();
+    if (succeeded) onBatchComplete('withdraw');
+  };
+
+  const retryFailed = async () => {
+    const succeeded = await rawRetryFailed();
+    if (succeeded) onBatchComplete(actionType);
+  };
+
+  if (selectedRequest) {
+    return (
+      <>
+        <DsButton
+          ref={backButtonRef}
+          variant='tertiary'
+          className={classes.backButton}
+          onClick={() => setSelectedRequest(null)}
+        >
+          <ArrowLeftIcon />
+          {t('common.back')}
+        </DsButton>
+        <DraftRequestBody
+          request={selectedRequest}
+          fromName={fromName}
+        />
+      </>
+    );
+  }
+
+  return (
+    <div className={classes.multipleDraftRequests}>
+      {failedRequests.length > 0 && (
+        <DsAlert data-color='danger'>
+          {t('draft_request_page.batch_partial_error', {
+            resources: failedRequests.map((f) => f.resourceName).join(', '),
+          })}
+        </DsAlert>
+      )}
+      <DsHeading
+        data-size='sm'
+        level={2}
+        id='multiple-services-title'
+      >
+        <Trans
+          i18nKey={'draft_request_page.multiple_services_title'}
+          components={{ b: <strong /> }}
+          values={{
+            name:
+              requests[0].from.id === selfParty?.partyUuid ? t('common.you_uppercase') : fromName,
+          }}
+        />
+      </DsHeading>
+      <ResourceList
+        size='xs'
+        border='dotted'
+        enableSearch={false}
+        showDetails={false}
+        resources={
+          failedRequests.length > 0
+            ? resources.filter((r) => failedRequests.some((f) => f.resourceName === r.title))
+            : resources
+        }
+        onSelect={handleSelect}
+        ariaLabelledBy='multiple-services-title'
+        renderControls={(resource) => (
+          <div className={classes.seeDetails}>
+            {t('common.see_details')} <ChevronRightIcon fontSize={'1.2rem'} />
+          </div>
+        )}
+      />
+      <div className={classes.buttonRow}>
+        <DsButton
+          variant='primary'
+          aria-disabled={isProcessing}
+          loading={isProcessing && actionType === 'confirm'}
+          onClick={failedRequests.length > 0 ? retryFailed : confirmAll}
+        >
+          {t('draft_request_page.confirm_request')}
+        </DsButton>
+        <DsButton
+          variant='primary'
+          aria-disabled={isProcessing}
+          loading={isProcessing && actionType === 'withdraw'}
+          onClick={failedRequests.length > 0 ? retryFailed : withdrawAll}
+        >
+          {t('draft_request_page.withdraw_request')}
+        </DsButton>
+      </div>
+    </div>
+  );
+};

--- a/src/features/amUI/requestPage/DraftRequestPage/RequestReceiptBody.tsx
+++ b/src/features/amUI/requestPage/DraftRequestPage/RequestReceiptBody.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Trans, useTranslation } from 'react-i18next';
+import { DsParagraph } from '@altinn/altinn-components';
+import classes from './DraftRequestPage.module.css';
+
+interface RequestReceiptBodyProps {
+  bodyTextKey: string;
+  toName: string;
+}
+
+export const RequestReceiptBody = ({ bodyTextKey, toName }: RequestReceiptBodyProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <DsParagraph>
+        <Trans
+          i18nKey={bodyTextKey}
+          components={{ b: <strong /> }}
+          values={{ to_name: toName }}
+        />
+      </DsParagraph>
+      <DsParagraph className={classes.closeWindowInfo}>
+        {t('draft_request_page.close_window_info')}
+      </DsParagraph>
+    </>
+  );
+};

--- a/src/features/amUI/requestPage/DraftRequestPage/SingleDraftRequestView.tsx
+++ b/src/features/amUI/requestPage/DraftRequestPage/SingleDraftRequestView.tsx
@@ -34,12 +34,14 @@ export const SingleDraftRequestView = ({
 
   return (
     <>
-      {!!confirmRequestError && (
-        <DsAlert data-color='danger'>{t('draft_request_page.approve_request_error')}</DsAlert>
-      )}
-      {!!withdrawRequestError && (
-        <DsAlert data-color='danger'>{t('draft_request_page.withdraw_request_error')}</DsAlert>
-      )}
+      <div aria-live='polite'>
+        {!!confirmRequestError && (
+          <DsAlert data-color='danger'>{t('draft_request_page.approve_request_error')}</DsAlert>
+        )}
+        {!!withdrawRequestError && (
+          <DsAlert data-color='danger'>{t('draft_request_page.withdraw_request_error')}</DsAlert>
+        )}
+      </div>
       <PartyRepresentationProvider
         fromPartyUuid={partyUuid}
         actingPartyUuid={partyUuid}

--- a/src/features/amUI/requestPage/DraftRequestPage/SingleDraftRequestView.tsx
+++ b/src/features/amUI/requestPage/DraftRequestPage/SingleDraftRequestView.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { DsAlert, DsButton } from '@altinn/altinn-components';
+import type { EnrichedResourceRequest } from '@/rtk/features/requestApi';
+import { PartyRepresentationProvider } from '../../common/PartyRepresentationContext/PartyRepresentationContext';
+import { DraftRequestBody } from './DraftRequestBody';
+import classes from './DraftRequestPage.module.css';
+
+interface SingleDraftRequestViewProps {
+  request: EnrichedResourceRequest;
+  fromName: string;
+  partyUuid: string;
+  onConfirmRequest: () => void;
+  onWithdrawRequest: () => void;
+  isConfirmingRequest: boolean;
+  isWithdrawingRequest: boolean;
+  confirmRequestError: unknown;
+  withdrawRequestError: unknown;
+}
+
+export const SingleDraftRequestView = ({
+  request,
+  fromName,
+  partyUuid,
+  onConfirmRequest,
+  onWithdrawRequest,
+  isConfirmingRequest,
+  isWithdrawingRequest,
+  confirmRequestError,
+  withdrawRequestError,
+}: SingleDraftRequestViewProps) => {
+  const { t } = useTranslation();
+  const isActionButtonDisabled = isConfirmingRequest || isWithdrawingRequest;
+
+  return (
+    <>
+      {!!confirmRequestError && (
+        <DsAlert data-color='danger'>{t('draft_request_page.approve_request_error')}</DsAlert>
+      )}
+      {!!withdrawRequestError && (
+        <DsAlert data-color='danger'>{t('draft_request_page.withdraw_request_error')}</DsAlert>
+      )}
+      <PartyRepresentationProvider
+        fromPartyUuid={partyUuid}
+        actingPartyUuid={partyUuid}
+        toPartyUuid={''}
+      >
+        <DraftRequestBody
+          request={request}
+          fromName={fromName}
+        />
+      </PartyRepresentationProvider>
+      <div className={classes.buttonRow}>
+        <DsButton
+          variant='primary'
+          aria-disabled={isActionButtonDisabled}
+          loading={isConfirmingRequest}
+          onClick={onConfirmRequest}
+        >
+          {t('draft_request_page.confirm_request')}
+        </DsButton>
+        <DsButton
+          variant='primary'
+          aria-disabled={isActionButtonDisabled}
+          loading={isWithdrawingRequest}
+          onClick={onWithdrawRequest}
+        >
+          {t('draft_request_page.withdraw_request')}
+        </DsButton>
+      </div>
+    </>
+  );
+};

--- a/src/features/amUI/requestPage/DraftRequestPage/useBatchRequestAction.ts
+++ b/src/features/amUI/requestPage/DraftRequestPage/useBatchRequestAction.ts
@@ -69,20 +69,26 @@ export const useBatchRequestAction = (
       if (failed.length > 0) {
         // Refetch failed requests to check if they are still in Draft status
         const refetchResults = await Promise.allSettled(
-          failed.map((f) =>
-            dispatch(
+          failed.map(async (f) => {
+            const queryResult = dispatch(
               requestApi.endpoints.getEnrichedDraftRequest.initiate(
                 { id: f.request.id },
                 { forceRefetch: true },
               ),
-            ).unwrap(),
-          ),
+            );
+
+            try {
+              return await queryResult.unwrap();
+            } finally {
+              queryResult.unsubscribe();
+            }
+          }),
         );
 
         const stillFailedRequests: FailedRequest[] = [];
         refetchResults.forEach((result, index) => {
-          // Keep as failed if: refetch also failed, or the request is still in Draft
-          if (result.status === 'rejected' || result.value.status === 'Draft') {
+          // Keep as failed if: refetch succeeded and the request is still in Draft
+          if (result.status === 'fulfilled' && result.value.status === 'Draft') {
             stillFailedRequests.push(failed[index]);
           }
         });

--- a/src/features/amUI/requestPage/DraftRequestPage/useBatchRequestAction.ts
+++ b/src/features/amUI/requestPage/DraftRequestPage/useBatchRequestAction.ts
@@ -1,0 +1,133 @@
+import { useState, useCallback, useRef } from 'react';
+import {
+  useConfirmRequestMutation,
+  useWithdrawRequestMutation,
+  type EnrichedResourceRequest,
+  requestApi,
+} from '@/rtk/features/requestApi';
+import { useAppDispatch } from '@/rtk/app/hooks';
+
+export interface FailedRequest {
+  request: EnrichedResourceRequest;
+  resourceName: string;
+}
+
+interface UseBatchRequestActionResult {
+  confirmAll: () => Promise<boolean>;
+  withdrawAll: () => Promise<boolean>;
+  retryFailed: () => Promise<boolean>;
+  isProcessing: boolean;
+  allSucceeded: boolean;
+  actionType: 'confirm' | 'withdraw' | null;
+  failedRequests: FailedRequest[];
+}
+
+export const useBatchRequestAction = (
+  requests: EnrichedResourceRequest[],
+): UseBatchRequestActionResult => {
+  const [confirmRequest] = useConfirmRequestMutation();
+  const [withdrawRequest] = useWithdrawRequestMutation();
+  const dispatch = useAppDispatch();
+
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [allSucceeded, setAllSucceeded] = useState(false);
+  const [actionType, setActionType] = useState<'confirm' | 'withdraw' | null>(null);
+  const [failedRequests, setFailedRequests] = useState<FailedRequest[]>([]);
+
+  const lastActionRef = useRef<'confirm' | 'withdraw' | null>(null);
+
+  const performAction = useCallback(
+    async (
+      targetRequests: EnrichedResourceRequest[],
+      action: 'confirm' | 'withdraw',
+    ): Promise<boolean> => {
+      setIsProcessing(true);
+      setFailedRequests([]);
+      setAllSucceeded(false);
+      setActionType(action);
+      lastActionRef.current = action;
+
+      const performMutation = action === 'confirm' ? confirmRequest : withdrawRequest;
+
+      const results = await Promise.allSettled(
+        targetRequests.map((r) => performMutation({ party: r.from.id, id: r.id }).unwrap()),
+      );
+
+      const failed: FailedRequest[] = [];
+      results.forEach((result, index) => {
+        if (result.status === 'rejected') {
+          const req = targetRequests[index];
+          failed.push({
+            request: req,
+            resourceName: req.resource.title,
+          });
+        }
+      });
+
+      let succeeded = false;
+
+      if (failed.length > 0) {
+        // Refetch failed requests to check if they are still in Draft status
+        const refetchResults = await Promise.allSettled(
+          failed.map((f) =>
+            dispatch(
+              requestApi.endpoints.getEnrichedDraftRequest.initiate(
+                { id: f.request.id },
+                { forceRefetch: true },
+              ),
+            ).unwrap(),
+          ),
+        );
+
+        const stillFailedRequests: FailedRequest[] = [];
+        refetchResults.forEach((result, index) => {
+          // Keep as failed if: refetch also failed, or the request is still in Draft
+          if (result.status === 'rejected' || result.value.status === 'Draft') {
+            stillFailedRequests.push(failed[index]);
+          }
+        });
+
+        setFailedRequests(stillFailedRequests);
+        succeeded = stillFailedRequests.length === 0;
+        setAllSucceeded(succeeded);
+      } else {
+        succeeded = true;
+        setAllSucceeded(true);
+      }
+
+      setIsProcessing(false);
+      return succeeded;
+    },
+    [confirmRequest, withdrawRequest, dispatch],
+  );
+
+  const confirmAll = useCallback(
+    () => performAction(requests, 'confirm'),
+    [performAction, requests],
+  );
+
+  const withdrawAll = useCallback(
+    () => performAction(requests, 'withdraw'),
+    [performAction, requests],
+  );
+
+  const retryFailed = useCallback(async () => {
+    if (failedRequests.length > 0 && lastActionRef.current) {
+      return performAction(
+        failedRequests.map((f) => f.request),
+        lastActionRef.current,
+      );
+    }
+    return false;
+  }, [failedRequests, performAction]);
+
+  return {
+    confirmAll,
+    withdrawAll,
+    retryFailed,
+    isProcessing,
+    allSucceeded,
+    actionType,
+    failedRequests,
+  };
+};

--- a/src/features/amUI/requestPage/DraftRequestPage/useBatchRequestAction.ts
+++ b/src/features/amUI/requestPage/DraftRequestPage/useBatchRequestAction.ts
@@ -15,7 +15,6 @@ export interface FailedRequest {
 interface UseBatchRequestActionResult {
   confirmAll: () => Promise<boolean>;
   withdrawAll: () => Promise<boolean>;
-  retryFailed: () => Promise<boolean>;
   isProcessing: boolean;
   allSucceeded: boolean;
   actionType: 'confirm' | 'withdraw' | null;
@@ -117,20 +116,9 @@ export const useBatchRequestAction = (
     [performAction, requests],
   );
 
-  const retryFailed = useCallback(async () => {
-    if (failedRequests.length > 0 && lastActionRef.current) {
-      return performAction(
-        failedRequests.map((f) => f.request),
-        lastActionRef.current,
-      );
-    }
-    return false;
-  }, [failedRequests, performAction]);
-
   return {
     confirmAll,
     withdrawAll,
-    retryFailed,
     isProcessing,
     allSucceeded,
     actionType,

--- a/src/features/amUI/requestPage/DraftRequestPage/useMultipleDraftRequests.ts
+++ b/src/features/amUI/requestPage/DraftRequestPage/useMultipleDraftRequests.ts
@@ -1,0 +1,42 @@
+import { useEffect, useMemo, useRef } from 'react';
+import { useAppDispatch, useAppSelector } from '@/rtk/app/hooks';
+import { requestApi, type EnrichedResourceRequest } from '@/rtk/features/requestApi';
+
+interface UseMultipleDraftRequestsResult {
+  requests: EnrichedResourceRequest[];
+  isLoading: boolean;
+  loadError: boolean;
+}
+
+export const useMultipleDraftRequests = (ids: string[]): UseMultipleDraftRequestsResult => {
+  const dispatch = useAppDispatch();
+  const subscriptionsRef = useRef<(() => void)[]>([]);
+
+  useEffect(() => {
+    const subscriptions = ids.map((id) =>
+      dispatch(requestApi.endpoints.getEnrichedDraftRequest.initiate({ id })),
+    );
+    subscriptionsRef.current = subscriptions.map((sub) => sub.unsubscribe);
+
+    return () => {
+      subscriptionsRef.current.forEach((unsub) => unsub());
+      subscriptionsRef.current = [];
+    };
+  }, [dispatch, ids]);
+
+  const selectors = useMemo(
+    () => ids.map((id) => requestApi.endpoints.getEnrichedDraftRequest.select({ id })),
+    [ids],
+  );
+
+  const results = useAppSelector((state) => selectors.map((sel) => sel(state)));
+
+  const requests = results
+    .map((r) => r.data)
+    .filter((d): d is EnrichedResourceRequest => d !== undefined);
+
+  const isLoading = results.some((r) => (r.isLoading || r.isUninitialized) && !r.data);
+  const loadError = results.every((r) => r.isError && !r.data); // Drop invalid IDs silently, but show error if all are invalid or fail to load
+
+  return { requests, isLoading, loadError };
+};

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -99,7 +99,8 @@
     "none": "no",
     "digdir": "The Norwegian Digitalisation Agency",
     "skiplink": "Skip to main content",
-    "no_access_to_page": "You do not have access to this page for the selected actor"
+    "no_access_to_page": "You do not have access to this page for the selected actor",
+    "see_details": "See details"
   },
   "beta_banner": {
     "info": "This is a beta version of the new access management pages in Altinn.",
@@ -1093,6 +1094,8 @@
     "request_withdrawn": "The request has been rejected",
     "request_withdrawn_info": "You have rejected the request and will therefore not receive power of attorney for <strong>{{to_name}}</strong>.",
     "close_window_info": "You can now close this window.",
-    "missing_request_id": "Cannot load request: requestId-parameter is not set in url"
+    "missing_request_id": "Cannot load request: requestId-parameter is not set in url",
+    "batch_partial_error": "Could not process the following resources: {{resources}}. Please try again.",
+    "multiple_services_title": "<strong>{{name}}</strong> request the following services:"
   }
 }

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -96,7 +96,8 @@
     "none": "ingen",
     "digdir": "Digitaliseringsdirektoratet",
     "skiplink": "Hopp til hovedinnholdet",
-    "no_access_to_page": "Du har ikke tilgang til denne siden for valgt aktør"
+    "no_access_to_page": "Du har ikke tilgang til denne siden for valgt aktør",
+    "see_details": "Se detaljer"
   },
   "beta_banner": {
     "info": "Du ser nå på en betaversjon av de nye sidene for tilgangsstyring i Altinn.",
@@ -1090,6 +1091,8 @@
     "request_withdrawn": "Forespørselen er avvist",
     "request_withdrawn_info": "Du har avvist forespørselen og vil dermed ikke få fullmakt til <strong>{{to_name}}</strong>.",
     "close_window_info": "Du kan nå lukke dette vinduet.",
-    "missing_request_id": "Kan ikke laste forespørsel: requestId-parameter er ikke satt i url"
+    "missing_request_id": "Kan ikke laste forespørsel: requestId-parameter er ikke satt i url",
+    "batch_partial_error": "Kunne ikke behandle følgende ressurser: {{resources}}. Vennligst prøv igjen.",
+    "multiple_services_title": "<strong>{{name}}</strong> ber om følgende tjenester:"
   }
 }

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -96,7 +96,8 @@
     "none": "ingen",
     "digdir": "Digitaliseringsdirektoratet",
     "skiplink": "Hopp til hovudinnhaldet",
-    "no_access_to_page": "Du har ikkje tilgang til denne sida for vald aktør"
+    "no_access_to_page": "Du har ikkje tilgang til denne sida for vald aktør",
+    "see_details": "Sjå detaljar"
   },
   "beta_banner": {
     "info": "Du ser no på ein betaversjon av dei nye sidene for tilgangsstyring i Altinn.",
@@ -1090,6 +1091,8 @@
     "request_withdrawn": "Førespurnaden er avslått",
     "request_withdrawn_info": "Du har avslått førespurnaden og vil dermed ikkje få fullmakt til <strong>{{to_name}}</strong>.",
     "close_window_info": "Du kan no lukke dette vinduet.",
-    "missing_request_id": "Kan ikkje laste førespurnaden: requestId-parameter er ikkje sett i url"
+    "missing_request_id": "Kan ikkje laste førespurnaden: requestId-parameter er ikkje sett i url",
+    "batch_partial_error": "Kunne ikkje behandle følgjande ressursar: {{resources}}. Ver venleg og prøv igjen.",
+    "multiple_services_title": "<strong>{{name}}</strong> ber om følgjande tenester:"
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<img width="1396" height="712" alt="image" src="https://github.com/user-attachments/assets/6e1b7d9c-4ac6-4ddd-bd50-ea6a1fd815e8" />

## Description
<!--- Describe your changes in detail -->
This PR adds functionality for confirming or withdrawing multiple resource requests (in draft mode) at the same time.
The UI is the same as before for when confirming a single request, but will go into `multiMode` when more than one requestId is provided in the UI. The user can thus batch-confirm or batch-withdraw all given requests, but cannot confirm or withdraw singular requests independently of another. This is done to allow the external sender (service owner that created the draft request) to craft the full multi-resource requirements for their needs without having to account for only partial confirmations in our UI.

Error handling for partial failing in the batch mutations is handled by allowing the user to retry the failing resource requests.
Invalid requestIDs (or IDs that are no longer in draft) are ignored.

### How to test

This can be tested by using this url: [https://am.ui.at22.altinn.cloud/accessmanagement/ui/requests/resource?requestId=019dd36b[…]161105568d&requestId=019dd36c-04b4-7283-bad0-cda32b47dc19](https://am.ui.at22.altinn.cloud/accessmanagement/ui/requests/resource?requestId=019dd36b-53da-7c18-b636-bd161105568d&requestId=019dd36c-04b4-7283-bad0-cda32b47dc19) and logging in with the ssn `11870749254`. All other users should fail when trying to access this url.

### Example screenshots

The display of multiple requests: 
<img width="1396" height="712" alt="image" src="https://github.com/user-attachments/assets/6e1b7d9c-4ac6-4ddd-bd50-ea6a1fd815e8" />

When viewing details of a single resource:
<img width="1167" height="635" alt="image" src="https://github.com/user-attachments/assets/3054bffd-c783-4738-bc83-f0c44ea51a4f" />

After rejecting/withdrawing:
<img width="1053" height="513" alt="image" src="https://github.com/user-attachments/assets/3509e4b7-9c99-4ab6-9ee8-ea8dd8ad6a55" />

If one or more of the mutations fail:
<img width="1381" height="785" alt="image" src="https://github.com/user-attachments/assets/07ec5d3c-c0b1-4aa8-8305-1d506eee45da" />


## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/2886

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-request batch support with confirm/withdraw/retry and distinct single vs. multi views.
  * New UI pieces: draft request header, receipt body, single-request and multiple-request views, and batch actions.

* **Style**
  * Added utility styles for back button, multi-request layout, and "see details" alignment.

* **Localization**
  * Added English, Bokmål, and Nynorsk strings for multi-request headings, partial-batch errors, and "see details".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->