### PR TITLE
fix: update menu to be more like AF menu

### DIFF
--- a/src/features/amUI/common/PageLayoutWrapper/PageLayoutWrapper.tsx
+++ b/src/features/amUI/common/PageLayoutWrapper/PageLayoutWrapper.tsx
@@ -37,7 +37,7 @@ export const PageLayoutWrapper = ({
 
   const { header, languageCode } = useHeader({ openAccountMenu, hideSidebarItems: hideSidebar });
   const footer = useFooter();
-  const { sidebarItems } = useSidebarItems({ isSmall: false });
+  const { sidebarItems, shortcutsMenuItem } = useSidebarItems({ isSmall: false });
 
   return (
     <RootProvider languageCode={languageCode as LanguageCode}>
@@ -61,7 +61,7 @@ export const PageLayoutWrapper = ({
             : {
                 menu: {
                   groups: menuGroups,
-                  items: sidebarItems,
+                  items: [...sidebarItems, ...shortcutsMenuItem],
                 },
                 footer: (
                   <Badge

--- a/src/features/amUI/common/PageLayoutWrapper/useGlobalMenu.tsx
+++ b/src/features/amUI/common/PageLayoutWrapper/useGlobalMenu.tsx
@@ -61,11 +61,11 @@ export const useGlobalMenu = ({
   const { data: reportee } = useGetReporteeQuery();
   const { data: userinfo } = useGetUserProfileQuery();
 
-  const { sidebarItems } = useSidebarItems({ isSmall: true });
+  const { sidebarItems, shortcutsMenuItem } = useSidebarItems({ isSmall: true });
 
   const headerLinks: MenuItemProps[] = [
     {
-      groupId: '1',
+      groupId: 'global',
       icon: { svgElement: InboxFillIcon, theme: 'surface' },
       id: 'inbox',
       size: 'lg',
@@ -79,12 +79,13 @@ export const useGlobalMenu = ({
       badge: { label: t('common.beta'), variant: 'base', color: 'neutral' },
     },
     {
-      groupId: '10',
+      groupId: 'global',
       icon: { svgElement: PadlockLockedFillIcon, theme: 'surface' },
       id: 'access_management',
       size: 'lg',
       title: t('header.access_management'),
       selected: true,
+      expanded: isSm && !hideSidebarItems,
       as: (props) => (
         <Link
           to={'/'}
@@ -92,10 +93,10 @@ export const useGlobalMenu = ({
         />
       ),
       badge: { label: t('common.beta'), variant: 'base', color: 'neutral' },
+      items: sidebarItems,
     },
-    ...(isSm && !hideSidebarItems ? sidebarItems : []),
     {
-      groupId: '100',
+      groupId: 'global',
       icon: { svgElement: MenuGridIcon, theme: 'surface' },
       id: 'all_forms',
       size: 'lg',
@@ -108,7 +109,7 @@ export const useGlobalMenu = ({
       ),
     },
     {
-      groupId: '100',
+      groupId: 'global',
       icon: { svgElement: MagnifyingGlassIcon, theme: 'surface' },
       id: 'search',
       size: 'lg',
@@ -122,7 +123,7 @@ export const useGlobalMenu = ({
     },
     {
       id: 'info',
-      groupId: '1000',
+      groupId: 'links',
       icon: InformationSquareIcon,
       title: t('header.new_altinn_info'),
       size: 'sm',
@@ -135,7 +136,7 @@ export const useGlobalMenu = ({
     },
     {
       id: 'starte-og-drive',
-      groupId: '1000',
+      groupId: 'links',
       icon: Buildings2Icon,
       title: t('header.start_business'),
       size: 'sm',
@@ -148,7 +149,7 @@ export const useGlobalMenu = ({
     },
     {
       id: 'trenger-du-hjelp',
-      groupId: '1000',
+      groupId: 'links',
       icon: ChatExclamationmarkIcon,
       title: t('header.help'),
       size: 'sm',
@@ -172,6 +173,7 @@ export const useGlobalMenu = ({
         />
       ),
     },
+    ...(isSm && !hideSidebarItems ? shortcutsMenuItem : []),
   ];
 
   const globalMenu = {
@@ -195,9 +197,8 @@ export const useGlobalMenu = ({
   };
 
   const groups = {
-    1: { divider: false },
-    10: { divider: false },
-    100: { divider: isSm },
+    global: { divider: true },
+    links: { divider: true },
     'current-user': {
       title: t('header.logged_in_as_name', {
         name: formatDisplayName({
@@ -207,9 +208,8 @@ export const useGlobalMenu = ({
         }),
       }),
     },
-    1000: { divider: true },
     shortcuts: {
-      divider: false,
+      divider: true,
       title: t('header.shortcuts'),
       defaultIconTheme: 'transparent' as Theme,
       defaultItemSize: 'sm' as MenuItemSize,

--- a/src/features/amUI/common/PageLayoutWrapper/useSidebarItems.tsx
+++ b/src/features/amUI/common/PageLayoutWrapper/useSidebarItems.tsx
@@ -138,13 +138,9 @@ export const useSidebarItems = ({ isSmall }: { isSmall?: boolean }) => {
     items.push(getMaskinportenMenuItem(pathname, isLoading, isSmall));
   }
 
-  if (displayConfettiPackage) {
-    items.push(...getShortcutsMenuItem(pathname, isLoading));
-  }
-
   const sidebarItems = items.map((item) => {
     return { ...item, description: '' };
   });
 
-  return { sidebarItems };
+  return { sidebarItems, shortcutsMenuItem: getShortcutsMenuItem(pathname, isLoading) };
 };

--- a/src/resources/utils/sidebarConfig.tsx
+++ b/src/resources/utils/sidebarConfig.tsx
@@ -256,7 +256,7 @@ export const getShortcutsMenuItem = (pathname?: string, isLoading = false): Menu
     {
       groupId: 'shortcuts',
       id: 'beta-about',
-      size: 'md',
+      size: 'sm',
       loading: isLoading,
       variant: 'tinted',
       title: t('header.help_pages'),
@@ -267,7 +267,7 @@ export const getShortcutsMenuItem = (pathname?: string, isLoading = false): Menu
     {
       groupId: 'shortcuts',
       id: 'beta-leave',
-      size: 'md',
+      size: 'sm',
       loading: isLoading,
       variant: 'tinted',
       title: t('header.leave_beta'),


### PR DESCRIPTION
## Description
- The menu in arbeidsflate looks a bit different from the current menu in tilgangsstyring; update tilgangsstyring menu to look more like arbeidsflate menu
<img width="1124" height="1195" alt="image" src="https://github.com/user-attachments/assets/c83490b1-0931-46ff-8dfe-4e97bb492a2a" />


## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Sidebar and shortcuts now render as a single combined menu for a more consistent navigation experience.
  * Menu groupings reorganized so key links (including access management) appear in the global/links sections and expand appropriately on small screens.
* **Style**
  * Shortcut items adjusted to a smaller size for a tighter, more compact shortcuts area.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->