### PR TITLE
Skjul ikke-delegerbare pakker fra pakkelister #3190

### DIFF
--- a/src/features/amUI/common/AccessPackageList/useAreaPackageList.ts
+++ b/src/features/amUI/common/AccessPackageList/useAreaPackageList.ts
@@ -133,6 +133,7 @@ export const useAreaPackageList = ({
                   };
                   pkgAcc.assigned.push(acquiredPkg);
                 } else if (showAllPackages && pkg.isAssignable !== false) {
+                  // Hide non-assignable packages that no one has
                   pkgAcc.available.push(pkg);
                 }
 
@@ -146,6 +147,7 @@ export const useAreaPackageList = ({
 
             acc.assignedAreas.push({ ...area, packages: pkgs });
           } else if (showAllAreas) {
+            // Hide the area entirely if it only contains non-assignable packages and has no existing delegations.
             const assignablePackages = area.accessPackages.filter(
               (pkg) => pkg.isAssignable !== false,
             );

--- a/src/features/amUI/common/AccessPackageList/useAreaPackageList.ts
+++ b/src/features/amUI/common/AccessPackageList/useAreaPackageList.ts
@@ -133,7 +133,7 @@ export const useAreaPackageList = ({
                   };
                   pkgAcc.assigned.push(acquiredPkg);
                 } else if (showAllPackages && pkg.isAssignable !== false) {
-                  // Hide non-assignable packages that no one has
+                  // Non-assignable packages cannot be delegated, so omit them from the available list.
                   pkgAcc.available.push(pkg);
                 }
 
@@ -147,10 +147,10 @@ export const useAreaPackageList = ({
 
             acc.assignedAreas.push({ ...area, packages: pkgs });
           } else if (showAllAreas) {
-            // Hide the area entirely if it only contains non-assignable packages and has no existing delegations.
             const assignablePackages = area.accessPackages.filter(
               (pkg) => pkg.isAssignable !== false,
             );
+            // Skip the area when none of its packages can be delegated — otherwise it would render empty.
             if (assignablePackages.length > 0) {
               acc.availableAreas.push({
                 ...area,

--- a/src/features/amUI/common/AccessPackageList/useAreaPackageList.ts
+++ b/src/features/amUI/common/AccessPackageList/useAreaPackageList.ts
@@ -145,7 +145,10 @@ export const useAreaPackageList = ({
               },
             );
 
-            acc.assignedAreas.push({ ...area, packages: pkgs });
+            // Skip the area if filtering left it empty (e.g. search hit only a non-assignable package).
+            if (pkgs.assigned.length > 0 || pkgs.available.length > 0) {
+              acc.assignedAreas.push({ ...area, packages: pkgs });
+            }
           } else if (showAllAreas) {
             const assignablePackages = area.accessPackages.filter(
               (pkg) => pkg.isAssignable !== false,


### PR DESCRIPTION
Skjuler pakker som har `isAssignable === false` i `useAreaPackageList`. Pakker som ingen har, og som uansett ikke kan delegeres via vanlig GUI, skjules nå fra både delegeringsflyten og fullmaktsoversikten.

Selve kodeendringen som fikser det ble dessverre med på en feiltagelse i forrige PR. Jeg hadde endringen liggende i working tree mens jeg jobbet med Maskinporten-PR-en, og fikk den ikke skilt ut i egen branch før commit. Men jeg legger på noen kommentarer for å synliggjøre endringen her.

Beklager det. Mea culpa. Jeg legger meg paddeflat 🐸 

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
https://github.com/Altinn/altinn-authorization-tmp/issues/3190

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added internal clarification comments to package-filtering logic to explain omission of non-assignable packages and skipping empty areas.

*Note: This release contains internal code improvements with no user-facing changes.*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-access-management-frontend/pull/2223?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->