### PR TITLE
fix: avoid rendering a div inside a p element

### DIFF
--- a/src/features/amUI/poaOverview/AccessPackagePermissions.tsx
+++ b/src/features/amUI/poaOverview/AccessPackagePermissions.tsx
@@ -15,10 +15,10 @@ export const AccessPackagePermissions = () => {
 
   return (
     <>
-      <DsParagraph className={classes.description}>
-        {t('poa_overview_page.packages_tab.description')}
+      <div className={classes.description}>
+        <DsParagraph>{t('poa_overview_page.packages_tab.description')}</DsParagraph>
         <AccessPackageInfoPopover />
-      </DsParagraph>
+      </div>
       <DebouncedSearchField
         placeholder={t('access_packages.search_label')}
         setDebouncedSearchString={setDebouncedSearchString}


### PR DESCRIPTION
## Description
-  Avoid rendering a `div` inside a `p` element, to fix error shown in console

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
