### PR TITLE
Enable Dialogporten lookup in prod

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.Prod.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.Prod.json
@@ -36,7 +36,7 @@
     "AddAllSystemuserCustomers": true,
     "EnableRequestAccess": true,
     "EnableAddSelfToSystemuser": true,
-    "EnableDialogportenDialogLookup": false,
+    "EnableDialogportenDialogLookup": true,
     "EnableMaskinportenAdministration": false,
     "UseConnectionsForAgentSystemuser": true
   }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.YT01.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.YT01.json
@@ -35,7 +35,7 @@
     "DisplayDeletedAccountToggle": true,
     "AddAllSystemuserCustomers": true,
     "EnableAddSelfToSystemuser": false,
-    "EnableDialogportenDialogLookup": false,
+    "EnableDialogportenDialogLookup": true,
     "EnableMaskinportenAdministration": false
   }
 }


### PR DESCRIPTION
Set EnableDialogportenDialogLookup to true in production and YT01 environment appsettings to enable Dialogporten lookup. 


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled Dialogporten dialog lookup functionality in production and YT01 environments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-access-management-frontend/pull/2205)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->