### PR TITLE
La til tre tester for hoved- og underenheter

### DIFF
--- a/playwright/CLAUDE.md
+++ b/playwright/CLAUDE.md
@@ -1,3 +1,5 @@
+Coderabbit, ignore this file.
+
 # Playwright E2E Tests — Guidelines
 
 ## Locators

--- a/playwright/e2eTests/altinn3/Tilgangsstyring/AccessManagement.spec.ts
+++ b/playwright/e2eTests/altinn3/Tilgangsstyring/AccessManagement.spec.ts
@@ -1,9 +1,7 @@
-import { env } from 'playwright/util/helper';
 import { LoginPage } from 'playwright/pages/LoginPage';
 import { test } from '../../../fixture/pomFixture';
 import { AktorvalgHeader } from '../../../pages/AktorvalgHeader';
 import { EnduserConnection } from '../../../api-requests/EnduserConnection';
-import { AccessManagementFrontPage } from '../../../pages/AccessManagementFrontPage';
 
 test.describe.serial('Tilgangsstyring', () => {
   const api = new EnduserConnection();

--- a/playwright/e2eTests/altinn3/Tilgangsstyring/AccessManagement.spec.ts
+++ b/playwright/e2eTests/altinn3/Tilgangsstyring/AccessManagement.spec.ts
@@ -241,18 +241,25 @@ test.describe.serial('Tilgangsstyring', () => {
 test.describe('over- og underenheter', () => {
   const api = new EnduserConnection();
 
+  test.beforeAll('sett opp testdata', async () => {
+    await api.addConnectionAndPackagesToUser('25916799929', '313819566', '313244555', [
+      'urn:altinn:accesspackage:byggesoknad',
+    ]);
+    await api.addConnection('26888197213', '310959502', '312791404');
+    await api.delegateSingleService(
+      '26888197213',
+      '310959502',
+      '312791404',
+      'bruno-correspondence',
+    );
+  });
+
   test('Virksomhet skal kunne se tilgangspakker hos hoved- og underenhet som delegerte dem', async ({
     page,
     accessManagementFrontPage,
     login,
     aktorvalgHeader,
   }) => {
-    await test.step('sett opp testdata', async () => {
-      await api.addConnectionAndPackagesToUser('25916799929', '313819566', '313244555', [
-        'urn:altinn:accesspackage:byggesoknad',
-      ]);
-    });
-
     await test.step('Logg inn', async () => {
       await login.LoginToAccessManagement('30847798242');
     });
@@ -295,16 +302,6 @@ test.describe('over- og underenheter', () => {
     login,
     aktorvalgHeader,
   }) => {
-    await test.step('sett opp testdata', async () => {
-      await api.addConnection('26888197213', '310959502', '312791404');
-      await api.delegateSingleService(
-        '26888197213',
-        '310959502',
-        '312791404',
-        'bruno-correspondence',
-      );
-    });
-
     await test.step('Logg inn', async () => {
       await login.LoginToAccessManagement('16906997766');
     });
@@ -338,6 +335,90 @@ test.describe('over- og underenheter', () => {
     await test.step('FORMBAR GENIERKLÆRT TIGER AS skal ha enkelttjenesten bruno-correspondence hos underenheten', async () => {
       await accessManagementFrontPage.goToEnkelttjenester();
       await accessManagementFrontPage.expectUserToHaveEnkelttjeneste('bruno-correspondence');
+    });
+  });
+
+  test('Underenhet A som delegerte tilgangspakke til Virksomhet B skal kunne se Virksomhet B i brukerlista si', async ({
+    page,
+    accessManagementFrontPage,
+    login,
+    aktorvalgHeader,
+  }) => {
+    await test.step('Logg inn', async () => {
+      await login.LoginToAccessManagement('25916799929');
+    });
+
+    await test.step('Velg underenhet SMISKENDE UMODEN TIGER AS og gå til fullmakter hos andre', async () => {
+      await aktorvalgHeader.selectSubOrgFromHeaderMenu('SMISKENDE UMODEN TIGER AS');
+      await accessManagementFrontPage.goToUsers();
+    });
+
+    await test.step('Velg KONSERVATIV USELVISK KATT KLINKEKULE i lista over brukere', async () => {
+      await accessManagementFrontPage.expandOrg('KONSERVATIV USELVISK KATT KLINKEKULE');
+      await accessManagementFrontPage.clickUser('KONSERVATIV USELVISK KATT KLINKEKULE');
+    });
+
+    await test.step('KONSERVATIV USELVISK KATT KLINKEKULE skal ha tilgangspakken Byggesøknad hos underenheten', async () => {
+      await accessManagementFrontPage.goToArea('Bygg, anlegg og eiendom');
+      await accessManagementFrontPage.expectUserToHavePackage('Byggesøknad');
+    });
+
+    await test.step('Velg hovedenhet KONSERVATIV USELVISK KATT KLINKEKULE og gå til fullmakter hos andre', async () => {
+      await aktorvalgHeader.goToSelectActor('SMISKENDE UMODEN TIGER AS');
+      await aktorvalgHeader.selectActorFromHeaderMenu('SMISKENDE UMODEN TIGER AS');
+      await accessManagementFrontPage.goToUsers();
+    });
+
+    await test.step('Velg KONSERVATIV USELVISK KATT KLINKEKULE i lista over brukere', async () => {
+      await accessManagementFrontPage.expandOrg('KONSERVATIV USELVISK KATT KLINKEKULE');
+      await accessManagementFrontPage.clickUser('KONSERVATIV USELVISK KATT KLINKEKULE');
+    });
+
+    await test.step('KONSERVATIV USELVISK KATT KLINKEKULE skal ha tilgangspakken Byggesøknad hos hovedenheten', async () => {
+      await accessManagementFrontPage.goToArea('Bygg, anlegg og eiendom');
+      await accessManagementFrontPage.userCanDeletePackage('Byggesøknad');
+    });
+  });
+
+  test('Underenhet A som delegerte enkelttjeneste til Virksomhet B skal kunne se Virksomhet B i brukerlista si', async ({
+    page,
+    accessManagementFrontPage,
+    login,
+    aktorvalgHeader,
+  }) => {
+    await test.step('Logg inn', async () => {
+      await login.LoginToAccessManagement('26888197213');
+    });
+
+    await test.step('Velg underenhet RIKTIG AUTENTISK APE og gå til fullmakter hos andre', async () => {
+      await aktorvalgHeader.selectSubOrgFromHeaderMenu('RIKTIG AUTENTISK APE');
+      await accessManagementFrontPage.goToUsers();
+    });
+
+    await test.step('Velg FORMBAR GENIERKLÆRT TIGER AS i lista over brukere', async () => {
+      await accessManagementFrontPage.expandOrg('FORMBAR GENIERKLÆRT TIGER AS');
+      await accessManagementFrontPage.clickUser('FORMBAR GENIERKLÆRT TIGER AS');
+    });
+
+    await test.step('FORMBAR GENIERKLÆRT TIGER AS skal ha enkelttjenesten bruno-correspondence hos underenheten', async () => {
+      await accessManagementFrontPage.goToEnkelttjenester();
+      await accessManagementFrontPage.userCanDeleteEnkelttjeneste('bruno-correspondence');
+    });
+
+    await test.step('Velg hovedenhet RIKTIG AUTENTISK APE og gå til fullmakter hos andre', async () => {
+      await aktorvalgHeader.goToSelectActor('RIKTIG AUTENTISK APE');
+      await aktorvalgHeader.selectActorFromHeaderMenu('RIKTIG AUTENTISK APE');
+      await accessManagementFrontPage.goToUsers();
+    });
+
+    await test.step('Velg FORMBAR GENIERKLÆRT TIGER AS i lista over brukere', async () => {
+      await accessManagementFrontPage.expandOrg('FORMBAR GENIERKLÆRT TIGER AS');
+      await accessManagementFrontPage.clickUser('FORMBAR GENIERKLÆRT TIGER AS');
+    });
+
+    await test.step('FORMBAR GENIERKLÆRT TIGER AS skal ha enkelttjenesten bruno-correspondence hos hovedenheten', async () => {
+      await accessManagementFrontPage.goToEnkelttjenester();
+      await accessManagementFrontPage.userCanDeleteEnkelttjeneste('bruno-correspondence');
     });
   });
 });

--- a/playwright/e2eTests/altinn3/Tilgangsstyring/AccessManagement.spec.ts
+++ b/playwright/e2eTests/altinn3/Tilgangsstyring/AccessManagement.spec.ts
@@ -3,6 +3,7 @@ import { LoginPage } from 'playwright/pages/LoginPage';
 import { test } from '../../../fixture/pomFixture';
 import { AktorvalgHeader } from '../../../pages/AktorvalgHeader';
 import { EnduserConnection } from '../../../api-requests/EnduserConnection';
+import { AccessManagementFrontPage } from '../../../pages/AccessManagementFrontPage';
 
 test.describe.serial('Tilgangsstyring', () => {
   const api = new EnduserConnection();
@@ -235,6 +236,110 @@ test.describe.serial('Tilgangsstyring', () => {
 
     await test.step('Brukeren skal ikke kunne gi fullmakt til deg selv', async () => {
       await accessManagementFrontPage.expectPowerOfAttorneyButtonToNotBeVisible();
+    });
+  });
+});
+
+test.describe('over- og underenheter', () => {
+  const api = new EnduserConnection();
+
+  test('Virksomhet skal kunne se tilgangspakker hos hoved- og underenhet som delegerte dem', async ({
+    page,
+    accessManagementFrontPage,
+    login,
+    aktorvalgHeader,
+  }) => {
+    await test.step('sett opp testdata', async () => {
+      await api.addConnectionAndPackagesToUser('25916799929', '313819566', '313244555', [
+        'urn:altinn:accesspackage:byggesoknad',
+      ]);
+    });
+
+    await test.step('Logg inn', async () => {
+      await login.LoginToAccessManagement('30847798242');
+    });
+
+    await test.step('Se at hovedenhet og underenhet for SMISKENDE UMODEN TIGER AS er klikkbare i aktørlista', async () => {
+      await aktorvalgHeader.orgExistsInAktorvalg('SMISKENDE UMODEN TIGER AS');
+      await aktorvalgHeader.subOrgExistsInAktorvalg('SMISKENDE UMODEN TIGER AS');
+    });
+
+    await test.step('Velg hovedenhet KONSERVATIV USELVISK KATT KLINKEKULE og gå til fullmakter hos andre', async () => {
+      await aktorvalgHeader.selectActorFromHeaderMenu('KONSERVATIV USELVISK KATT KLINKEKULE');
+      await accessManagementFrontPage.goToFullmakterHosAndre();
+    });
+
+    await test.step('Velg hovedenhet SMISKENDE UMODEN TIGER AS i lista over fullmakter hos andre', async () => {
+      await accessManagementFrontPage.expandOrg('SMISKENDE UMODEN TIGER AS');
+      await accessManagementFrontPage.clickUser('SMISKENDE UMODEN TIGER AS');
+    });
+
+    await test.step('KONSERVATIV USELVISK KATT KLINKEKULE skal ha tilgangspakken Byggesøknad hos hovedenheten', async () => {
+      await accessManagementFrontPage.goToArea('Bygg, anlegg og eiendom');
+      await accessManagementFrontPage.userCanDeletePackage('Byggesøknad');
+    });
+
+    await test.step('Gå tilbake til fullmakter hos andre og velg underenhet SMISKENDE UMODEN TIGER AS', async () => {
+      await accessManagementFrontPage.goToFullmakterHosAndre();
+      await accessManagementFrontPage.expandOrg('SMISKENDE UMODEN TIGER AS');
+      await accessManagementFrontPage.clickUser('SMISKENDE UMODEN TIGER AS', 1);
+    });
+
+    await test.step('KONSERVATIV USELVISK KATT KLINKEKULE skal ha tilgangspakken Byggesøknad hos underenheten', async () => {
+      await accessManagementFrontPage.goToArea('Bygg, anlegg og eiendom');
+      await accessManagementFrontPage.expectUserToHavePackage('Byggesøknad');
+    });
+  });
+
+  test('Virksomhet skal kunne se enkelttjenester hos hoved- og underenhet som delegerte dem', async ({
+    page,
+    accessManagementFrontPage,
+    login,
+    aktorvalgHeader,
+  }) => {
+    await test.step('sett opp testdata', async () => {
+      await api.addConnection('26888197213', '310959502', '312791404');
+      await api.delegateSingleService(
+        '26888197213',
+        '310959502',
+        '312791404',
+        'bruno-correspondence',
+      );
+    });
+
+    await test.step('Logg inn', async () => {
+      await login.LoginToAccessManagement('16906997766');
+    });
+
+    await test.step('Se at hovedenhet og underenhet for RIKTIG AUTENTISK APE er klikkbare i aktørlista', async () => {
+      await aktorvalgHeader.orgExistsInAktorvalg('RIKTIG AUTENTISK APE');
+      await aktorvalgHeader.subOrgExistsInAktorvalg('RIKTIG AUTENTISK APE');
+    });
+
+    await test.step('Velg hovedenhet FORMBAR GENIERKLÆRT TIGER AS og gå til fullmakter hos andre', async () => {
+      await aktorvalgHeader.selectActorFromHeaderMenu('FORMBAR GENIERKLÆRT TIGER AS');
+      await accessManagementFrontPage.goToFullmakterHosAndre();
+    });
+
+    await test.step('Velg hovedenhet RIKTIG AUTENTISK APE i lista over fullmakter hos andre', async () => {
+      await accessManagementFrontPage.expandOrg('RIKTIG AUTENTISK APE');
+      await accessManagementFrontPage.clickUser('RIKTIG AUTENTISK APE');
+    });
+
+    await test.step('FORMBAR GENIERKLÆRT TIGER AS skal ha tilgangspakken Byggesøknad hos hovedenheten', async () => {
+      await accessManagementFrontPage.goToEnkelttjenester();
+      await accessManagementFrontPage.userCanDeleteEnkelttjeneste('bruno-correspondence');
+    });
+
+    await test.step('Gå tilbake til fullmakter hos andre og velg underenhet RIKTIG AUTENTISK APE', async () => {
+      await accessManagementFrontPage.goToFullmakterHosAndre();
+      await accessManagementFrontPage.expandOrg('RIKTIG AUTENTISK APE');
+      await accessManagementFrontPage.clickUser('RIKTIG AUTENTISK APE', 1);
+    });
+
+    await test.step('FORMBAR GENIERKLÆRT TIGER AS skal ha tilgangspakken Byggesøknad hos underenheten', async () => {
+      await accessManagementFrontPage.goToEnkelttjenester();
+      await accessManagementFrontPage.expectUserToHaveEnkelttjeneste('bruno-correspondence');
     });
   });
 });

--- a/playwright/e2eTests/altinn3/Tilgangsstyring/AccessManagement.spec.ts
+++ b/playwright/e2eTests/altinn3/Tilgangsstyring/AccessManagement.spec.ts
@@ -324,7 +324,7 @@ test.describe('over- og underenheter', () => {
       await accessManagementFrontPage.clickUser('RIKTIG AUTENTISK APE');
     });
 
-    await test.step('FORMBAR GENIERKLÆRT TIGER AS skal ha tilgangspakken Byggesøknad hos hovedenheten', async () => {
+    await test.step('FORMBAR GENIERKLÆRT TIGER AS skal ha enkelttjenesten bruno-correspondence hos hovedenheten', async () => {
       await accessManagementFrontPage.goToEnkelttjenester();
       await accessManagementFrontPage.userCanDeleteEnkelttjeneste('bruno-correspondence');
     });
@@ -335,7 +335,7 @@ test.describe('over- og underenheter', () => {
       await accessManagementFrontPage.clickUser('RIKTIG AUTENTISK APE', 1);
     });
 
-    await test.step('FORMBAR GENIERKLÆRT TIGER AS skal ha tilgangspakken Byggesøknad hos underenheten', async () => {
+    await test.step('FORMBAR GENIERKLÆRT TIGER AS skal ha enkelttjenesten bruno-correspondence hos underenheten', async () => {
       await accessManagementFrontPage.goToEnkelttjenester();
       await accessManagementFrontPage.expectUserToHaveEnkelttjeneste('bruno-correspondence');
     });

--- a/playwright/e2eTests/altinn3/Tilgangsstyring/AccessManagement.spec.ts
+++ b/playwright/e2eTests/altinn3/Tilgangsstyring/AccessManagement.spec.ts
@@ -255,7 +255,6 @@ test.describe('over- og underenheter', () => {
   });
 
   test('Virksomhet skal kunne se tilgangspakker hos hoved- og underenhet som delegerte dem', async ({
-    page,
     accessManagementFrontPage,
     login,
     aktorvalgHeader,
@@ -297,7 +296,6 @@ test.describe('over- og underenheter', () => {
   });
 
   test('Virksomhet skal kunne se enkelttjenester hos hoved- og underenhet som delegerte dem', async ({
-    page,
     accessManagementFrontPage,
     login,
     aktorvalgHeader,
@@ -339,7 +337,6 @@ test.describe('over- og underenheter', () => {
   });
 
   test('Underenhet A som delegerte tilgangspakke til Virksomhet B skal kunne se Virksomhet B i brukerlista si', async ({
-    page,
     accessManagementFrontPage,
     login,
     aktorvalgHeader,
@@ -381,7 +378,6 @@ test.describe('over- og underenheter', () => {
   });
 
   test('Underenhet A som delegerte enkelttjeneste til Virksomhet B skal kunne se Virksomhet B i brukerlista si', async ({
-    page,
     accessManagementFrontPage,
     login,
     aktorvalgHeader,

--- a/playwright/e2eTests/altinn3/Tilgangsstyring/Enkelttjenestedelegering.spec.ts
+++ b/playwright/e2eTests/altinn3/Tilgangsstyring/Enkelttjenestedelegering.spec.ts
@@ -67,7 +67,7 @@ test.describe('Enkelttjenestedelegering fra person til person og person til org'
       await accessManagementFrontPage.goToUsers();
       await accessManagementFrontPage.clickUser('KONSERVATIV FATTIGMANNSKOST');
       await accessManagementFrontPage.goToEnkelttjenester();
-      await accessManagementFrontPage.expectUserToHaveEnkelttjeneste('bruno-correspondence');
+      await accessManagementFrontPage.userCanDeleteEnkelttjeneste('bruno-correspondence');
     });
   });
 
@@ -106,7 +106,7 @@ test.describe('Enkelttjenestedelegering fra person til person og person til org'
       await accessManagementFrontPage.expandOrg('OVERFLØDIG SOLID TIGER AS');
       await accessManagementFrontPage.clickUser('OVERFLØDIG SOLID TIGER AS');
       await accessManagementFrontPage.goToEnkelttjenester();
-      await accessManagementFrontPage.expectUserToHaveEnkelttjeneste('bruno-correspondence');
+      await accessManagementFrontPage.userCanDeleteEnkelttjeneste('bruno-correspondence');
     });
   });
 
@@ -261,7 +261,7 @@ test.describe('Enkelttjenestedelegering fra org til person og org til org', () =
       await accessManagementFrontPage.goToUsers();
       await accessManagementFrontPage.clickUser('ANSVARSFULL REGLE');
       await accessManagementFrontPage.goToEnkelttjenester();
-      await accessManagementFrontPage.expectUserToHaveEnkelttjeneste('bruno-correspondence');
+      await accessManagementFrontPage.userCanDeleteEnkelttjeneste('bruno-correspondence');
     });
   });
 
@@ -300,7 +300,7 @@ test.describe('Enkelttjenestedelegering fra org til person og org til org', () =
       await accessManagementFrontPage.expandOrg('RIK INNBRINGENDE TIGER AS');
       await accessManagementFrontPage.clickUser('RIK INNBRINGENDE TIGER AS');
       await accessManagementFrontPage.goToEnkelttjenester();
-      await accessManagementFrontPage.expectUserToHaveEnkelttjeneste('bruno-correspondence');
+      await accessManagementFrontPage.userCanDeleteEnkelttjeneste('bruno-correspondence');
     });
   });
 

--- a/playwright/e2eTests/altinn3/Tilgangsstyring/tilgangspakkedelegering.spec.ts
+++ b/playwright/e2eTests/altinn3/Tilgangsstyring/tilgangspakkedelegering.spec.ts
@@ -122,7 +122,7 @@ test.describe('tilgangspakkedelegering fra person til person og person til org',
       await accessManagementFrontPage.goToUsers();
       await accessManagementFrontPage.clickUser('LETT ANKEL');
       await accessManagementFrontPage.goToArea('Arbeidsliv, skole og utdanning');
-      await accessManagementFrontPage.expectUserToHavePackage('Utdanning');
+      await accessManagementFrontPage.userCanDeletePackage('Utdanning');
     });
   });
 
@@ -159,7 +159,7 @@ test.describe('tilgangspakkedelegering fra person til person og person til org',
       await accessManagementFrontPage.expandOrg('OPPLYST KVART TIGER AS');
       await accessManagementFrontPage.clickUser('OPPLYST KVART TIGER AS');
       await accessManagementFrontPage.goToArea('Arbeidsliv, skole og utdanning');
-      await accessManagementFrontPage.expectUserToHavePackage('Utdanning');
+      await accessManagementFrontPage.userCanDeletePackage('Utdanning');
     });
   });
 
@@ -356,7 +356,7 @@ test.describe('tilgangspakkedelegering fra org til person og org til org', () =>
       await accessManagementFrontPage.goToUsers();
       await accessManagementFrontPage.clickUser('UFØLSOM BADERING');
       await accessManagementFrontPage.goToArea('Andre tjenesteytende næringer');
-      await accessManagementFrontPage.expectUserToHavePackage('Posttjenester');
+      await accessManagementFrontPage.userCanDeletePackage('Posttjenester');
     });
   });
 
@@ -393,7 +393,7 @@ test.describe('tilgangspakkedelegering fra org til person og org til org', () =>
       await accessManagementFrontPage.expandOrg('EVENTYRLIG PUSLETE TIGER AS');
       await accessManagementFrontPage.clickUser('EVENTYRLIG PUSLETE TIGER AS');
       await accessManagementFrontPage.goToArea('Andre tjenesteytende næringer');
-      await accessManagementFrontPage.expectUserToHavePackage('Posttjenester');
+      await accessManagementFrontPage.userCanDeletePackage('Posttjenester');
     });
   });
 

--- a/playwright/e2eTests/altinn3/navigation/headertest.spec.ts
+++ b/playwright/e2eTests/altinn3/navigation/headertest.spec.ts
@@ -3,12 +3,14 @@ import { env } from 'playwright/util/helper';
 import { LoginPage } from 'playwright/pages/LoginPage';
 import type { AktorvalgHeader } from 'playwright/pages/AktorvalgHeader';
 import { test } from 'playwright/fixture/pomFixture';
+import { EnduserConnection } from '../../../api-requests/EnduserConnection';
 
 test.describe('Aktørvalg, valg og visning av avgiver', () => {
   const ENV = env('environment')?.toUpperCase();
   const HEADER_TEST_USER = '11886599619';
   const SHOW_DELETED_TEST_USER = '19846999968';
   const DEFAULT_ACTOR_NAME = 'Kunnskapsrik Kry Ape';
+  const api = new EnduserConnection();
 
   const loginAsHeaderTestUser = async (page: Page, aktorvalgHeader: AktorvalgHeader) => {
     const login = new LoginPage(page);
@@ -104,6 +106,52 @@ test.describe('Aktørvalg, valg og visning av avgiver', () => {
 
       await aktorvalgHeader.typeInSearchField('310470422');
       await aktorvalgHeader.actorIsListed('Kunnskapsrik Kry Ape');
+    });
+  });
+
+  test('Virksomhet A skal ikke kunne velge hovedenhet B når underenhet B har delegert en tilgangspakke', async ({
+    login,
+    aktorvalgHeader,
+  }) => {
+    await test.step('sett opp testdata', async () => {
+      await api.addConnectionAndPackagesToUser('10845998952', '311908421', '311151932', [
+        'urn:altinn:accesspackage:byggesoknad',
+      ]);
+    });
+
+    await test.step('Logg inn', async () => {
+      await login.LoginToAccessManagement('08868199785');
+    });
+
+    await test.step('Hovedenhet UVITENDE TOM TIGER AS skal ikke være klikkbar', async () => {
+      await aktorvalgHeader.orgIsNotClickableInAktorvalg('UVITENDE TOM TIGER AS');
+    });
+
+    await test.step('Se at underenheten for UVITENDE TOM TIGER AS er klikkbare i aktørlista', async () => {
+      await aktorvalgHeader.subOrgExistsInAktorvalg('UVITENDE TOM TIGER AS');
+    });
+  });
+
+  test('Virksomhet A skal ikke kunne velge hovedenhet B når underenhet B har delegert en enkelttjeneste', async ({
+    login,
+    aktorvalgHeader,
+  }) => {
+    await test.step('sett opp testdata', async () => {
+      await api.addConnectionAndPackagesToUser('10845998952', '311908421', '311151932', [
+        'urn:altinn:accesspackage:byggesoknad',
+      ]);
+    });
+
+    await test.step('Logg inn', async () => {
+      await login.LoginToAccessManagement('08868199785');
+    });
+
+    await test.step('Hovedenhet UVITENDE TOM TIGER AS skal ikke være klikkbar', async () => {
+      await aktorvalgHeader.orgIsNotClickableInAktorvalg('UVITENDE TOM TIGER AS');
+    });
+
+    await test.step('Se at underenheten for UVITENDE TOM TIGER AS er klikkbare i aktørlista', async () => {
+      await aktorvalgHeader.subOrgExistsInAktorvalg('UVITENDE TOM TIGER AS');
     });
   });
 });

--- a/playwright/e2eTests/altinn3/navigation/headertest.spec.ts
+++ b/playwright/e2eTests/altinn3/navigation/headertest.spec.ts
@@ -137,9 +137,13 @@ test.describe('Aktørvalg, valg og visning av avgiver', () => {
     aktorvalgHeader,
   }) => {
     await test.step('sett opp testdata', async () => {
-      await api.addConnectionAndPackagesToUser('10845998952', '311908421', '311151932', [
-        'urn:altinn:accesspackage:byggesoknad',
-      ]);
+      await api.addConnection('10845998952', '311908421', '311151932');
+      await api.delegateSingleService(
+        '10845998952',
+        '311908421',
+        '311151932',
+        'bruno-correspondence',
+      );
     });
 
     await test.step('Logg inn', async () => {

--- a/playwright/pages/AccessManagementFrontPage.ts
+++ b/playwright/pages/AccessManagementFrontPage.ts
@@ -52,7 +52,7 @@ export class AccessManagementFrontPage {
   }
 
   async goToFullmakterHosAndre() {
-    await this.page.getByRole('group').getByLabel('Fullmakter hos andre').click();
+    await this.ourAccessAtOthersLink.click();
   }
 
   async sokEtterEnkelttjeneste(tjenesteNavn: string) {

--- a/playwright/pages/AccessManagementFrontPage.ts
+++ b/playwright/pages/AccessManagementFrontPage.ts
@@ -100,9 +100,6 @@ export class AccessManagementFrontPage {
   }
 
   async expectUserToHaveEnkelttjeneste(tjenesteNavn: string) {
-    // await expect(
-    //   this.page.getByRole('button', { name: tjenesteNavn }),
-    // ).toBeVisible();
     await expect(this.page.getByText(tjenesteNavn)).toBeVisible();
   }
 

--- a/playwright/pages/AccessManagementFrontPage.ts
+++ b/playwright/pages/AccessManagementFrontPage.ts
@@ -43,12 +43,16 @@ export class AccessManagementFrontPage {
     await this.page.getByRole('button', { name: org }).click();
   }
 
-  async clickUser(userName: string) {
-    await this.page.getByRole('link', { name: userName }).click();
+  async clickUser(userName: string, num = 0) {
+    await this.page.getByRole('link', { name: userName }).nth(num).click();
   }
 
   async goToEnkelttjenester() {
     await this.page.getByRole('tab', { name: 'Enkelttjenester' }).click();
+  }
+
+  async goToFullmakterHosAndre() {
+    await this.page.getByRole('group').getByLabel('Fullmakter hos andre').click();
   }
 
   async sokEtterEnkelttjeneste(tjenesteNavn: string) {
@@ -81,14 +85,25 @@ export class AccessManagementFrontPage {
     ).toBeVisible();
   }
 
-  async expectUserToHavePackage(packageName: string) {
+  async userCanDeletePackage(packageName: string) {
     await expect(
       this.page.getByRole('button', { name: 'Slett fullmakt for ' + packageName }),
     ).toBeVisible();
   }
 
-  async expectUserToHaveEnkelttjeneste(resourceName: string) {
+  async expectUserToHavePackage(packageName: string) {
+    await expect(this.page.getByRole('button', { name: packageName })).toBeVisible();
+  }
+
+  async userCanDeleteEnkelttjeneste(resourceName: string) {
     await expect(this.page.getByRole('button', { name: 'Slett ' + resourceName })).toBeVisible();
+  }
+
+  async expectUserToHaveEnkelttjeneste(tjenesteNavn: string) {
+    // await expect(
+    //   this.page.getByRole('button', { name: tjenesteNavn }),
+    // ).toBeVisible();
+    await expect(this.page.getByText(tjenesteNavn)).toBeVisible();
   }
 
   async clickSlettFullmaktForTilgangspakke(packageName: string) {
@@ -108,7 +123,7 @@ export class AccessManagementFrontPage {
     });
     await expect(giFullmaktKnapp).toBeVisible();
     await giFullmaktKnapp.click();
-    await this.expectUserToHavePackage(packageName);
+    await this.userCanDeletePackage(packageName);
   }
 
   async clickAccessPackageToDelegateIfVisible(packageName: string) {

--- a/playwright/pages/AktorvalgHeader.ts
+++ b/playwright/pages/AktorvalgHeader.ts
@@ -112,7 +112,7 @@ export class AktorvalgHeader {
     if (isDisabled || ariaDisabled === 'true' || pointerEvents === 'none') {
       return;
     }
-    throw new Error(`Forventet å ikke kunne klikke på ${orgName}, men det den var klikkbar.`);
+    throw new Error(`Forventet å ikke kunne klikke på ${orgName}, men den var klikkbar.`);
   }
 
   async subOrgExistsInAktorvalg(orgName: string) {

--- a/playwright/pages/AktorvalgHeader.ts
+++ b/playwright/pages/AktorvalgHeader.ts
@@ -105,7 +105,7 @@ export class AktorvalgHeader {
     const actor = this.page.getByText(orgName).first();
     try {
       await expect(actor).toBeVisible();
-      await actor.click();
+      await actor.click({ timeout: 1000 });
     } catch {
       return;
     }

--- a/playwright/pages/AktorvalgHeader.ts
+++ b/playwright/pages/AktorvalgHeader.ts
@@ -91,6 +91,31 @@ export class AktorvalgHeader {
     await this.actorOption(actorName).click();
   }
 
+  async selectSubOrgFromHeaderMenu(orgName: string) {
+    const subOrg = this.page.getByText(orgName).nth(1);
+    await expect(subOrg).toBeVisible();
+    await subOrg.click();
+  }
+
+  async orgExistsInAktorvalg(orgName: string) {
+    await expect(this.page.getByText(orgName).first()).toBeVisible();
+  }
+
+  async orgIsNotClickableInAktorvalg(orgName: string) {
+    const actor = this.page.getByText(orgName).first();
+    try {
+      await expect(actor).toBeVisible();
+      await actor.click();
+    } catch {
+      return;
+    }
+    throw new Error(`Forventet å ikke kunne klikke på ${orgName}, men det den var klikkbar.`);
+  }
+
+  async subOrgExistsInAktorvalg(orgName: string) {
+    await expect(this.page.getByText(orgName).nth(1)).toBeVisible();
+  }
+
   async currentlySelectedActor(actorName: string) {
     await expect(this.selectedActorButton(actorName)).toBeVisible();
   }
@@ -131,6 +156,7 @@ export class AktorvalgHeader {
   }
 
   async checkAllMenuButtons() {
+    await this.page.waitForTimeout(1000);
     await this.menuButton.click();
     await expect(this.menuInbox).toBeVisible();
     await expect(this.menuAccessManagement).toBeVisible();

--- a/playwright/pages/AktorvalgHeader.ts
+++ b/playwright/pages/AktorvalgHeader.ts
@@ -103,10 +103,13 @@ export class AktorvalgHeader {
 
   async orgIsNotClickableInAktorvalg(orgName: string) {
     const actor = this.page.getByText(orgName).first();
-    try {
-      await expect(actor).toBeVisible();
-      await actor.click({ timeout: 1000 });
-    } catch {
+    await expect(actor).toBeVisible();
+    const isDisabled = await actor.isDisabled();
+    const ariaDisabled = await actor.getAttribute('aria-disabled');
+    const pointerEvents = await actor.evaluate(
+      (element) => window.getComputedStyle(element).pointerEvents,
+    );
+    if (isDisabled || ariaDisabled === 'true' || pointerEvents === 'none') {
       return;
     }
     throw new Error(`Forventet å ikke kunne klikke på ${orgName}, men det den var klikkbar.`);


### PR DESCRIPTION
tre nye tester:
-Virksomhet A skal ikke kunne velge hovedenhet B når underenhet B har delegert en tilgangspakke 
-Virksomhet skal kunne se tilgangspakker hos hoved- og underenhet som delegerte dem 
-Virksomhet skal kunne se enkelttjenester hos hoved- og underenhet som delegerte dem

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests covering parent/child org delegated access, actor selection behavior, and header selection restrictions.
  * Expanded checks to verify users can remove delegated access packages and single services, and that delegated users appear correctly.

* **Documentation**
  * Minor update to Playwright guidelines file.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-access-management-frontend/pull/2224?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->