### PR TITLE
Add aria-label so request count is read by screen reader

### DIFF
--- a/src/features/amUI/common/PageLayoutWrapper/useSidebarItems.tsx
+++ b/src/features/amUI/common/PageLayoutWrapper/useSidebarItems.tsx
@@ -35,8 +35,10 @@ import { BadgeVariant, Color, MenuItemProps } from '@altinn/altinn-components';
 import { useLocation } from 'react-router';
 import { useGetRolePermissionsQuery } from '@/rtk/features/roleApi';
 import { useSidebarRequestCount } from '@/resources/hooks/useSidebarRequestCount';
+import { useTranslation } from 'react-i18next';
 
 export const useSidebarItems = ({ isSmall }: { isSmall?: boolean }) => {
+  const { t } = useTranslation();
   const displayConfettiPackage = window.featureFlags?.displayConfettiPackage;
 
   const displaySettingsPage = window.featureFlags?.displaySettingsPage;
@@ -93,8 +95,12 @@ export const useSidebarItems = ({ isSmall }: { isSmall?: boolean }) => {
             variant: 'base' as BadgeVariant,
           }
         : undefined;
+    const requestMenuItem = getRequestsMenuItem(pathname, isLoading, isSmall);
+    const requestCountAriaLabel =
+      requestsBadgeCount > 0 ? `(${requestsBadgeCount} ${t('sidebar.requests_badge')})` : '';
     items.push({
-      ...getRequestsMenuItem(pathname, isLoading, isSmall),
+      ...requestMenuItem,
+      'aria-label': `${requestMenuItem.title} ${requestCountAriaLabel}`,
       badge: requestsBadge,
     });
   }

--- a/src/features/amUI/common/PageLayoutWrapper/useSidebarItems.tsx
+++ b/src/features/amUI/common/PageLayoutWrapper/useSidebarItems.tsx
@@ -97,10 +97,10 @@ export const useSidebarItems = ({ isSmall }: { isSmall?: boolean }) => {
         : undefined;
     const requestMenuItem = getRequestsMenuItem(pathname, isLoading, isSmall);
     const requestCountAriaLabel =
-      requestsBadgeCount > 0 ? `(${requestsBadgeCount} ${t('sidebar.requests_badge')})` : '';
+      requestsBadgeCount > 0 ? ` (${requestsBadgeCount} ${t('sidebar.requests_badge')})` : '';
     items.push({
       ...requestMenuItem,
-      'aria-label': `${requestMenuItem.title} ${requestCountAriaLabel}`,
+      'aria-label': `${requestMenuItem.title}${requestCountAriaLabel}`,
       badge: requestsBadge,
     });
   }

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -155,6 +155,7 @@
     "poa_overview": "Powers of attorney",
     "settings": "Settings",
     "requests": "Requests",
+    "requests_badge": "received",
     "maskinporten": "Maskinporten administration"
   },
   "error_page": {

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -183,6 +183,7 @@
     "poa_overview": "Fullmakter",
     "settings": "Innstillinger",
     "requests": "Forespørsler",
+    "requests_badge": "mottatt",
     "maskinporten": "Maskinporten\u00ADadministrasjon"
   },
   "profile": {

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -152,6 +152,7 @@
     "poa_overview": "Fullmakter",
     "settings": "Innstillingar",
     "requests": "Forespørsler",
+    "requests_badge": "mottatt",
     "maskinporten": "Maskinporten\u00ADadministrasjon"
   },
   "error_page": {


### PR DESCRIPTION
## Description
- Screen reader will now read number of requests for requests menu item

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/3122

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sidebar requests badge label translations for English and Norwegian (Bokmål and Nynorsk).
  * Improved accessibility for the requests badge with enhanced screen reader support.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-access-management-frontend/pull/2207)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->