### PR TITLE
Add aria-live region for add org search result

### DIFF
--- a/src/features/amUI/users/NewUserModal/NewOrgContent.tsx
+++ b/src/features/amUI/users/NewUserModal/NewOrgContent.tsx
@@ -74,18 +74,27 @@ export const NewOrgContent = ({
         size='sm'
         onChange={(e) => setOrgNumber((e.target as HTMLInputElement).value.replace(/ /g, ''))}
       />
-      {!isGetOrgError && !orgDataLoading && orgData && orgData.orgNumber === orgNumber && (
-        <div className={classes.searchResult}>
-          <DsParagraph>
-            <strong>{orgData.name}</strong>
-          </DsParagraph>
-          <DsParagraph data-size='sm'>
-            {t('common.org_nr')} {formatOrgNr(orgData.orgNumber)}
-            {orgData.unitType === 'AAFY' ||
-              (orgData?.unitType === 'BEDR' && ' - ' + t('common.subunit'))}
-          </DsParagraph>
-        </div>
-      )}
+      <div aria-live='polite'>
+        {!isGetOrgError && !orgDataLoading && orgData && orgData.orgNumber === orgNumber && (
+          <div className={classes.searchResult}>
+            <DsHeading
+              data-size='2xs'
+              level={3}
+              className={classes.searchResultHeading}
+            >
+              {t('new_user_modal.org_search_result_label')}
+            </DsHeading>
+            <DsParagraph>
+              <strong>{orgData.name}</strong>
+            </DsParagraph>
+            <DsParagraph data-size='sm'>
+              {t('common.org_nr')} {formatOrgNr(orgData.orgNumber)}
+              {orgData.unitType === 'AAFY' ||
+                (orgData?.unitType === 'BEDR' && ' - ' + t('common.subunit'))}
+            </DsParagraph>
+          </div>
+        )}
+      </div>
 
       <div className={classes.validationButton}>
         <DsButton

--- a/src/features/amUI/users/NewUserModal/NewUserModal.module.css
+++ b/src/features/amUI/users/NewUserModal/NewUserModal.module.css
@@ -32,6 +32,11 @@
   gap: 10px;
 }
 
+.searchResultHeading {
+  margin-bottom: var(--ds-spacing-1);
+  font-size: 0.9em;
+}
+
 .searchResult {
   padding: 10px 0 10px 0;
 }

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -585,7 +585,8 @@
     "person_identifier_ssn_format_error": "Social security number must consist of 11 digits",
     "person_identifier_username_format_error": "Username must be at least 6 characters",
     "person_identifier_whitespace_forbidden_error": "Spaces are not allowed in SSN or username",
-    "last_name_format_error": "Please enter a valid last name"
+    "last_name_format_error": "Please enter a valid last name",
+    "org_search_result_label": "You will add:"
   },
   "maskinporten_page": {
     "heading": "Maskinporten administration",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -582,7 +582,8 @@
     "person_identifier_ssn_format_error": "Fødselsnummer må bestå av 11 siffer",
     "person_identifier_username_format_error": "Brukernavn må bestå av minst 6 tegn",
     "person_identifier_whitespace_forbidden_error": "Mellomrom er ikke tillatt i fødselsnummer eller brukernavn",
-    "last_name_format_error": "Vennligst fyll inn et gyldig etternavn"
+    "last_name_format_error": "Vennligst fyll inn et gyldig etternavn",
+    "org_search_result_label": "Du legger til:"
   },
   "maskinporten_page": {
     "heading": "Maskinporten\u00ADadministrasjon",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -582,7 +582,8 @@
     "person_identifier_ssn_format_error": "Fødselsnummer må bestå av 11 siffer",
     "person_identifier_username_format_error": "Brukarnamn må bestå av minst 6 teikn",
     "person_identifier_whitespace_forbidden_error": "Mellomrom er ikkje tillate i fødselsnummer eller brukarnamn",
-    "last_name_format_error": "Vennligst fyll inn eit gyldig etternavn"
+    "last_name_format_error": "Vennligst fyll inn eit gyldig etternavn",
+    "org_search_result_label": "Du legg til:"
   },
   "maskinporten_page": {
     "heading": "Maskinporten\u00ADadministrasjon",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<img width="766" height="518" alt="image" src="https://github.com/user-attachments/assets/5008aeac-c9c3-47dd-80a1-910d8091af41" />

## Description
<!--- Describe your changes in detail -->
Added aria-live region to the result of org search in NewUserModal so that the result will be read out loud by screen readers. Also added a small header to contextualize the result.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved screen reader announcements for organization search results in the new user modal

* **Style**
  * Enhanced search result heading styling with better spacing and sizing

* **Localization**
  * Added translated labels for organization search results across supported languages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->