### PR TITLE
Turn off A2 actor sync in AT22

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.AT22.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.AT22.json
@@ -55,6 +55,7 @@
     "EnableAddSelfToSystemuser": true,
     "EnableDialogportenDialogLookup": false,
     "UseConnectionsForAgentSystemuser": true,
-    "EnableMaskinportenAdministration": true
+    "EnableMaskinportenAdministration": true,
+    "RouteChangeReporteeViaAltinn2": false
   }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.Development.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.Development.json
@@ -59,6 +59,6 @@
     "EnableAddSelfToSystemuser": true,
     "EnableDialogportenDialogLookup": true,
     "EnableMaskinportenAdministration": true,
-    "RouteChangeReporteeViaAltinn2": true
+    "RouteChangeReporteeViaAltinn2": false
   }
 }

--- a/src/components/ReloadAlert/ReloadAlert.tsx
+++ b/src/components/ReloadAlert/ReloadAlert.tsx
@@ -8,7 +8,7 @@ import classes from './ReloadAlert.module.css';
 export const ReloadAlert = () => {
   const { t } = useTranslation();
 
-  const displayAlert = useCookieListener('AltinnPartyId');
+  const displayAlert = useCookieListener('AltinnPartyId', 2000, 2000);
 
   return (
     displayAlert && (

--- a/src/resources/Cookie/CookieMethods.ts
+++ b/src/resources/Cookie/CookieMethods.ts
@@ -28,15 +28,21 @@ export const useCookieListener = (cookieName: string, interval = 2000, delayResp
   const [cookieChanged, setCookieChanged] = useState(false);
 
   useEffect(() => {
+    let delayTimeout: ReturnType<typeof setTimeout> | undefined;
+
     const checkCookie = setInterval(() => {
       const currentCookie = getCookie(cookieName);
       if (currentCookie !== cookieValue) {
         setCookieValue(currentCookie);
-        setTimeout(() => setCookieChanged(true), delayResponse);
+        clearTimeout(delayTimeout);
+        delayTimeout = setTimeout(() => setCookieChanged(true), delayResponse);
       }
     }, interval); // Check every interval
 
-    return () => clearInterval(checkCookie);
+    return () => {
+      clearInterval(checkCookie);
+      clearTimeout(delayTimeout);
+    };
   }, [cookieName, interval, delayResponse]);
 
   return cookieChanged;

--- a/src/resources/Cookie/CookieMethods.ts
+++ b/src/resources/Cookie/CookieMethods.ts
@@ -20,9 +20,10 @@ export function getCookie(cname: string) {
  * Detects changes in a given cookie by polling it with the given interval
  * @param cookieName The name of the cookie to be checked
  * @param interval The interval in which to poll the cookie (given in milliseconds)
+ * @param delayResponse The delay in milliseconds before signalling that the cookie has changed. Defaults to 0ms (no delay).
  * @returns `true` if the cookie has been changed from it's original value, `false` otherwise.
  */
-export const useCookieListener = (cookieName: string, interval = 2000) => {
+export const useCookieListener = (cookieName: string, interval = 2000, delayResponse = 0) => {
   const [cookieValue, setCookieValue] = useState(getCookie(cookieName));
   const [cookieChanged, setCookieChanged] = useState(false);
 
@@ -31,12 +32,12 @@ export const useCookieListener = (cookieName: string, interval = 2000) => {
       const currentCookie = getCookie(cookieName);
       if (currentCookie !== cookieValue) {
         setCookieValue(currentCookie);
-        setCookieChanged(true);
+        setTimeout(() => setCookieChanged(true), delayResponse);
       }
     }, interval); // Check every interval
 
     return () => clearInterval(checkCookie);
-  }, [cookieName, interval]);
+  }, [cookieName, interval, delayResponse]);
 
   return cookieChanged;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

To test decoupling from A2, we turn off the actor syncing to A2 in AT22 (and dev)

Also: Added optional delay to cookie listener hook to minimize risk of the "reload modal" appearing in the current tab when changing the actor in that same tab.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Updated feature flag settings across environment-specific configuration files to manage system behavior

* **Improvements**
  * Modified reload alert mechanism with new configurable timing parameters that support customizable response delays for improved alert triggering across different scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-access-management-frontend/pull/2222?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->