### PR TITLE
UU: set focus to h1 element on page navigation

### DIFF
--- a/src/features/amUI/common/InstanceDescription/InstanceDescription.tsx
+++ b/src/features/amUI/common/InstanceDescription/InstanceDescription.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { useEffect, useRef, type ReactNode } from 'react';
 import { Avatar, DsHeading, DsParagraph, Icon, formatDisplayName } from '@altinn/altinn-components';
 import { useTranslation } from 'react-i18next';
 
@@ -32,6 +32,7 @@ export const InstanceDescription = ({
   titleLevel = 2,
   statusSection,
 }: InstanceDescriptionProps) => {
+  const headerRef = useRef<HTMLHeadingElement>(null);
   const { getProviderLogoUrl } = useProviderLogoUrl();
   const { t, i18n } = useTranslation();
   const dialogportenLookupEnabled = enableDialogportenDialogLookup();
@@ -45,11 +46,19 @@ export const InstanceDescription = ({
     type: fromPartyType === PartyType.Person ? 'person' : 'company',
   });
 
+  useEffect(() => {
+    if (headerRef.current && titleLevel === 1) {
+      headerRef.current.focus();
+    }
+  }, [titleLevel]);
+
   return (
     <div className={classes.container}>
       <DsHeading
         level={titleLevel}
         data-size='sm'
+        ref={headerRef}
+        tabIndex={-1}
       >
         {title}
       </DsHeading>

--- a/src/features/amUI/common/ReporteePageHeading/ReporteePageHeading.tsx
+++ b/src/features/amUI/common/ReporteePageHeading/ReporteePageHeading.tsx
@@ -5,6 +5,7 @@ import { DsHeading, DsSkeleton } from '@altinn/altinn-components';
 
 import styles from './ReporteePageHeading.module.css';
 import { formatOrgNr, isSubUnit } from '@/resources/utils/reporteeUtils';
+import { useEffect, useRef } from 'react';
 
 type Props = {
   title: string;
@@ -27,10 +28,17 @@ export const ReporteePageHeading: React.FC<Props> = ({
   subHeadingDataSize = '2xs',
   isLoading = false,
 }) => {
+  const headerRef = useRef<HTMLHeadingElement>(null);
   const { t } = useTranslation();
   const orgNumber = reportee?.organizationNumber ?? '';
   const isReporteeMainUnit = (reportee?.subunits?.length ?? 0) > 0;
   const isReporteeSubUnit = isSubUnit(reportee);
+
+  useEffect(() => {
+    if (headerRef.current && !isLoading) {
+      headerRef.current.focus();
+    }
+  }, [isLoading]);
 
   if (isLoading) {
     return (
@@ -55,6 +63,8 @@ export const ReporteePageHeading: React.FC<Props> = ({
       <DsHeading
         level={level}
         data-size={dataSize}
+        tabIndex={-1}
+        ref={headerRef}
       >
         {title}
       </DsHeading>

--- a/src/features/amUI/common/RequestPageLayout/RequestPageLayout.tsx
+++ b/src/features/amUI/common/RequestPageLayout/RequestPageLayout.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useSearchParams } from 'react-router';
 import cn from 'classnames';

--- a/src/features/amUI/common/RequestPageLayout/RequestPageLayout.tsx
+++ b/src/features/amUI/common/RequestPageLayout/RequestPageLayout.tsx
@@ -36,7 +36,6 @@ export const RequestPageLayout = ({
   footer,
 }: RequestPageLayoutProps) => {
   const { t, i18n } = useTranslation();
-  const headingRef = useRef<HTMLDivElement>(null);
 
   const [searchParams] = useSearchParams();
   const backToPage = searchParams.get('backtopage');
@@ -49,12 +48,6 @@ export const RequestPageLayout = ({
     document.cookie = `selectedLanguage=${newLocale}; path=/; SameSite=Strict`;
     updateSelectedLanguage(newLocale);
   };
-
-  useEffect(() => {
-    if (headingRef.current) {
-      headingRef.current.focus();
-    }
-  }, [headingRef, heading]);
 
   return (
     <RootProvider>
@@ -126,13 +119,7 @@ export const RequestPageLayout = ({
                 </Link>
               </DsButton>
             )}
-            <div
-              className={cn(classes.requestBlock, classes.headerBlock)}
-              ref={headingRef}
-              tabIndex={-1}
-            >
-              {heading}
-            </div>
+            <div className={cn(classes.requestBlock, classes.headerBlock)}>{heading}</div>
             <div className={classes.requestBlock}>{body}</div>
             {footer}
           </div>

--- a/src/features/amUI/common/RequestPageLayout/RequestPageLayout.tsx
+++ b/src/features/amUI/common/RequestPageLayout/RequestPageLayout.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useSearchParams } from 'react-router';
 import cn from 'classnames';
@@ -36,6 +36,7 @@ export const RequestPageLayout = ({
   footer,
 }: RequestPageLayoutProps) => {
   const { t, i18n } = useTranslation();
+  const headingRef = useRef<HTMLDivElement>(null);
 
   const [searchParams] = useSearchParams();
   const backToPage = searchParams.get('backtopage');
@@ -49,10 +50,16 @@ export const RequestPageLayout = ({
     updateSelectedLanguage(newLocale);
   };
 
+  useEffect(() => {
+    if (headingRef.current) {
+      headingRef.current.focus();
+    }
+  }, [headingRef, heading]);
+
   return (
     <RootProvider>
       <Layout
-        color={account.type}
+        color={isLoading ? 'neutral' : account.type}
         theme='subtle'
         header={{
           locale: {
@@ -119,7 +126,13 @@ export const RequestPageLayout = ({
                 </Link>
               </DsButton>
             )}
-            <div className={cn(classes.requestBlock, classes.headerBlock)}>{heading}</div>
+            <div
+              className={cn(classes.requestBlock, classes.headerBlock)}
+              ref={headingRef}
+              tabIndex={-1}
+            >
+              {heading}
+            </div>
             <div className={classes.requestBlock}>{body}</div>
             {footer}
           </div>

--- a/src/features/amUI/common/UserPageHeader/UserPageHeader.tsx
+++ b/src/features/amUI/common/UserPageHeader/UserPageHeader.tsx
@@ -10,6 +10,7 @@ import classes from './UserPageHeader.module.css';
 import { UserPageHeaderSkeleton } from './UserPageHeaderSkeleton';
 import { isSubUnitByType } from '@/resources/utils/reporteeUtils';
 import { useIsMobileOrSmaller } from '@/resources/utils/screensizeUtils';
+import { useEffect, useRef } from 'react';
 
 interface UserPageHeaderProps {
   direction: 'to' | 'from';
@@ -30,6 +31,7 @@ export const UserPageHeader = ({
   displayDirection = false,
   displayRoles = true,
 }: UserPageHeaderProps) => {
+  const headerRef = useRef<HTMLDivElement>(null);
   const { toParty, fromParty, isLoading: loadingPartyRepresentation } = usePartyRepresentation();
   const toPartyName = formatDisplayName({
     fullName: toParty?.name ?? '',
@@ -40,6 +42,12 @@ export const UserPageHeader = ({
     type: fromParty?.partyTypeName === PartyType.Organization ? 'company' : 'person',
   });
   const isSmall = useIsMobileOrSmaller();
+
+  useEffect(() => {
+    if (headerRef.current && !loadingPartyRepresentation) {
+      headerRef.current.focus();
+    }
+  }, [headerRef.current, loadingPartyRepresentation]);
 
   if (!toParty && !fromParty && !loadingPartyRepresentation) {
     return null;
@@ -89,6 +97,8 @@ export const UserPageHeader = ({
         level={1}
         data-size={isSmall ? '2xs' : 'sm'}
         className={classes.heading}
+        ref={headerRef}
+        tabIndex={-1}
       >
         {userName}
       </DsHeading>

--- a/src/features/amUI/consent/ConsentRequestPage/ConsentRequestPage.tsx
+++ b/src/features/amUI/consent/ConsentRequestPage/ConsentRequestPage.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useSearchParams } from 'react-router';
 import { DsAlert, DsButton, DsHeading, DsParagraph } from '@altinn/altinn-components';
@@ -20,6 +20,7 @@ import { ConsentRights } from '../components/ConsentRights/ConsentRights';
 
 export const ConsentRequestPage = () => {
   const { t, i18n } = useTranslation();
+  const headerRef = useRef<HTMLHeadingElement>(null);
 
   useDocumentTitle(t('consent_request.page_title'));
   const [searchParams] = useSearchParams();
@@ -49,6 +50,12 @@ export const ConsentRequestPage = () => {
     postRejectConsent,
     { data: rejectResponse, error: rejectConsentError, isLoading: isRejectingConsent },
   ] = useRejectConsentRequestMutation();
+
+  useEffect(() => {
+    if (!isLoadingRequest) {
+      headerRef.current?.focus();
+    }
+  }, [isLoadingRequest]);
 
   const isRequestApproved = isAccepted(request?.consentRequestEvents ?? []);
   const isRequestRejected = isRevoked(request?.consentRequestEvents ?? []);
@@ -159,6 +166,8 @@ export const ConsentRequestPage = () => {
         <DsHeading
           level={1}
           data-size='md'
+          ref={headerRef}
+          tabIndex={-1}
         >
           {memoizedRequest.title[language]}
         </DsHeading>

--- a/src/features/amUI/landingPage/LandingPage.tsx
+++ b/src/features/amUI/landingPage/LandingPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { PageWrapper } from '@/components';
 import { PageLayoutWrapper } from '../common/PageLayoutWrapper';
 import classes from './LandingPage.module.css';
@@ -59,6 +59,7 @@ import { useDocumentTitle } from '@/resources/hooks/useDocumentTitle';
 
 export const LandingPage = () => {
   const { t } = useTranslation();
+  const headerRef = useRef<HTMLDivElement>(null);
   useDocumentTitle(t('landing_page.page_title'));
   const [searchParams, setSearchParams] = useSearchParams();
   const [shouldOpenAccountMenu, setShouldOpenAccountMenu] = useState<boolean>(false);
@@ -114,6 +115,12 @@ export const LandingPage = () => {
       setSearchParams(newSearchParams, { replace: true });
     }
   }, [searchParams, setSearchParams]);
+
+  useEffect(() => {
+    if (headerRef.current && reportee) {
+      headerRef.current.focus();
+    }
+  }, [reportee]);
 
   const isLoading =
     isLoadingReportee ||
@@ -273,21 +280,26 @@ export const LandingPage = () => {
     <PageWrapper>
       <PageLayoutWrapper openAccountMenu={shouldOpenAccountMenu}>
         <div className={classes.landingPage}>
-          <List className={classes.landingPageHeading}>
-            <UserListItem
-              id={reportee?.partyUuid ?? ''}
-              type={isOrganization(reportee) ? 'company' : 'person'}
-              name={reporteeName}
-              description={getReporteeDescription()}
-              subUnit={isReporteeSubUnit}
-              deleted={reportee?.isDeleted}
-              size='lg'
-              titleAs='h1'
-              loading={!reportee}
-              interactive={false}
-              shadow='none'
-            />
-          </List>
+          <div
+            ref={headerRef}
+            tabIndex={-1}
+          >
+            <List className={classes.landingPageHeading}>
+              <UserListItem
+                id={reportee?.partyUuid ?? ''}
+                type={isOrganization(reportee) ? 'company' : 'person'}
+                name={reporteeName}
+                description={getReporteeDescription()}
+                subUnit={isReporteeSubUnit}
+                deleted={reportee?.isDeleted}
+                size='lg'
+                titleAs='h1'
+                loading={!reportee}
+                interactive={false}
+                shadow='none'
+              />
+            </List>
+          </div>
           <DsAlert data-color='info'>
             {isLoading ? (
               <DsSkeleton

--- a/src/features/amUI/packagePoaDetailsPage/PackagePoaDetailsHeader.tsx
+++ b/src/features/amUI/packagePoaDetailsPage/PackagePoaDetailsHeader.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import classes from './PackagePoaDetailsHeader.module.css';
 import { DsHeading, DsParagraph } from '@altinn/altinn-components';
 import { PackageIcon } from '@navikt/aksel-icons';
@@ -17,6 +17,14 @@ export const PackagePoaDetailsHeader: React.FC<PackagePoaDetailsHeaderProps> = (
   isLoading = false,
   statusSection,
 }) => {
+  const headerRef = useRef<HTMLHeadingElement>(null);
+
+  useEffect(() => {
+    if (headerRef.current && !isLoading) {
+      headerRef.current.focus();
+    }
+  }, [isLoading]);
+
   return isLoading ? (
     <PackagePoaDetailsHeaderSkeleton />
   ) : (
@@ -29,6 +37,8 @@ export const PackagePoaDetailsHeader: React.FC<PackagePoaDetailsHeaderProps> = (
         level={1}
         data-size='lg'
         className={classes.pageHeading}
+        ref={headerRef}
+        tabIndex={-1}
       >
         {packageName}
       </DsHeading>

--- a/src/features/amUI/requestPage/DraftRequestPage/DraftRequestHeader.tsx
+++ b/src/features/amUI/requestPage/DraftRequestPage/DraftRequestHeader.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Trans } from 'react-i18next';
 import { DsHeading } from '@altinn/altinn-components';
 
@@ -8,10 +8,20 @@ interface DraftRequestHeaderProps {
 }
 
 export const DraftRequestHeader = ({ headerTextKey, toName }: DraftRequestHeaderProps) => {
+  const headerRef = useRef<HTMLHeadingElement>(null);
+
+  useEffect(() => {
+    if (toName) {
+      headerRef.current?.focus();
+    }
+  }, [toName]);
+
   return (
     <DsHeading
       level={1}
       data-size='md'
+      ref={headerRef}
+      tabIndex={-1}
     >
       <Trans
         i18nKey={headerTextKey}

--- a/src/features/amUI/systemUser/components/RequestPageBase/RequestPageBase.tsx
+++ b/src/features/amUI/systemUser/components/RequestPageBase/RequestPageBase.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { DsHeading, DsParagraph } from '@altinn/altinn-components';
 import { ReporteeInfo } from '@/rtk/features/userInfoApi';
@@ -25,11 +25,18 @@ export const RequestPageBase = ({
   children,
 }: RequestPageBaseProps): React.ReactNode => {
   const { t } = useTranslation();
+  const headerRef = useRef<HTMLHeadingElement>(null);
 
   const account: { name: string; type: 'person' | 'company' } = {
     name: reportee?.name || '',
     type: reportee?.type === 'Person' ? 'person' : 'company',
   };
+
+  useEffect(() => {
+    if (heading && !isLoading) {
+      headerRef.current?.focus();
+    }
+  }, [heading, isLoading]);
 
   return (
     <RequestPageLayout
@@ -40,6 +47,8 @@ export const RequestPageBase = ({
         <DsHeading
           level={1}
           data-size='lg'
+          ref={headerRef}
+          tabIndex={-1}
         >
           {heading}
         </DsHeading>

--- a/src/features/amUI/systemUser/components/SystemUserHeader/SystemUserHeader.tsx
+++ b/src/features/amUI/systemUser/components/SystemUserHeader/SystemUserHeader.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Avatar, DsHeading, DsParagraph, DsSkeleton } from '@altinn/altinn-components';
 
 import classes from './SystemUserHeader.module.css';
@@ -16,6 +16,14 @@ export const SystemUserHeader = ({
   subTitle,
   isLoading,
 }: SystemUserHeaderProps): React.ReactNode => {
+  const headerRef = useRef<HTMLHeadingElement>(null);
+
+  useEffect(() => {
+    if (headerRef.current && !isLoading) {
+      headerRef.current.focus();
+    }
+  }, [isLoading]);
+
   return (
     <div className={classes.systemUserDetailsHeader}>
       <Avatar
@@ -27,6 +35,8 @@ export const SystemUserHeader = ({
         <DsHeading
           level={1}
           data-size='sm'
+          ref={headerRef}
+          tabIndex={-1}
         >
           {isLoading ? (
             <DsSkeleton


### PR DESCRIPTION
## Description
- When navigating to a new page, set focus on the top h1 element when the h1 element is rendered

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/2938

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility by automatically moving keyboard focus to main page headings when pages load or relevant state changes complete—applied across landing, consent, request, user, system user, reportee and package pages for more consistent keyboard navigation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-access-management-frontend/pull/2218?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->