### PR TITLE
Add aria attributes to settings icons

### DIFF
--- a/src/features/amUI/settings/SettingsModal.tsx
+++ b/src/features/amUI/settings/SettingsModal.tsx
@@ -76,12 +76,22 @@ export const SettingsModal = ({
     case 'email':
       headingText = t('settings_page.alerts_on_email');
       labelText = t('settings_page.email_label');
-      icon = <PaperplaneIcon fontSize='2rem' />;
+      icon = (
+        <PaperplaneIcon
+          fontSize='2rem'
+          aria-hidden='true'
+        />
+      );
       break;
     case 'sms':
       headingText = t('settings_page.alerts_on_sms');
       labelText = t('settings_page.sms_label');
-      icon = <ChatIcon fontSize='2rem' />;
+      icon = (
+        <ChatIcon
+          fontSize='2rem'
+          aria-hidden='true'
+        />
+      );
       break;
     default:
       return null;

--- a/src/features/amUI/settings/SettingsPageContent.tsx
+++ b/src/features/amUI/settings/SettingsPageContent.tsx
@@ -96,8 +96,9 @@ export const SettingsPageContent = () => {
           <DsPopover.Trigger
             variant='tertiary'
             icon
+            aria-label={t('settings_page.alert_settings_info_icon_label')}
           >
-            <QuestionmarkCircleIcon />
+            <QuestionmarkCircleIcon aria-hidden='true' />
           </DsPopover.Trigger>
           <DsPopover placement='right'>
             <Trans
@@ -121,7 +122,7 @@ export const SettingsPageContent = () => {
             id='settings-email-alerts'
             title={t('settings_page.alerts_on_email')}
             value={emailAddresses.join(', ')}
-            icon={<PaperplaneIcon />}
+            icon={<PaperplaneIcon aria-hidden='true' />}
             badge={
               emailAddresses.length > 0 && {
                 label:
@@ -141,7 +142,7 @@ export const SettingsPageContent = () => {
             id='settings-sms-alerts'
             title={t('settings_page.alerts_on_sms')}
             value={phoneNumbers.join(', ')}
-            icon={<ChatIcon />}
+            icon={<ChatIcon aria-hidden='true' />}
             badge={
               phoneNumbers.length > 0 && {
                 label:

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -647,7 +647,8 @@
     "remove_sms": "Remove phone number",
     "error_saving_addresses": "Something went wrong. Please try again.",
     "no_addresses_error": "The organization must have at least one email address or SMS number for notifications.",
-    "alert_settings_info": "Notifications sent to registered notification addresses are sent regardless of whether the recipient has the right to view the content in Altinn. If you have a shared email address, it is natural to include it here. <a>Read more</a>"
+    "alert_settings_info": "Notifications sent to registered notification addresses are sent regardless of whether the recipient has the right to view the content in Altinn. If you have a shared email address, it is natural to include it here. <a>Read more</a>",
+    "alert_settings_info_icon_label": "Information about notification addresses"
   },
   "text_field_errors": {
     "required": "The field is required",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -644,7 +644,8 @@
     "remove_sms": "Fjern telefonnummer",
     "error_saving_addresses": "Noe gikk galt. Vennligst prøv igjen.",
     "no_addresses_error": "Virksomheten må ha minst én e-postadresse eller sms-adresse for varslinger.",
-    "alert_settings_info": "Varslene som sendes ut til registrerte varslingsadresser sendes uavhengig av om mottaker har rettighet til å se innholdet i altinn. Hvis dere har en felles e-postadresse er det naturlig å legge den inn her. <a>Les mer</a>"
+    "alert_settings_info": "Varslene som sendes ut til registrerte varslingsadresser sendes uavhengig av om mottaker har rettighet til å se innholdet i altinn. Hvis dere har en felles e-postadresse er det naturlig å legge den inn her. <a>Les mer</a>",
+    "alert_settings_info_icon_label": "Informasjon om varslingsadresser"
   },
   "text_field_errors": {
     "required": "Feltet er påkrevd",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -644,7 +644,8 @@
     "remove_sms": "Fjern telefonnummer",
     "error_saving_addresses": "Noko gjekk gale. Ver venleg å prøv igjen.",
     "no_addresses_error": "Verksemda må ha minst ei e-postadresse eller sms-adresse for varslingar.",
-    "alert_settings_info": "Varsla som sendast ut til registrerte varslingsadresser sendast uavhengig av om mottakar har rett til å sjå innhaldet i Altinn. Dersom de har ei felles e-postadresse er det naturleg å legge den inn her. <a>Les meir</a>"
+    "alert_settings_info": "Varsla som sendast ut til registrerte varslingsadresser sendast uavhengig av om mottakar har rett til å sjå innhaldet i Altinn. Dersom de har ei felles e-postadresse er det naturleg å legge den inn her. <a>Les meir</a>",
+    "alert_settings_info_icon_label": "Informasjon om varslingsadresser"
   },
   "text_field_errors": {
     "required": "Feltet er påkrevd",


### PR DESCRIPTION
Mark decorative icons as aria-hidden in SettingsModal and SettingsPageContent
Add an aria-label for the popover info trigger. 

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
https://github.com/Altinn/altinn-authorization-tmp/issues/2217

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Enhanced screen reader support and keyboard navigation in settings with improved accessibility labels and attributes.

* **Localization**
  * Added translations for accessibility labels in English, Norwegian Bokmål, and Norwegian Nynorsk.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-access-management-frontend/pull/2237?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->