### PR TITLE
fix for setting phone numbers on small screens

### DIFF
--- a/src/features/amUI/settings/SettingsModal.module.css
+++ b/src/features/amUI/settings/SettingsModal.module.css
@@ -8,7 +8,7 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  padding-top: 1.5rem;
+  margin-top: 1.5rem;
 }
 
 .addressList {
@@ -29,7 +29,7 @@
 
 .phoneFieldRow {
   display: grid;
-  grid-template-columns: 0.15fr 1fr auto;
+  grid-template-columns: 5rem 1fr auto;
   justify-content: space-between;
 }
 


### PR DESCRIPTION
## Description
- Minor css changes to enlarge country-number fields (to support 3 digits) on smaller screens

before:
<img width="291" height="418" alt="image" src="https://github.com/user-attachments/assets/e3943f68-f407-4bac-9c56-a35a5d6ba0f0" />

with this PR:
<img width="292" height="416" alt="image" src="https://github.com/user-attachments/assets/892eca9f-e1b0-4d33-93af-6a362c826cc4" />


## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted spacing and layout in the settings modal for improved visual consistency
  * Fixed phone field input alignment for better form presentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->