### PR TITLE
use ReporteePageHeading (common heading across pages)

### DIFF
--- a/src/features/amUI/clientAdministration/ClientAdministrationPageContent.tsx
+++ b/src/features/amUI/clientAdministration/ClientAdministrationPageContent.tsx
@@ -11,14 +11,18 @@ import {
 } from '@altinn/altinn-components';
 
 import { clientAdministrationPageEnabled } from '@/resources/utils/featureFlagUtils';
-import { PartyType, useGetIsClientAdminQuery } from '@/rtk/features/userInfoApi';
+import {
+  PartyType,
+  useGetIsClientAdminQuery,
+  useGetReporteeQuery,
+} from '@/rtk/features/userInfoApi';
 import { usePartyRepresentation } from '../common/PartyRepresentationContext/PartyRepresentationContext';
 import { ClientAdministrationAgentsTab } from './ClientAdministrationAgentsTab';
 import { ClientAdministrationClientsTab } from './ClientAdministrationClientsTab';
 import classes from './ClientAdministrationPageContent.module.css';
 import { DatabaseIcon, PersonGroupIcon } from '@navikt/aksel-icons';
-import { isSubUnitByType } from '@/resources/utils/reporteeUtils';
 import { useUrlParamState } from '../common/useUrlParamState';
+import { ReporteePageHeading } from '../common/ReporteePageHeading/ReporteePageHeading';
 
 const clientAdministrationTabs = ['users', 'clients'] as const;
 
@@ -27,16 +31,13 @@ export const ClientAdministrationPageContent = () => {
   const pageIsEnabled = clientAdministrationPageEnabled();
   const { actingParty } = usePartyRepresentation();
 
-  const unitType = isSubUnitByType(actingParty?.variant)
-    ? t('common.subunit_lowercase')
-    : t('common.mainunit_lowercase');
-
   const [activeTab, setActiveTab] = useUrlParamState({
     key: 'tab',
     defaultValue: 'users',
     validValues: clientAdministrationTabs,
   });
 
+  const { data: reportee, isLoading: isLoadingReportee } = useGetReporteeQuery();
   const { data: isClientAdmin, isLoading: isLoadingIsClientAdmin } = useGetIsClientAdminQuery();
 
   if (!pageIsEnabled) {
@@ -79,29 +80,16 @@ export const ClientAdministrationPageContent = () => {
     <>
       <div className={classes.headerSection}>
         <div className={classes.pageHeader}>
-          <DsHeading
-            data-size='sm'
-            level={1}
-          >
-            <Trans
-              i18nKey='client_administration_page.page_heading'
-              values={{
-                name: formatDisplayName({
-                  fullName: actingParty?.name ?? '',
-                  type: actingParty?.partyTypeName === PartyType.Person ? 'person' : 'company',
-                }),
-              }}
-            />
-          </DsHeading>
-          <DsParagraph data-size='md'>
-            <Trans
-              i18nKey='client_administration_page.page_description'
-              values={{
-                organisationidentifier: actingParty?.orgNumber ?? '',
-                unitType,
-              }}
-            />
-          </DsParagraph>
+          <ReporteePageHeading
+            title={t('client_administration_page.page_heading', {
+              name: formatDisplayName({
+                fullName: actingParty?.name ?? '',
+                type: actingParty?.partyTypeName === PartyType.Person ? 'person' : 'company',
+              }),
+            })}
+            reportee={reportee}
+            isLoading={isLoadingReportee}
+          />
         </div>
         <DsParagraph
           data-size='md'

--- a/src/features/amUI/clientAdministration/ClientAdministrationPageContent.tsx
+++ b/src/features/amUI/clientAdministration/ClientAdministrationPageContent.tsx
@@ -29,7 +29,7 @@ const clientAdministrationTabs = ['users', 'clients'] as const;
 export const ClientAdministrationPageContent = () => {
   const { t } = useTranslation();
   const pageIsEnabled = clientAdministrationPageEnabled();
-  const { actingParty } = usePartyRepresentation();
+  const { actingParty, isLoading: actorLoading } = usePartyRepresentation();
 
   const [activeTab, setActiveTab] = useUrlParamState({
     key: 'tab',
@@ -88,7 +88,7 @@ export const ClientAdministrationPageContent = () => {
               }),
             })}
             reportee={reportee}
-            isLoading={isLoadingReportee}
+            isLoading={isLoadingReportee || actorLoading}
           />
         </div>
         <DsParagraph

--- a/src/features/amUI/common/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/features/amUI/common/Breadcrumbs/Breadcrumbs.tsx
@@ -42,7 +42,7 @@ const BreadcrumbConfig = {
   },
   consent_log: {
     href: `/${ConsentPath.Consent}/${ConsentPath.Log}`,
-    label: 'consent_log.heading',
+    label: 'consent_log.breadcrumb',
   },
   settings: {
     href: `/${amUIPath.Settings}`,

--- a/src/features/amUI/consent/ActiveConsentsPage/ActiveConsentsPage.module.css
+++ b/src/features/amUI/consent/ActiveConsentsPage/ActiveConsentsPage.module.css
@@ -1,8 +1,3 @@
-.consentsHeader {
-  margin-top: 15px;
-  padding-bottom: 1rem;
-}
-
 .activeConsentsSubHeading {
   display: flex;
   align-items: center;

--- a/src/features/amUI/consent/ActiveConsentsPage/ActiveConsentsPage.tsx
+++ b/src/features/amUI/consent/ActiveConsentsPage/ActiveConsentsPage.tsx
@@ -1,7 +1,15 @@
 import React, { useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useLocation, useNavigate } from 'react-router';
-import { DsAlert, DsDialog, DsHeading, DsLink, DsParagraph, List } from '@altinn/altinn-components';
+import {
+  DsAlert,
+  DsDialog,
+  DsHeading,
+  DsLink,
+  DsParagraph,
+  formatDisplayName,
+  List,
+} from '@altinn/altinn-components';
 import { FolderFileIcon } from '@navikt/aksel-icons';
 
 import { useDocumentTitle } from '@/resources/hooks/useDocumentTitle';
@@ -22,6 +30,7 @@ import { OldConsentAlert } from '../components/OldConsentAlert/OldConsentAlert';
 import { Breadcrumbs } from '../../common/Breadcrumbs/Breadcrumbs';
 import { getConsentRequestUrl } from '@/routes/paths/consentPath';
 import { toDateTimeString } from '../utils';
+import { ReporteePageHeading } from '../../common/ReporteePageHeading';
 
 export const ActiveConsentsPage = () => {
   const { t } = useTranslation();
@@ -63,18 +72,20 @@ export const ActiveConsentsPage = () => {
     modalRef.current?.showModal();
   };
 
+  const reporteeName = formatDisplayName({
+    fullName: reportee?.name || '',
+    type: reportee?.type === 'Person' ? 'person' : 'company',
+  });
+
   return (
     <PageWrapper>
       <PageLayoutWrapper>
         <Breadcrumbs items={['root', 'consent']} />
-        <DsHeading
-          level={1}
-          data-size='sm'
-          className={classes.consentsHeader}
-        >
-          {t('active_consents.heading')}
-        </DsHeading>
-
+        <ReporteePageHeading
+          title={t('active_consents.heading', { name: reporteeName })}
+          reportee={reportee}
+          isLoading={isLoading}
+        />
         <OldConsentAlert
           heading='active_consents.altinn2_consent_alert_header'
           text='active_consents.altinn2_consent_alert_body'

--- a/src/features/amUI/consent/ActiveConsentsPage/ActiveConsentsPage.tsx
+++ b/src/features/amUI/consent/ActiveConsentsPage/ActiveConsentsPage.tsx
@@ -84,7 +84,7 @@ export const ActiveConsentsPage = () => {
         <ReporteePageHeading
           title={t('active_consents.heading', { name: reporteeName })}
           reportee={reportee}
-          isLoading={isLoading}
+          isLoading={isLoadingReportee}
         />
         <OldConsentAlert
           heading='active_consents.altinn2_consent_alert_header'

--- a/src/features/amUI/consent/ConsentHistoryPage/ConsentHistoryPage.module.css
+++ b/src/features/amUI/consent/ConsentHistoryPage/ConsentHistoryPage.module.css
@@ -20,7 +20,3 @@
   gap: var(--ds-size-1);
   margin-bottom: var(--ds-size-3);
 }
-
-.consentLogTopHeader {
-  margin-top: 15px;
-}

--- a/src/features/amUI/consent/ConsentHistoryPage/ConsentHistoryPage.tsx
+++ b/src/features/amUI/consent/ConsentHistoryPage/ConsentHistoryPage.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import {
   DsAlert,
   DsDialog,
-  DsHeading,
+  formatDisplayName,
   Timeline,
   TimelineActivity,
   TimelineSegment,
@@ -19,10 +19,11 @@ import classes from './ConsentHistoryPage.module.css';
 import { useGetConsentLogQuery } from '@/rtk/features/consentApi';
 import { getCookie } from '@/resources/Cookie/CookieMethods';
 import { ConsentTimeline } from './ConsentTimeline';
-import { useGetIsAdminQuery } from '@/rtk/features/userInfoApi';
+import { useGetIsAdminQuery, useGetReporteeQuery } from '@/rtk/features/userInfoApi';
 import { hasConsentPermission } from '@/resources/utils/permissionUtils';
 import { OldConsentAlert } from '../components/OldConsentAlert/OldConsentAlert';
 import { Breadcrumbs } from '../../common/Breadcrumbs/Breadcrumbs';
+import { ReporteePageHeading } from '../../common/ReporteePageHeading';
 
 export const ConsentHistoryPage = () => {
   const { t } = useTranslation();
@@ -32,6 +33,7 @@ export const ConsentHistoryPage = () => {
   useDocumentTitle(t('consent_log.page_title'));
   const partyUuid = getCookie('AltinnPartyUuid');
 
+  const { data: reportee, isLoading: isLoadingReportee } = useGetReporteeQuery();
   const { data: isAdmin, isLoading: isLoadingIsAdmin } = useGetIsAdminQuery();
   const hasPermission = hasConsentPermission(isAdmin);
 
@@ -41,24 +43,27 @@ export const ConsentHistoryPage = () => {
     error: loadConsentLogError,
   } = useGetConsentLogQuery({ partyId: partyUuid }, { skip: !partyUuid || !hasPermission });
 
-  const isLoading = isLoadingIsAdmin || isLoadingConsentLog;
+  const isLoading = isLoadingIsAdmin || isLoadingConsentLog || isLoadingReportee;
 
   const showConsentDetails = (consentId: string): void => {
     setSelectedConsentId(consentId);
     modalRef.current?.showModal();
   };
 
+  const reporteeName = formatDisplayName({
+    fullName: reportee?.name || '',
+    type: reportee?.type === 'Person' ? 'person' : 'company',
+  });
+
   return (
     <PageWrapper>
       <PageLayoutWrapper>
         <Breadcrumbs items={['root', 'consent', 'consent_log']} />
-        <DsHeading
-          level={1}
-          data-size='sm'
-          className={classes.consentLogTopHeader}
-        >
-          {t('consent_log.heading')}
-        </DsHeading>
+        <ReporteePageHeading
+          title={t('consent_log.heading', { name: reporteeName })}
+          reportee={reportee}
+          isLoading={isLoading}
+        />
         <OldConsentAlert
           heading='consent_log.altinn2_consent_alert_header'
           text='consent_log.altinn2_consent_alert_body'

--- a/src/features/amUI/consent/ConsentHistoryPage/ConsentHistoryPage.tsx
+++ b/src/features/amUI/consent/ConsentHistoryPage/ConsentHistoryPage.tsx
@@ -62,7 +62,7 @@ export const ConsentHistoryPage = () => {
         <ReporteePageHeading
           title={t('consent_log.heading', { name: reporteeName })}
           reportee={reportee}
-          isLoading={isLoading}
+          isLoading={isLoadingReportee}
         />
         <OldConsentAlert
           heading='consent_log.altinn2_consent_alert_header'

--- a/src/features/amUI/settings/SettingsPageContent.tsx
+++ b/src/features/amUI/settings/SettingsPageContent.tsx
@@ -83,7 +83,7 @@ export const SettingsPageContent = () => {
       <ReporteePageHeading
         title={t('settings_page.page_heading', { name: formattedActingPartyName })}
         reportee={reportee}
-        isLoading={isLoading || actorLoading}
+        isLoading={isLoading}
       />
       <div className={classes.settingsHeaderAndInfo}>
         <DsHeading

--- a/src/features/amUI/settings/SettingsPageContent.tsx
+++ b/src/features/amUI/settings/SettingsPageContent.tsx
@@ -83,7 +83,7 @@ export const SettingsPageContent = () => {
       <ReporteePageHeading
         title={t('settings_page.page_heading', { name: formattedActingPartyName })}
         reportee={reportee}
-        isLoading={isLoading}
+        isLoading={isLoading || actorLoading}
       />
       <div className={classes.settingsHeaderAndInfo}>
         <DsHeading

--- a/src/features/amUI/settings/SettingsPageContent.tsx
+++ b/src/features/amUI/settings/SettingsPageContent.tsx
@@ -17,7 +17,12 @@ import { useGetOrgNotificationAddressesQuery } from '@/rtk/features/settingsApi'
 import classes from './SettingsPageContent.module.css';
 import { ChatIcon, PaperplaneIcon, QuestionmarkCircleIcon } from '@navikt/aksel-icons';
 import { SettingsModal } from './SettingsModal';
-import { PartyType, useGetIsCompanyProfileAdminQuery } from '@/rtk/features/userInfoApi';
+import {
+  PartyType,
+  useGetIsCompanyProfileAdminQuery,
+  useGetReporteeQuery,
+} from '@/rtk/features/userInfoApi';
+import { ReporteePageHeading } from '../common/ReporteePageHeading/ReporteePageHeading';
 
 export const SettingsPageContent = () => {
   const { t } = useTranslation();
@@ -26,6 +31,7 @@ export const SettingsPageContent = () => {
   const [openModal, setOpenModal] = React.useState(false);
   const [modalMode, setModalMode] = React.useState<'email' | 'sms' | null>(null);
 
+  const { data: reportee, isLoading: isLoadingReportee } = useGetReporteeQuery();
   const { actingParty, isLoading: actorLoading } = usePartyRepresentation();
   const { data: notificationAddresses, isLoading: notifLoading } =
     useGetOrgNotificationAddressesQuery(actingParty?.orgNumber ?? '', {
@@ -41,7 +47,8 @@ export const SettingsPageContent = () => {
     notificationAddresses
       ?.filter((addr) => addr.phone)
       .map((addr) => `${addr.countryCode} ${addr.phone}`) ?? [];
-  const isLoading = actorLoading || notifLoading || isCompanyProfileAdminLoading;
+  const isLoading =
+    actorLoading || notifLoading || isCompanyProfileAdminLoading || isLoadingReportee;
 
   const onSettingsClick = (mode: 'email' | 'sms') => {
     setModalMode(mode);
@@ -73,14 +80,11 @@ export const SettingsPageContent = () => {
 
   return (
     <div className={classes.pageContent}>
-      <DsHeading
-        level={1}
-        data-size='sm'
-      >
-        {t('settings_page.page_heading', {
-          name: formattedActingPartyName,
-        })}
-      </DsHeading>
+      <ReporteePageHeading
+        title={t('settings_page.page_heading', { name: formattedActingPartyName })}
+        reportee={reportee}
+        isLoading={isLoading}
+      />
       <div className={classes.settingsHeaderAndInfo}>
         <DsHeading
           level={2}

--- a/src/features/amUI/systemUser/SystemUsersOverviewPage/SystemUserOverviewPage.module.css
+++ b/src/features/amUI/systemUser/SystemUsersOverviewPage/SystemUserOverviewPage.module.css
@@ -14,10 +14,6 @@
   flex-direction: column;
 }
 
-.systemUserTopHeader {
-  margin-top: 15px;
-}
-
 .systemUserTabs {
   align-self: flex-start;
 }

--- a/src/features/amUI/systemUser/SystemUsersOverviewPage/SystemUserOverviewPage.tsx
+++ b/src/features/amUI/systemUser/SystemUsersOverviewPage/SystemUserOverviewPage.tsx
@@ -5,9 +5,9 @@ import { PlusIcon } from '@navikt/aksel-icons';
 import {
   DsAlert,
   DsButton,
-  DsHeading,
   DsParagraph,
   DsSkeleton,
+  formatDisplayName,
   List,
   ListItem,
 } from '@altinn/altinn-components';
@@ -29,6 +29,7 @@ import { useGetIsAdminQuery, useGetIsClientAdminQuery } from '@/rtk/features/use
 import { hasCreateSystemUserPermission } from '@/resources/utils/permissionUtils';
 import { SystemUserList } from './SystemUserList';
 import { Breadcrumbs } from '../../common/Breadcrumbs/Breadcrumbs';
+import ReporteePageHeading from '../../common/ReporteePageHeading';
 
 export const SystemUserOverviewPage = () => {
   const { t } = useTranslation();
@@ -76,17 +77,20 @@ export const SystemUserOverviewPage = () => {
     isLoadingPendingSystemUsers ||
     isLoadingIsAdmin;
 
+  const reporteeName = formatDisplayName({
+    fullName: reporteeData?.name || '',
+    type: reporteeData?.type === 'Person' ? 'person' : 'company',
+  });
+
   return (
     <PageWrapper>
       <PageLayoutWrapper>
         <Breadcrumbs items={['root', 'systemuser_overview']} />
-        <DsHeading
-          level={1}
-          data-size='sm'
-          className={classes.systemUserTopHeader}
-        >
-          {t('systemuser_overviewpage.banner_title')}
-        </DsHeading>
+        <ReporteePageHeading
+          title={t('systemuser_overviewpage.banner_title', { name: reporteeName })}
+          reportee={reporteeData}
+          isLoading={isLoading}
+        />
         <div className={classes.flexContainer}>
           <DsParagraph
             data-size='sm'

--- a/src/features/amUI/systemUser/SystemUsersOverviewPage/SystemUserOverviewPage.tsx
+++ b/src/features/amUI/systemUser/SystemUsersOverviewPage/SystemUserOverviewPage.tsx
@@ -89,7 +89,7 @@ export const SystemUserOverviewPage = () => {
         <ReporteePageHeading
           title={t('systemuser_overviewpage.banner_title', { name: reporteeName })}
           reportee={reporteeData}
-          isLoading={isLoading}
+          isLoading={isLoadingReportee}
         />
         <div className={classes.flexContainer}>
           <DsParagraph

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -623,7 +623,7 @@
   },
   "systemuser_overviewpage": {
     "page_title": "System accesses - Altinn",
-    "banner_title": "System accesses",
+    "banner_title": "System accesses for {{name}}",
     "sub_title_text": "By creating a system access, you give a vendor system access to solve tasks in Altinn on behalf of your company.",
     "systemusers_load_error": "Failed to load system accesses",
     "pending_systemusers_load_error": "Failed to load pending system access requests",
@@ -889,7 +889,7 @@
   },
   "active_consents": {
     "page_title": "Consent and power of attorney agreements - Altinn",
-    "heading": "Consents and powers of attorney",
+    "heading": "Consent and power of attorney agreements for {{name}}",
     "sub_heading": "Active agreements",
     "pending_agreements": "Pending agreements",
     "loading_consents": "Loading active agreements...",
@@ -923,7 +923,8 @@
   },
   "consent_log": {
     "page_title": "Agreement log - Altinn",
-    "heading": "Agreement log",
+    "heading": "Agreement log for {{name}}",
+    "breadcrumb": "Agreement log",
     "loading_consent_log": "Loading agreement log...",
     "loading_consent_log_error": "Could not load agreement log",
     "no_consent_log_permission": "You do not have permission to view the agreement log for this organization.",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -620,7 +620,7 @@
   },
   "systemuser_overviewpage": {
     "page_title": "Systemtilganger - Altinn",
-    "banner_title": "Systemtilganger",
+    "banner_title": "Systemtilganger for {{name}}",
     "sub_title_text": "Ved å opprette en systemtilgang gir du et fagsystem tilgang til å løse oppgaver i Altinn på vegne av bedriften din.",
     "systemusers_load_error": "Kunne ikke laste systemtilganger",
     "pending_systemusers_load_error": "Kunne ikke laste ventende systemtilgang-forespørsler",
@@ -886,7 +886,7 @@
   },
   "active_consents": {
     "page_title": "Samtykke- og fullmaktsavtaler - Altinn",
-    "heading": "Samtykker og fullmakter",
+    "heading": "Samtykker og fullmakter for {{name}}",
     "sub_heading": "Aktive avtaler",
     "pending_agreements": "Ventende avtaler",
     "loading_consents": "Laster aktive avtaler...",
@@ -920,7 +920,8 @@
   },
   "consent_log": {
     "page_title": "Avtalelogg - Altinn",
-    "heading": "Avtalelogg",
+    "heading": "Avtalelogg for {{name}}",
+    "breadcrumb": "Avtalelogg",
     "loading_consent_log": "Laster avtalelogg...",
     "loading_consent_log_error": "Kunne ikke laste avtalelogg",
     "no_consent_log_permission": "Du har ikke rettigheter til å se avtaleloggen for denne organisasjonen.",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -620,7 +620,7 @@
   },
   "systemuser_overviewpage": {
     "page_title": "Systemtilgangar - Altinn",
-    "banner_title": "Systemtilgangar",
+    "banner_title": "Systemtilgangar for {{name}}",
     "sub_title_text": "Ved å opprette ein systemtilgang gir du eit fagsystem tilgang til å løyse oppgåver i Altinn på vegne av bedrifta di.",
     "systemusers_load_error": "Kunne ikkje laste systemtilgangar",
     "pending_systemusers_load_error": "Kunne ikkje laste ventende systemtilgang-førespurnader",
@@ -886,7 +886,7 @@
   },
   "active_consents": {
     "page_title": "Samtykke- og fullmaktsavtaler - Altinn",
-    "heading": "Samtykke og fullmakter",
+    "heading": "Samtykke og fullmakter for {{name}}",
     "sub_heading": "Aktive avtaler",
     "pending_agreements": "Ventende avtalar",
     "loading_consents": "Laster aktive avtaler...",
@@ -920,7 +920,8 @@
   },
   "consent_log": {
     "page_title": "Avtalelogg - Altinn",
-    "heading": "Avtalelogg",
+    "heading": "Avtalelogg for {{name}}",
+    "breadcrumb": "Avtalelogg",
     "loading_consent_log": "Lastar avtalelogg...",
     "loading_consent_log_error": "Kunne ikkje laste avtalelogg",
     "no_consent_log_permission": "Du har ikkje rettar til å sjå avtaleloggen for denne organisasjonen.",


### PR DESCRIPTION
## Description
Use `ReporteePageHeading` component for:
- Systemuser page heading
- Consent page heading
- Agreement log page heading
- Settings page heading
- Client administration page heading
<img width="766" height="160" alt="image" src="https://github.com/user-attachments/assets/6bf532e1-0368-4ef2-836b-4394c1aa5cd3" />
---
<img width="898" height="180" alt="image" src="https://github.com/user-attachments/assets/752e27cc-81a5-43e0-8aa3-cc9c20f911ed" />
---
<img width="801" height="174" alt="image" src="https://github.com/user-attachments/assets/957a7fde-1624-4c71-bdb6-b063f7457d2c" />
---
<img width="822" height="178" alt="image" src="https://github.com/user-attachments/assets/22ae5e3c-75dc-405f-85f5-e9ddfaca593c" />
---
<img width="684" height="200" alt="image" src="https://github.com/user-attachments/assets/3e83c5c2-ed38-4d24-8850-fbbbf227c577" />


## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Headings and breadcrumb labels now include the specific person or organization name across system access, active consents, and agreement-log pages.

* **Refactor**
  * Page header areas replaced with a unified reportee-aware heading component; loading state and reportee data are consolidated for consistent rendering.

* **Style**
  * Minor CSS class adjustments to header and layout styles for improved spacing and layout consistency.

* **Localization**
  * Updated translations to include name interpolation and a dedicated breadcrumb label.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-access-management-frontend/pull/2179)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->