### PR TITLE
only client admins can add and remove agent system user clients

### DIFF
--- a/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPage.tsx
@@ -24,7 +24,7 @@ import { PageContainer } from '../../common/PageContainer/PageContainer';
 import { SystemUserPath } from '@/routes/paths';
 import { hasCreateSystemUserPermission } from '@/resources/utils/permissionUtils';
 import { DeleteSystemUserPopover } from '../components/DeleteSystemUserPopover/DeleteSystemUserPopover';
-import { useGetIsAdminQuery } from '@/rtk/features/userInfoApi';
+import { useGetIsAdminQuery, useGetIsClientAdminQuery } from '@/rtk/features/userInfoApi';
 
 export const SystemUserAgentDelegationPage = (): React.ReactNode => {
   const { id } = useParams();
@@ -36,6 +36,10 @@ export const SystemUserAgentDelegationPage = (): React.ReactNode => {
 
   useDocumentTitle(t('systemuser_agent_delegation.page_title'));
 
+  const { data: reporteeData } = useGetSystemUserReporteeQuery(partyId);
+  const { data: isAdmin } = useGetIsAdminQuery();
+  const { data: isClientAdmin } = useGetIsClientAdminQuery();
+
   const {
     data: systemUser,
     isError: isLoadSystemUserError,
@@ -43,22 +47,26 @@ export const SystemUserAgentDelegationPage = (): React.ReactNode => {
   } = useGetAgentSystemUserQuery({ partyId, systemUserId: id || '' });
 
   const {
-    data: customers,
+    data: customers = [],
     isError: isLoadCustomersError,
     isLoading: isLoadingCustomers,
-  } = useGetCustomersQuery({ partyId, systemUserId: id ?? '', partyUuid });
+  } = useGetCustomersQuery(
+    { partyId, systemUserId: id ?? '', partyUuid },
+    { skip: isClientAdmin !== true },
+  );
 
   const {
-    data: agentDelegations,
+    data: agentDelegations = [],
     isError: isLoadAssignedCustomersError,
     isLoading: isLoadingAssignedCustomers,
-  } = useGetAssignedCustomersQuery({
-    partyId: partyId,
-    systemUserId: id || '',
-    partyUuid,
-  });
-  const { data: reporteeData } = useGetSystemUserReporteeQuery(partyId);
-  const { data: isAdmin } = useGetIsAdminQuery();
+  } = useGetAssignedCustomersQuery(
+    {
+      partyId: partyId,
+      systemUserId: id || '',
+      partyUuid,
+    },
+    { skip: isClientAdmin !== true },
+  );
 
   const [deleteAgentSystemUser, { isError: isDeleteError, isLoading: isDeletingSystemUser }] =
     useDeleteAgentSystemuserMutation();
@@ -128,7 +136,7 @@ export const SystemUserAgentDelegationPage = (): React.ReactNode => {
               {t('systemuser_agent_delegation.load_assigned_customers_error')}
             </DsAlert>
           )}
-          {systemUser && customers && agentDelegations && (
+          {systemUser && customers && agentDelegations && !isLoading && (
             <SnackbarProvider>
               <SystemUserAgentDelegationPageContent
                 systemUser={systemUser}

--- a/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPageContent.tsx
+++ b/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPageContent.tsx
@@ -350,9 +350,16 @@ export const SystemUserAgentDelegationPageContent = ({
         >
           {t('systemuser_agent_delegation.assigned_customers_header')}
         </DsHeading>
+        {!isClientAdmin && (
+          <DsAlert data-color='info'>
+            {t('systemuser_agent_delegation.user_is_not_client_admin')}
+          </DsAlert>
+        )}
         {assignedCustomersList.length === 0 ? (
           <>
-            <DsParagraph>{t('systemuser_agent_delegation.no_assigned_customers')}</DsParagraph>
+            {isClientAdmin && (
+              <DsParagraph>{t('systemuser_agent_delegation.no_assigned_customers')}</DsParagraph>
+            )}
             <div className={classes.addButtons}>
               {hasAddSelfPermission && !isSelfAdded && (
                 <DsButton

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -842,7 +842,8 @@
     "add_own_organization_list_aria": "Add your organization to system access",
     "add_own_organization": "Add your organization",
     "add_own_organization_error": "Could not add your organization",
-    "remove_own_organization_error": "Could not remove your organization"
+    "remove_own_organization_error": "Could not remove your organization",
+    "user_is_not_client_admin": "Only client administrators can manage clients."
   },
   "systemuser_delegation_errors": {
     "01_rights_not_found_or_not_delegable": "One or more services do not exist, or cannot be delegated.",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -839,7 +839,8 @@
     "add_own_organization_list_aria": "Legg til din virksomhet i systemtilgang",
     "add_own_organization": "Legg til din virksomhet",
     "add_own_organization_error": "Kunne ikke legge til din virksomhet",
-    "remove_own_organization_error": "Kunne ikke fjerne din virksomhet"
+    "remove_own_organization_error": "Kunne ikke fjerne din virksomhet",
+    "user_is_not_client_admin": "Kun klientadministratorer kan administrere klienter."
   },
   "systemuser_delegation_errors": {
     "01_rights_not_found_or_not_delegable": "En eller flere tjenester eksisterer ikke, eller er ikke delegerbare.",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -839,7 +839,8 @@
     "add_own_organization_list_aria": "Legg til di verksemd i systemtilgang",
     "add_own_organization": "Legg til di verksemd",
     "add_own_organization_error": "Kunne ikkje leggja til di verksemd",
-    "remove_own_organization_error": "Kunne ikkje fjerna di verksemd"
+    "remove_own_organization_error": "Kunne ikkje fjerna di verksemd",
+    "user_is_not_client_admin": "Kun klientadministratorer kan administrere klientar."
   },
   "systemuser_delegation_errors": {
     "01_rights_not_found_or_not_delegable": "Ei eller fleire tenester finst ikkje, eller kan ikkje delegerast.",


### PR DESCRIPTION
## Description
- Endpoints for loading available clients and assigned clients require that user is client admin. An admin user who is not client admin should not be able to see, add or remove clients
<img width="1413" height="862" alt="image" src="https://github.com/user-attachments/assets/67b5f511-39ee-473f-8e98-2f827de20d2a" />


## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted client delegation management access to client administrators only
  * Added informational message for non-client-admin users explaining access limitations
  * Updated multi-language support with localized messaging for access restrictions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->