### PR TITLE
Display request heading in modal when requesting package

### DIFF
--- a/src/features/amUI/common/DelegationModal/AccessPackages/PackageSearch.tsx
+++ b/src/features/amUI/common/DelegationModal/AccessPackages/PackageSearch.tsx
@@ -6,7 +6,7 @@ import type { Party } from '@/rtk/features/lookupApi';
 import { AccessPackageList } from '@/features/amUI/common/AccessPackageList/AccessPackageList';
 
 import { useDelegationModalContext } from '../DelegationModalContext';
-import type { DelegationAction } from '../EditModal';
+import { DelegationAction } from '../EditModal';
 
 import classes from './PackageSearch.module.css';
 import { PartyType } from '@/rtk/features/userInfoApi';
@@ -36,7 +36,11 @@ export const PackageSearch = ({
           data-size='sm'
         >
           <Trans
-            i18nKey='delegation_modal.give_package_to_name'
+            i18nKey={
+              availableActions?.includes(DelegationAction.REQUEST)
+                ? 'delegation_modal.request_package'
+                : 'delegation_modal.give_package_to_name'
+            }
             values={{
               name: formatDisplayName({
                 fullName: toParty.name,

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -468,8 +468,9 @@
     "heading_subtitle": "Power of attorney given to {{name}}"
   },
   "delegation_modal": {
-    "request_service": "Which service do you want to request power of attorney for?",
+    "request_service": "Which service do you need?",
     "give_service_to_name": "Give <strong>{{name}}</strong> power of attorney for new service",
+    "request_package": "Which access package do you need?",
     "give_package_to_name": "Give <strong>{{name}}</strong> power of attorney for new access package",
     "name_will_receive": "<strong>{{name}}</strong> will receive:",
     "name_has_the_following": "<strong>{{name}}</strong> has the following:",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -465,8 +465,9 @@
     "heading_subtitle": "fullmakter gitt til {{name}}"
   },
   "delegation_modal": {
-    "request_service": "Hvilken tjeneste ønsker du fullmakt til?",
+    "request_service": "Hvilken tjeneste vil du be om?",
     "give_service_to_name": "Gi <strong>{{name}}</strong> fullmakt til ny tjeneste",
+    "request_package": "Hvilken tilgangspakke vil du be om?",
     "give_package_to_name": "Gi <strong>{{name}}</strong> fullmakt til ny tilgangspakke",
     "name_will_receive": "<strong>{{name}}</strong> vil få:",
     "name_has_the_following": "<strong>{{name}}</strong> har:",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -465,8 +465,9 @@
     "heading_subtitle": "fullmakter gitt til {{name}}"
   },
   "delegation_modal": {
-    "request_service": "Kva for enkelttenester ønsker du fullmakt til?",
+    "request_service": "Kva for teneste vil du be om?",
     "give_service_to_name": "Gi <strong>{{name}}</strong> fullmakt til ny teneste",
+    "request_package": "Kva for tilgangspakke vil du be om?",
     "give_package_to_name": "Gi <strong>{{name}}</strong> fullmakt til ny tilgangspakke",
     "name_will_receive": "<strong>{{name}}</strong> vil få:",
     "name_has_the_following": "<strong>{{name}}</strong> har:",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<img width="1327" height="792" alt="image" src="https://github.com/user-attachments/assets/6dacbe86-5f8f-4532-837e-bf714f0896b3" />

## Description
<!--- Describe your changes in detail -->

@TheTechArch discovered a bug where we displayed the delegation heading when requesting new packages. This has now been fixed and we display a more suitable heading when in requesting mode.

Related issue: https://github.com/Altinn/altinn-authorization-tmp/issues/2963

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Delegation modal heading now dynamically adapts based on user action—displays context-appropriate text for package requests versus grants
  * Updated delegation workflow messaging across English and Norwegian (Bokmål and Nynorsk) for improved clarity in the access package selection flow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->