### PR TITLE
Ignore duplicate requestIds in draft confirmation

### DIFF
--- a/src/features/amUI/requestPage/DraftRequestPage/DraftRequestPage.tsx
+++ b/src/features/amUI/requestPage/DraftRequestPage/DraftRequestPage.tsx
@@ -25,7 +25,7 @@ export const DraftRequestPage = () => {
   useDocumentTitle(t('draft_request_page.page_title'));
   const [searchParams] = useSearchParams();
   const partyUuid = getCookie('AltinnPartyUuid') || '';
-  const requestIds = searchParams.getAll('requestId');
+  const requestIds = Array.from(new Set(searchParams.getAll('requestId'))); // Duplicate IDs are ignored
   const isMultiMode = requestIds.length > 1;
   const [batchCompleteAction, setBatchCompleteAction] = useState<BatchActionType>(null);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

We want to ignore duplicate IDs so we avoid views like this:
<img width="1860" height="1206" alt="image" src="https://github.com/user-attachments/assets/709710a4-cb8c-40d4-9d50-3eea6d76a716" />

A single request can only be confirmed once

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of duplicate request identifiers in URL parameters to ensure accurate multi-request behavior and prevent redundant processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->