### PR TITLE
fix: set focus to h1 on receipt page on consent request and draft request pages

### DIFF
--- a/src/features/amUI/consent/ConsentRequestPage/ConsentRequestPage.tsx
+++ b/src/features/amUI/consent/ConsentRequestPage/ConsentRequestPage.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useSearchParams } from 'react-router';
 import { DsAlert, DsButton, DsHeading, DsParagraph } from '@altinn/altinn-components';
@@ -26,8 +26,15 @@ export const ConsentRequestPage = () => {
   const requestId = searchParams.get('id') ?? '';
   const language = getLanguage(i18n.language);
   const skipLogout = searchParams.get('skiplogout');
+  const receiptHeadingRef = useRef<HTMLHeadingElement>(null);
   const navigate = useNavigate();
   const [isReceiptVisible, setIsReceiptVisible] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (isReceiptVisible) {
+      receiptHeadingRef.current?.focus();
+    }
+  }, [isReceiptVisible]);
 
   const {
     data: request,
@@ -129,6 +136,8 @@ export const ConsentRequestPage = () => {
       <DsHeading
         level={1}
         data-size='md'
+        tabIndex={-1}
+        ref={receiptHeadingRef}
       >
         {memoizedRequest?.isPoa
           ? t('consent_request.receipt_header_poa')

--- a/src/features/amUI/requestPage/DraftRequestPage/DraftRequestHeader.tsx
+++ b/src/features/amUI/requestPage/DraftRequestPage/DraftRequestHeader.tsx
@@ -1,17 +1,31 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Trans } from 'react-i18next';
 import { DsHeading } from '@altinn/altinn-components';
 
 interface DraftRequestHeaderProps {
   headerTextKey: string;
   toName: string;
+  autoFocus?: boolean;
 }
 
-export const DraftRequestHeader = ({ headerTextKey, toName }: DraftRequestHeaderProps) => {
+export const DraftRequestHeader = ({
+  headerTextKey,
+  toName,
+  autoFocus,
+}: DraftRequestHeaderProps) => {
+  const headingRef = useRef<HTMLHeadingElement>(null);
+  useEffect(() => {
+    if (autoFocus) {
+      headingRef.current?.focus();
+    }
+  }, [autoFocus]);
+
   return (
     <DsHeading
       level={1}
       data-size='md'
+      tabIndex={-1}
+      ref={headingRef}
     >
       <Trans
         i18nKey={headerTextKey}

--- a/src/features/amUI/requestPage/DraftRequestPage/DraftRequestPage.tsx
+++ b/src/features/amUI/requestPage/DraftRequestPage/DraftRequestPage.tsx
@@ -125,6 +125,7 @@ export const DraftRequestPage = () => {
           isConfirm ? 'draft_request_page.request_approved' : 'draft_request_page.request_withdrawn'
         }
         toName={toName}
+        autoFocus
       />
     );
     body = (


### PR DESCRIPTION
## Description
-  set focus to h1 element on receipt page on consent request and draft request pages. Otherwise focus is lost when screen reader user accepts the request

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/3216

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Enhanced keyboard focus management on receipt and confirmation screens to improve navigation for keyboard users when confirmation views are displayed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-access-management-frontend/pull/2231?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->