### PR TITLE
Display account selector on reportee error page

### DIFF
--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -182,7 +182,9 @@
       "header": "We couldn't change reportee",
       "description": "The selected reportee isn't available to you, or the link you followed was invalid.",
       "if_persistent_contact_service": "If the problem persists, please contact Altinn support at 75 00 60 00.",
-      "go_to_altinn": "Go to Altinn's start page"
+      "go_to_altinn": "Go to Altinn's start page",
+      "go_to_innbox": "Go to inbox",
+      "go_to_am": "Go to access management"
     }
   },
   "profile": {

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -182,6 +182,7 @@
       "header": "We couldn't change reportee",
       "description": "The selected reportee isn't available to you, or the link you followed was invalid.",
       "if_persistent_contact_service": "If the problem persists, please contact Altinn support at 75 00 60 00.",
+      "where_to_now": "Where would you like to go now?",
       "go_to_altinn": "Go to Altinn's start page",
       "go_to_innbox": "Go to inbox",
       "go_to_am": "Go to access management"

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -183,7 +183,7 @@
       "description": "The selected reportee isn't available to you, or the link you followed was invalid.",
       "if_persistent_contact_service": "If the problem persists, please contact Altinn support at 75 00 60 00.",
       "go_to_altinn": "Go to Altinn's start page",
-      "go_to_innbox": "Go to inbox",
+      "go_to_inbox": "Go to inbox",
       "go_to_am": "Go to access management"
     }
   },

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -130,7 +130,7 @@
       "if_persistent_contact_service": "Hvis problemet vedvarer kan du kontakte Altinn brukerstøtte på telefon 75 00 60 00.",
       "where_to_now": "Hvor vil du gå nå?",
       "go_to_altinn": "Gå til startsiden for Altinn",
-      "go_to_innbox": "Gå til innboks",
+      "go_to_inbox": "Gå til innboks",
       "go_to_am": "Gå til tilgangsstyring"
     }
   },

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -128,7 +128,10 @@
       "header": "Vi klarte ikke å bytte avgiver",
       "description": "Den valgte avgiveren er ikke tilgjengelig for deg, eller lenken du fulgte var ugyldig.",
       "if_persistent_contact_service": "Hvis problemet vedvarer kan du kontakte Altinn brukerstøtte på telefon 75 00 60 00.",
-      "go_to_altinn": "Gå til startsiden for Altinn"
+      "where_to_now": "Hvor vil du gå nå?",
+      "go_to_altinn": "Gå til startsiden for Altinn",
+      "go_to_innbox": "Gå til innboks",
+      "go_to_am": "Gå til tilgangsstyring"
     }
   },
   "header": {

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -180,7 +180,7 @@
       "description": "Den valde avgivaren er ikkje tilgjengeleg for deg, eller lenka du følgde var ugyldig.",
       "if_persistent_contact_service": "Dersom problemet held fram kan du kontakte Altinn brukarservice på telefon 75 00 60 00.",
       "go_to_altinn": "Gå til startsiden for Altinn",
-      "go_to_innbox": "Gå til innboks",
+      "go_to_inbox": "Gå til innboks",
       "go_to_am": "Gå til tilgangsstyring"
     }
   },

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -179,6 +179,7 @@
       "header": "Vi klarte ikkje å byte avgivar",
       "description": "Den valde avgivaren er ikkje tilgjengeleg for deg, eller lenka du følgde var ugyldig.",
       "if_persistent_contact_service": "Dersom problemet held fram kan du kontakte Altinn brukarservice på telefon 75 00 60 00.",
+      "where_to_now": "Kvar vil du gå no?",
       "go_to_altinn": "Gå til startsiden for Altinn",
       "go_to_innbox": "Gå til innboks",
       "go_to_am": "Gå til tilgangsstyring"

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -179,7 +179,9 @@
       "header": "Vi klarte ikkje å byte avgivar",
       "description": "Den valde avgivaren er ikkje tilgjengeleg for deg, eller lenka du følgde var ugyldig.",
       "if_persistent_contact_service": "Dersom problemet held fram kan du kontakte Altinn brukarservice på telefon 75 00 60 00.",
-      "go_to_altinn": "Gå til startsiden for Altinn"
+      "go_to_altinn": "Gå til startsiden for Altinn",
+      "go_to_innbox": "Gå til innboks",
+      "go_to_am": "Gå til tilgangsstyring"
     }
   },
   "profile": {

--- a/src/sites/ErrorPage/amUi/ErrorLayoutWrapper.tsx
+++ b/src/sites/ErrorPage/amUi/ErrorLayoutWrapper.tsx
@@ -6,11 +6,21 @@ import { LanguageCode, Layout, RootProvider, Snackbar } from '@altinn/altinn-com
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router';
 
-export const ErrorLayoutWrapper = ({ children }: { children: React.ReactNode }) => {
+export const ErrorLayoutWrapper = ({
+  hideAccountSelector = true,
+  children,
+}: {
+  hideAccountSelector?: boolean;
+  children: React.ReactNode;
+}) => {
   const { t } = useTranslation();
   const { pathname, search } = useLocation();
 
-  const { header, languageCode } = useHeader({ openAccountMenu: false, hideAccountSelector: true });
+  const { header, languageCode } = useHeader({
+    openAccountMenu: false,
+    hideAccountSelector,
+    hideSidebarItems: true,
+  });
   const footer = useFooter();
 
   return (

--- a/src/sites/ErrorPage/amUi/ErrorPage.module.css
+++ b/src/sites/ErrorPage/amUi/ErrorPage.module.css
@@ -29,6 +29,11 @@
   padding-bottom: 0.5rem;
 }
 
+.secondHeader {
+  padding-bottom: 0.5rem;
+  padding-left: var(--ds-spacing-4);
+}
+
 .nextSteps {
   margin: var(--ds-spacing-1) 0;
   padding: var(--ds-spacing-8) var(--ds-spacing-8) var(--ds-spacing-12) var(--ds-spacing-8);
@@ -41,5 +46,8 @@
 @media only screen and (max-width: 576px) {
   .header {
     font-size: 20px;
+  }
+  .secondHeader {
+    font-size: 18px;
   }
 }

--- a/src/sites/ErrorPage/amUi/ErrorPage.module.css
+++ b/src/sites/ErrorPage/amUi/ErrorPage.module.css
@@ -31,7 +31,7 @@
 
 .secondHeader {
   padding-bottom: 0.5rem;
-  padding-left: var(--ds-spacing-4);
+  padding-left: var(--ds-spacing-2);
 }
 
 .nextSteps {
@@ -48,6 +48,6 @@
     font-size: 20px;
   }
   .secondHeader {
-    font-size: 18px;
+    font-size: 19px;
   }
 }

--- a/src/sites/ErrorPage/amUi/ErrorPage.module.css
+++ b/src/sites/ErrorPage/amUi/ErrorPage.module.css
@@ -29,6 +29,15 @@
   padding-bottom: 0.5rem;
 }
 
+.nextSteps {
+  margin: var(--ds-spacing-1) 0;
+  padding: var(--ds-spacing-8) var(--ds-spacing-8) var(--ds-spacing-12) var(--ds-spacing-8);
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  background-color: #f0f0f0;
+}
+
 @media only screen and (max-width: 576px) {
   .header {
     font-size: 20px;

--- a/src/sites/ErrorPage/amUi/ReporteeChangeErrorPage.tsx
+++ b/src/sites/ErrorPage/amUi/ReporteeChangeErrorPage.tsx
@@ -6,7 +6,7 @@ import { ReporteeChangeError } from './contents/ReporteeChangeError';
 
 export const ReporteeChangeErrorPage = () => {
   return (
-    <ErrorLayoutWrapper>
+    <ErrorLayoutWrapper hideAccountSelector={false}>
       <div className={classes.errorPageWrapper}>
         <ReporteeChangeError />
       </div>

--- a/src/sites/ErrorPage/amUi/contents/ReporteeChangeError.tsx
+++ b/src/sites/ErrorPage/amUi/contents/ReporteeChangeError.tsx
@@ -1,9 +1,9 @@
 import { useTranslation } from 'react-i18next';
 import * as React from 'react';
-import { DsHeading, DsParagraph, DsLink } from '@altinn/altinn-components';
+import { DsHeading, DsParagraph, DsLink, DsListItem } from '@altinn/altinn-components';
 
 import classes from '../ErrorPage.module.css';
-import { getAltinnStartPageUrl } from '@/resources/utils/pathUtils';
+import { getAfUrl, getAltinnStartPageUrl, getAmStartPageUrl } from '@/resources/utils/pathUtils';
 
 export const ReporteeChangeError = () => {
   const { t } = useTranslation();
@@ -21,11 +21,44 @@ export const ReporteeChangeError = () => {
       <DsParagraph>
         {t('error_page.reportee_change_error.if_persistent_contact_service')}
       </DsParagraph>
-      <DsParagraph>
-        <DsLink href={getAltinnStartPageUrl()}>
-          {t('error_page.reportee_change_error.go_to_altinn')}
-        </DsLink>
-      </DsParagraph>
+      <div className={classes.nextSteps}>
+        <DsHeading
+          id='where-to-header'
+          className={classes.header}
+          level={2}
+          data-size='xs'
+        >
+          {t('error_page.reportee_change_error.where_to_now')}
+        </DsHeading>
+        <div
+          className={classes.list}
+          aria-labelledby='where-to-header'
+        >
+          <DsListItem>
+            <DsParagraph>
+              <DsLink href={getAltinnStartPageUrl()}>
+                {t('error_page.reportee_change_error.go_to_altinn')}
+              </DsLink>
+            </DsParagraph>
+          </DsListItem>
+
+          <DsListItem>
+            <DsParagraph>
+              <DsLink href={getAfUrl()}>
+                {t('error_page.reportee_change_error.go_to_innbox')}
+              </DsLink>
+            </DsParagraph>
+          </DsListItem>
+
+          <DsListItem>
+            <DsParagraph>
+              <DsLink href={getAmStartPageUrl()}>
+                {t('error_page.reportee_change_error.go_to_am')}
+              </DsLink>
+            </DsParagraph>
+          </DsListItem>
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/sites/ErrorPage/amUi/contents/ReporteeChangeError.tsx
+++ b/src/sites/ErrorPage/amUi/contents/ReporteeChangeError.tsx
@@ -1,6 +1,12 @@
 import { useTranslation } from 'react-i18next';
 import * as React from 'react';
-import { DsHeading, DsParagraph, DsLink, DsListItem } from '@altinn/altinn-components';
+import {
+  DsHeading,
+  DsParagraph,
+  DsLink,
+  DsListItem,
+  DsListUnordered,
+} from '@altinn/altinn-components';
 
 import classes from '../ErrorPage.module.css';
 import { getAfUrl, getAltinnStartPageUrl, getAmStartPageUrl } from '@/resources/utils/pathUtils';
@@ -30,7 +36,7 @@ export const ReporteeChangeError = () => {
         >
           {t('error_page.reportee_change_error.where_to_now')}
         </DsHeading>
-        <div
+        <DsListUnordered
           className={classes.list}
           aria-labelledby='where-to-header'
         >
@@ -55,7 +61,7 @@ export const ReporteeChangeError = () => {
               </DsLink>
             </DsParagraph>
           </DsListItem>
-        </div>
+        </DsListUnordered>
       </div>
     </div>
   );

--- a/src/sites/ErrorPage/amUi/contents/ReporteeChangeError.tsx
+++ b/src/sites/ErrorPage/amUi/contents/ReporteeChangeError.tsx
@@ -44,9 +44,7 @@ export const ReporteeChangeError = () => {
 
           <DsListItem>
             <DsParagraph>
-              <DsLink href={getAfUrl()}>
-                {t('error_page.reportee_change_error.go_to_innbox')}
-              </DsLink>
+              <DsLink href={getAfUrl()}>{t('error_page.reportee_change_error.go_to_inbox')}</DsLink>
             </DsParagraph>
           </DsListItem>
 

--- a/src/sites/ErrorPage/amUi/contents/ReporteeChangeError.tsx
+++ b/src/sites/ErrorPage/amUi/contents/ReporteeChangeError.tsx
@@ -30,7 +30,7 @@ export const ReporteeChangeError = () => {
       <div className={classes.nextSteps}>
         <DsHeading
           id='where-to-header'
-          className={classes.header}
+          className={classes.secondHeader}
           level={2}
           data-size='xs'
         >


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<img width="1607" height="682" alt="image" src="https://github.com/user-attachments/assets/56f2fcf8-dc7b-4ef1-a4ef-f9c3491228d8" />

## Description
<!--- Describe your changes in detail -->

Display account selector on the reportee error page. The likeliest case is that it fails due to cache in one of the other products, but we do not use cache and thus should have the updated account list. Thus, we can display the currently chose reportee so the end-user knows who they are currently representing (and possibly open the selector to see that the account they tried to select is gone)

Also added links to inbox and AMUI in addition to some minor cosmetic fixes.

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/2846

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced reportee change error pages with a "next steps" navigation section, guiding users to relevant destinations including the Altinn start page, inbox, and account management.
  * Added complete localization support across English, Norwegian Bokmål, and Norwegian Nynorsk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->