### PR TITLE
Fixed text on no resources in ResourceList

### DIFF
--- a/src/features/amUI/common/DelegationModal/AccessPackages/PackageMeta.tsx
+++ b/src/features/amUI/common/DelegationModal/AccessPackages/PackageMeta.tsx
@@ -36,6 +36,7 @@ export const PackageMeta = ({ accessPackage }: PackageMetaProps) => {
         <div className={classes.service_list}>
           <ResourceList
             resources={accessPackage.resources}
+            noResourcesText={t('delegation_modal.no_resources_in_package')}
             enableMaxHeight={true}
             showDetails={false}
             interactive={false}

--- a/src/features/amUI/userRightsPage/SingleRightsSection/SingleRightsSection.tsx
+++ b/src/features/amUI/userRightsPage/SingleRightsSection/SingleRightsSection.tsx
@@ -140,6 +140,7 @@ export const SingleRightsSection = ({ isReportee = false }: { isReportee?: boole
             }}
             size={isSmallScreen ? 'sm' : 'md'}
             titleAs='h3'
+            noResourcesText={t('resource_list.no_user_resources')}
             delegationModal={
               (availableActions.includes(DelegationAction.DELEGATE) ||
                 availableActions.includes(DelegationAction.REQUEST)) && (

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -488,6 +488,7 @@
     "edit_success": "The power of attorney was updated",
     "package_services_one": "Grants access to {{count}} service",
     "package_services_other": "Grants access to {{count}} services",
+    "no_resources_in_package": "This access package currently contains no services.",
     "inherited_role_org_message": "{{user_name}} has access to this through their role in {{org_name}}. Therefore, it cannot be deleted.",
     "actions": {
       "access_to_all": "Access to the full service",
@@ -1040,7 +1041,8 @@
   "resource_list": {
     "resource_search_placeholder": "Search resources",
     "no_resources_filtered": "No matches for the search \"{{searchTerm}}\".",
-    "no_resources": "This user has no services.",
+    "no_resources": "No services.",
+    "no_user_resources": "This user has no services.",
     "filter_by_serviceowner": "Filter by service owner",
     "filtered_serviceowners": "{{count}} service owners",
     "resource_search_clear": "Clear search",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -485,6 +485,7 @@
     "edit_success": "Fullmakt oppdatert",
     "package_services_one": "Gir tilgang til {{count}} tjeneste",
     "package_services_other": "Gir tilgang til {{count}} tjenester",
+    "no_resources_in_package": "Denne tilgangspakken inneholder foreløpig ingen tjenester.",
     "inherited_role_org_message": "{{user_name}} har tilgang til denne gjennom sin rolle i {{org_name}}. Den kan derfor ikke slettes.",
     "actions": {
       "access_to_all": "Tilgang til hele tjenesten",
@@ -1037,7 +1038,8 @@
   "resource_list": {
     "resource_search_placeholder": "Søk etter tjenester",
     "no_resources_filtered": "Ingen treff på søket \"{{searchTerm}}\".",
-    "no_resources": "Denne brukeren har ingen tjenester.",
+    "no_resources": "Ingen tjenester.",
+    "no_user_resources": "Denne brukeren har ingen tjenester.",
     "filter_by_serviceowner": "Filtrer på tjenesteeier",
     "filtered_serviceowners": "{{count}} tjenesteeiere",
     "resource_search_clear": "Tøm søk",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -485,7 +485,7 @@
     "edit_success": "Fullmakt oppdatert",
     "package_services_one": "Gir tilgang til {{count}} teneste",
     "package_services_other": "Gir tilgang til {{count}} tenester",
-    "no_resources_in_package": "Denne tilgangspakken innehelder foreløpig ingen tenester.",
+    "no_resources_in_package": "Denne tilgangspakken inneheld førebels ingen tenester.",
     "inherited_role_org_message": "{{user_name}} har tilgang til denne gjennom rolla si i {{org_name}}. Den kan derfor ikkje slettast.",
     "actions": {
       "access_to_all": "Tilgang til heile tenesta",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -485,9 +485,10 @@
     "edit_success": "Fullmakt oppdatert",
     "package_services_one": "Gir tilgang til {{count}} teneste",
     "package_services_other": "Gir tilgang til {{count}} tenester",
+    "no_resources_in_package": "Denne tilgangspakken innehelder foreløpig ingen tenester.",
     "inherited_role_org_message": "{{user_name}} har tilgang til denne gjennom rolla si i {{org_name}}. Den kan derfor ikkje slettast.",
     "actions": {
-      "access_to_all": "Tilgang til heile tenesten",
+      "access_to_all": "Tilgang til heile tenesta",
       "partial_access": "Tilgang til {{count}} av {{total}} handlingar",
       "action_description": "Her ser du dei tekniske handlingane som tenesta tilbyr. Du kan gi fullmakt til heile tenesta eller velje spesifikke handlingar.",
       "request_action_description": "Her ser du dei tekniske handlingane som tenesta tilbyr. Du kan berre be om fullmakt til heile tenesta.",
@@ -1037,7 +1038,8 @@
   "resource_list": {
     "resource_search_placeholder": "Søk etter tenester",
     "no_resources_filtered": "Ingen treff på søket \"{{searchTerm}}\".",
-    "no_resources": "Denne brukaren har ingen tenester.",
+    "no_resources": "Ingen tenester.",
+    "no_user_resources": "Denne brukaren har ingen tenester.",
     "filter_by_serviceowner": "Filtrer på tenesteeigar",
     "filtered_serviceowners": "{{count}} tenesteeigare",
     "resource_search_clear": "Tøm søk",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<img width="1237" height="582" alt="image" src="https://github.com/user-attachments/assets/fe27d802-48de-456f-bd16-c00e6a3e6266" />
<img width="1492" height="859" alt="image" src="https://github.com/user-attachments/assets/75de463b-64e4-42f1-b179-4ac3f9a03736" />


## Description
<!--- Describe your changes in detail -->

Fixed faulty default text so more neutral text is shown per default, and added more descriptive texts for specific cases.

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/2981

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced empty-state messaging throughout the application to provide context-specific guidance
  * Improved user-facing text to distinguish between "no services available" and "this user has no services" scenarios
  * Updated translations across English, Norwegian Bokmål, and Norwegian Nynorsk
  * Added new localization key for access package empty states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->