### PR TITLE
change standalone ListItem and UserListItem element type to div

### DIFF
--- a/src/features/amUI/common/CurrentUserPageHeader/CurrentUserPageHeader.tsx
+++ b/src/features/amUI/common/CurrentUserPageHeader/CurrentUserPageHeader.tsx
@@ -41,6 +41,7 @@ export const CurrentUserPageHeader = ({
         titleAs='h2'
         size='lg'
         loading={loading}
+        containerAs='div'
       />
     </div>
   );

--- a/src/features/amUI/common/CurrentUserPageHeader/CurrentUserSkeleton.tsx
+++ b/src/features/amUI/common/CurrentUserPageHeader/CurrentUserSkeleton.tsx
@@ -10,6 +10,7 @@ export const CurrentUserSkeleton = () => {
       description='xxxxxxx, xxxxxxx'
       type='person'
       id='xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
+      containerAs='div'
     />
   );
 };

--- a/src/features/amUI/common/DelegationModal/SingleRights/RightsSection.tsx
+++ b/src/features/amUI/common/DelegationModal/SingleRights/RightsSection.tsx
@@ -114,6 +114,7 @@ export const RightsSection = ({
           onClick={() => setRightsExpanded(!rightsExpanded)}
           expanded={rightsExpanded}
           as='button'
+          containerAs='div'
           border='solid'
           shadow='none'
         >

--- a/src/features/amUI/landingPage/LandingPage.tsx
+++ b/src/features/amUI/landingPage/LandingPage.tsx
@@ -268,7 +268,7 @@ export const LandingPage = () => {
     <PageWrapper>
       <PageLayoutWrapper openAccountMenu={shouldOpenAccountMenu}>
         <div className={classes.landingPage}>
-          <List className={classes.landingPageHeading}>
+          <div className={classes.landingPageHeading}>
             <UserListItem
               id={reportee?.partyUuid ?? ''}
               type={isOrganization(reportee) ? 'company' : 'person'}
@@ -281,8 +281,9 @@ export const LandingPage = () => {
               loading={!reportee}
               interactive={false}
               shadow='none'
+              containerAs='div'
             />
-          </List>
+          </div>
           <LandingPageInfoCard
             isLoading={isLoading}
             isOrganization={isOrganization(reportee)}


### PR DESCRIPTION
## Description
- For ListItem and UserListItem components that are not used in list, change the container element to div

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined container element rendering in multiple user interface components to improve layout consistency.
  * Updated internal container configuration across several application views for better visual alignment and structure.
  * Adjusted how components render their containers for improved visual presentation throughout the interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-access-management-frontend/pull/2241?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->