### PR TITLE
Add warning banner for June 19th

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "vitest:ci": "vitest --coverage"
   },
   "dependencies": {
-    "@altinn/altinn-components": "0.59.0",
+    "@altinn/altinn-components": "0.62.0",
     "@navikt/aksel-icons": "^8.9.0",
     "@reduxjs/toolkit": "^2.11.2",
     "@tanstack/react-query": "^5.95.2",

--- a/src/features/amUI/common/PageLayoutWrapper/PageLayoutWrapper.tsx
+++ b/src/features/amUI/common/PageLayoutWrapper/PageLayoutWrapper.tsx
@@ -39,13 +39,21 @@ export const PageLayoutWrapper = ({
   const footer = useFooter();
   const { sidebarItems, shortcutsMenuItem } = useSidebarItems({ isSmall: false });
 
+  const escalateBannerSeverity = new Date() >= new Date(2026, 5, 2); // Escalate to warning on June 2nd, 2026
+  const bannerLink = getBannerLink(languageCode as LanguageCode);
+
   return (
     <RootProvider languageCode={languageCode as LanguageCode}>
       <Layout
-        useGlobalHeader
         color={reportee?.type ? getAccountType(reportee.type) : 'neutral'}
         theme='subtle'
         header={header}
+        banner={{
+          title: t('info_banner.info'),
+          link: { label: t('info_banner.link'), href: bannerLink },
+          color: escalateBannerSeverity ? 'warning' : undefined,
+          variant: escalateBannerSeverity ? 'alert' : undefined,
+        }}
         skipLink={{
           href:
             pathname === '/'
@@ -81,4 +89,15 @@ export const PageLayoutWrapper = ({
       <Snackbar />
     </RootProvider>
   );
+};
+
+const getBannerLink = (languageCode: LanguageCode) => {
+  switch (languageCode) {
+    case 'en':
+      return 'https://info.altinn.no/en/news/check-if-you-need-to-take-action-before-we-shut-down-the-old-altinn/';
+    case 'nn':
+      return 'https://info.altinn.no/nn/nyheiter/sjekk-om-du-ma-gjere-noko-for-vi-slar-av-gamle-altinn/';
+    default:
+      return 'https://info.altinn.no/nyheter/sjekk-om-du-ma-gjore-noe-for-vi-slar-av-gamle-altinn/';
+  }
 };

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -102,9 +102,9 @@
     "no_access_to_page": "You do not have access to this page for the selected actor",
     "see_details": "See details"
   },
-  "beta_banner": {
-    "info": "This is a beta version of the new access management pages in Altinn.",
-    "link": "Click here to go back to today's Altinn."
+  "info_banner": {
+    "info": "June 19: the old Altinn will be shut down.",
+    "link": "Here's what you need to be aware of."
   },
   "header": {
     "access_management": "Access management",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -99,9 +99,9 @@
     "no_access_to_page": "Du har ikke tilgang til denne siden for valgt aktør",
     "see_details": "Se detaljer"
   },
-  "beta_banner": {
-    "info": "Du ser nå på en betaversjon av de nye sidene for tilgangsstyring i Altinn.",
-    "link": "Klikk her for å gå tilbake til dagens Altinn."
+  "info_banner": {
+    "info": "19. juni skrus gamle Altinn av.",
+    "link": "Dette må du passe på."
   },
   "error_page": {
     "not_found_site_error_type": "Feil 404",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -99,9 +99,9 @@
     "no_access_to_page": "Du har ikkje tilgang til denne sida for vald aktør",
     "see_details": "Sjå detaljar"
   },
-  "beta_banner": {
-    "info": "Du ser no på ein betaversjon av dei nye sidene for tilgangsstyring i Altinn.",
-    "link": "Klikk her for å gå tilbake til dagens Altinn."
+  "info_banner": {
+    "info": "19. juni blir gamle Altinn skrudd av.",
+    "link": "Dette må du passe på."
   },
   "header": {
     "access_management": "Tilgangsstyring",

--- a/src/sites/ErrorPage/amUi/ErrorLayoutWrapper.tsx
+++ b/src/sites/ErrorPage/amUi/ErrorLayoutWrapper.tsx
@@ -26,7 +26,6 @@ export const ErrorLayoutWrapper = ({
   return (
     <RootProvider languageCode={languageCode as LanguageCode}>
       <Layout
-        useGlobalHeader
         color={'neutral'}
         theme='default'
         header={header}

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,9 +19,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@altinn/altinn-components@npm:0.59.0":
-  version: 0.59.0
-  resolution: "@altinn/altinn-components@npm:0.59.0"
+"@altinn/altinn-components@npm:0.62.0":
+  version: 0.62.0
+  resolution: "@altinn/altinn-components@npm:0.62.0"
   dependencies:
     "@digdir/designsystemet-css": "npm:^1.9.0"
     "@digdir/designsystemet-react": "npm:^1.9.0"
@@ -34,7 +34,7 @@ __metadata:
   peerDependencies:
     react: ">=18.3.1 || ^19.0.0"
     react-dom: ">=18.3.1 || ^19.0.0"
-  checksum: 10/d665b96746249d9c6b848719b1ab60c2fb9363b172454d548426792f5339d2cb30d6f66f8c4cce64d59daeadfa93d67a823a3eee62e2e526d131fdedefdd331b
+  checksum: 10/ee23ce1b98f994739af8fee9b859a2afa51a8f1d10b307791a4b9ea6637490b17eb7ffb24754c1aaea8ea22bc1bf2e4ffd62d3db3046b894670942d60d17b6bb
   languageName: node
   linkType: hard
 
@@ -3347,7 +3347,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "access-management@workspace:."
   dependencies:
-    "@altinn/altinn-components": "npm:0.59.0"
+    "@altinn/altinn-components": "npm:0.62.0"
     "@axe-core/playwright": "npm:^4.10.2"
     "@navikt/aksel-icons": "npm:^8.9.0"
     "@playwright/test": "npm:^1.55.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<img width="1439" height="651" alt="image" src="https://github.com/user-attachments/assets/5e647509-dbb9-4049-b34a-7c1c58d425c9" />

## Description
<!--- Describe your changes in detail -->

This introduces an info banner at the top of all our pages which informs the users that the old Altinn solution will be turned off on June 19th. The warning is in default mode until June 2nd, when it will automatically switch to warning color and symbol to imply more urgency.

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/3044

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added informational banner announcing service changes with dynamic visual escalation approaching the update date.

* **Chores**
  * Updated `@altinn/altinn-components` dependency version.
  * Refactored banner and layout rendering logic.

* **Documentation**
  * Updated translations for new service announcement banner across multiple languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->