### PR TITLE
Hide all links to A2 in TT02

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.TT02.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.TT02.json
@@ -37,6 +37,7 @@
     "EnableDialogportenDialogLookup": true,
     "UseConnectionsForAgentSystemuser": true,
     "EnableMaskinportenAdministration": true,
-    "EnableRoleDeletion": false
+    "EnableRoleDeletion": false,
+    "HideA2Links": true
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Activate feature that hides all links backe to the "old Altinn" in TT02

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
