### PR TITLE
Set error-snackbars to default duration

### DIFF
--- a/src/features/amUI/agentDetails/useAgentDetailsAccessPackageActions.ts
+++ b/src/features/amUI/agentDetails/useAgentDetailsAccessPackageActions.ts
@@ -63,7 +63,6 @@ export const useAgentDetailsAccessPackageActions = ({
             accessPackage: accessPackageName,
           }),
           color: 'danger',
-          duration: SnackbarDuration.infinite,
         });
       }
     },
@@ -110,7 +109,6 @@ export const useAgentDetailsAccessPackageActions = ({
             accessPackage: accessPackageName,
           }),
           color: 'danger',
-          duration: SnackbarDuration.infinite,
         });
       }
     },

--- a/src/features/amUI/agentDetails/useAgentDetailsAccessPackageActions.ts
+++ b/src/features/amUI/agentDetails/useAgentDetailsAccessPackageActions.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { SnackbarDuration, useSnackbar } from '@altinn/altinn-components';
+import { useSnackbar } from '@altinn/altinn-components';
 import { useTranslation } from 'react-i18next';
 
 import type {

--- a/src/features/amUI/clientAdministration/ClientAdministrationAgentsTab.tsx
+++ b/src/features/amUI/clientAdministration/ClientAdministrationAgentsTab.tsx
@@ -81,7 +81,6 @@ export const ClientAdministrationAgentsTab = ({ isActive }: ClientAdministration
         openSnackbar({
           message: t('client_administration_page.add_agent_error'),
           color: 'danger',
-          duration: SnackbarDuration.infinite,
         });
       });
   };

--- a/src/features/amUI/clientAdministration/ClientAdministrationAgentsTab.tsx
+++ b/src/features/amUI/clientAdministration/ClientAdministrationAgentsTab.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { DsAlert, DsParagraph, SnackbarDuration, useSnackbar } from '@altinn/altinn-components';
+import { DsAlert, DsParagraph, useSnackbar } from '@altinn/altinn-components';
 
 import { AddAgentButton } from '../users/NewUserModal/AddAgentModal';
 import { UserSearch } from '../common/UserSearch/UserSearch';

--- a/src/features/amUI/clientDetails/useClientDetailsAccessPackageActions.ts
+++ b/src/features/amUI/clientDetails/useClientDetailsAccessPackageActions.ts
@@ -63,7 +63,6 @@ export const useClientDetailsAccessPackageActions = ({
             accessPackage: accessPackageName,
           }),
           color: 'danger',
-          duration: SnackbarDuration.infinite,
         });
       }
     },
@@ -110,7 +109,6 @@ export const useClientDetailsAccessPackageActions = ({
             accessPackage: accessPackageName,
           }),
           color: 'danger',
-          duration: SnackbarDuration.infinite,
         });
       }
     },

--- a/src/features/amUI/clientDetails/useClientDetailsAccessPackageActions.ts
+++ b/src/features/amUI/clientDetails/useClientDetailsAccessPackageActions.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { SnackbarDuration, useSnackbar } from '@altinn/altinn-components';
+import { useSnackbar } from '@altinn/altinn-components';
 import { useTranslation } from 'react-i18next';
 
 import type {

--- a/src/features/amUI/common/AccessPackageList/useAccessPackageActions.ts
+++ b/src/features/amUI/common/AccessPackageList/useAccessPackageActions.ts
@@ -104,7 +104,6 @@ export const useAccessPackageActions = ({
           accessPackage: accessPackage.name,
         }),
         color: 'danger',
-        duration: SnackbarDuration.infinite,
       });
     }
   };
@@ -136,7 +135,6 @@ export const useAccessPackageActions = ({
           accessPackage: accessPackage.name,
         }),
         color: 'danger',
-        duration: SnackbarDuration.infinite,
       });
     }
   };
@@ -246,7 +244,6 @@ export const useAccessPackageActions = ({
           resource: accessPackage.name,
         }),
         color: 'danger',
-        duration: SnackbarDuration.infinite,
       });
     }
   };

--- a/src/features/amUI/common/AccessPackageList/useAccessPackageActions.ts
+++ b/src/features/amUI/common/AccessPackageList/useAccessPackageActions.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { formatDisplayName, SnackbarDuration, useSnackbar } from '@altinn/altinn-components';
+import { formatDisplayName, useSnackbar } from '@altinn/altinn-components';
 
 import type { DelegationErrorDetails } from '@/resources/hooks/useDelegateAccessPackage';
 import { useDelegateAccessPackage } from '@/resources/hooks/useDelegateAccessPackage';

--- a/src/features/amUI/myClients/MyClientsAccessSection.tsx
+++ b/src/features/amUI/myClients/MyClientsAccessSection.tsx
@@ -57,7 +57,6 @@ export const MyClientsAccessSection = ({
             accessPackage: accessPackageName,
           }),
           color: 'danger',
-          duration: SnackbarDuration.infinite,
         });
       }
     },

--- a/src/features/amUI/myClients/MyClientsAccessSection.tsx
+++ b/src/features/amUI/myClients/MyClientsAccessSection.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { Snackbar, SnackbarDuration, useSnackbar } from '@altinn/altinn-components';
+import { Snackbar, useSnackbar } from '@altinn/altinn-components';
 import { useTranslation } from 'react-i18next';
 
 import {

--- a/src/features/amUI/requestPage/RequestReviewModal/useRequestReview.ts
+++ b/src/features/amUI/requestPage/RequestReviewModal/useRequestReview.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { SnackbarDuration, useSnackbar } from '@altinn/altinn-components';
+import { useSnackbar } from '@altinn/altinn-components';
 import { useTranslation } from 'react-i18next';
 import type { Request, ProcessedStatus } from '../types';
 import { usePartyRepresentation } from '../../common/PartyRepresentationContext/PartyRepresentationContext';
@@ -174,7 +174,6 @@ export const useRequestReview = (request: Request | null, onClose: () => void) =
       openSnackbar({
         message: t('request_page.request_approved'),
         color: 'success',
-        duration: SnackbarDuration.normal,
       });
     } catch {
       openSnackbar({
@@ -205,7 +204,6 @@ export const useRequestReview = (request: Request | null, onClose: () => void) =
       openSnackbar({
         message: t('request_page.request_rejected'),
         color: 'success',
-        duration: SnackbarDuration.normal,
       });
     } catch {
       openSnackbar({

--- a/src/features/amUI/requestPage/RequestReviewModal/useRequestReview.ts
+++ b/src/features/amUI/requestPage/RequestReviewModal/useRequestReview.ts
@@ -180,7 +180,6 @@ export const useRequestReview = (request: Request | null, onClose: () => void) =
       openSnackbar({
         message: t('request_page.approve_failed'),
         color: 'danger',
-        duration: SnackbarDuration.infinite,
       });
     } finally {
       setActionLoading(null);
@@ -212,7 +211,6 @@ export const useRequestReview = (request: Request | null, onClose: () => void) =
       openSnackbar({
         message: t('request_page.reject_failed'),
         color: 'danger',
-        duration: SnackbarDuration.infinite,
       });
     } finally {
       setActionLoading(null);

--- a/src/features/amUI/userRightsPage/AccessPackageSection/PendingPackageRequests/RequestsList.tsx
+++ b/src/features/amUI/userRightsPage/AccessPackageSection/PendingPackageRequests/RequestsList.tsx
@@ -85,7 +85,6 @@ export const PendingPackageRequestsList = ({
           resource: request.package?.name,
         }),
         color: 'danger',
-        duration: SnackbarDuration.infinite,
       });
     }
   };

--- a/src/features/amUI/userRightsPage/AccessPackageSection/PendingPackageRequests/RequestsList.tsx
+++ b/src/features/amUI/userRightsPage/AccessPackageSection/PendingPackageRequests/RequestsList.tsx
@@ -1,13 +1,6 @@
 import { useEffect, useState } from 'react';
 import { ArrowLeftIcon, MinusCircleIcon } from '@navikt/aksel-icons';
-import {
-  Button,
-  DsButton,
-  DsHeading,
-  List,
-  SnackbarDuration,
-  useSnackbar,
-} from '@altinn/altinn-components';
+import { Button, DsButton, DsHeading, List, useSnackbar } from '@altinn/altinn-components';
 import { useTranslation } from 'react-i18next';
 import { usePartyRepresentation } from '../../../common/PartyRepresentationContext/PartyRepresentationContext';
 import { PartyType } from '@/rtk/features/userInfoApi';

--- a/src/features/amUI/userRightsPage/SingleRightsSection/DeleteResourceButton.tsx
+++ b/src/features/amUI/userRightsPage/SingleRightsSection/DeleteResourceButton.tsx
@@ -53,7 +53,6 @@ export const DeleteResourceButton = ({
         },
       ),
       color,
-      duration: isSuccessful ? SnackbarDuration.normal : SnackbarDuration.infinite,
     };
     openSnackbar(snackbarData);
   };

--- a/src/features/amUI/userRightsPage/SingleRightsSection/DeleteResourceButton.tsx
+++ b/src/features/amUI/userRightsPage/SingleRightsSection/DeleteResourceButton.tsx
@@ -1,11 +1,6 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import {
-  Button,
-  formatDisplayName,
-  SnackbarDuration,
-  useSnackbar,
-} from '@altinn/altinn-components';
+import { Button, formatDisplayName, useSnackbar } from '@altinn/altinn-components';
 
 import type { ServiceResource } from '@/rtk/features/singleRights/singleRightsApi';
 import { useRevokeResource } from '@/resources/hooks/useRevokeResource';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

After a request from UX (and I agree) we change the error-toasts to no longer be infinite duration. They do not give a lot of information anyway so the value of leaving them there to be screenshotted is minimal. Also, since they do appear to disappear when closing the modal that owns them only to then appear again if you open that modal again, they currently make the solution feel buggy.

For consistency, we use the same (default) duration on ALL snackbars

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/2932

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Error notification messages now automatically dismiss after a default time period instead of remaining on screen indefinitely across access package and request management features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->