### PR TITLE
Do not clear role meta after deleting the role

### DIFF
--- a/src/features/amUI/common/DelegationModal/EditModal.tsx
+++ b/src/features/amUI/common/DelegationModal/EditModal.tsx
@@ -72,23 +72,6 @@ export const EditModal = forwardRef<HTMLDialogElement, EditModalProps>(
       }
     }, [openWithError, setActionError]);
 
-    /* handle closing */
-    useEffect(() => {
-      const handleClose = () => {
-        onClose?.();
-        reset();
-      };
-
-      if (ref && 'current' in ref && ref.current) {
-        ref.current.addEventListener('close', handleClose);
-      }
-      return () => {
-        if (ref && 'current' in ref && ref.current) {
-          ref.current.removeEventListener('close', handleClose);
-        }
-      };
-    }, [onClose, reset, ref]);
-
     return (
       <DsDialog
         ref={ref}

--- a/src/features/amUI/common/DeletePoaConfirmation/DeletePoaConfirmation.tsx
+++ b/src/features/amUI/common/DeletePoaConfirmation/DeletePoaConfirmation.tsx
@@ -2,6 +2,8 @@ import { useTranslation } from 'react-i18next';
 import { DsButton, DsDialog, DsHeading, DsParagraph, DsSpinner } from '@altinn/altinn-components';
 import classes from './DeletePoaConfirmation.module.css';
 import { MinusCircleIcon } from '@navikt/aksel-icons';
+import { useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 
 export interface DeletePoaConfirmationProps {
   warningText: string;
@@ -27,49 +29,59 @@ export const DeletePoaConfirmation = ({
   disabled = false,
 }: DeletePoaConfirmationProps) => {
   const { t } = useTranslation();
-  const closeDialog = (event: React.MouseEvent<HTMLButtonElement>) => {
-    event.stopPropagation();
-    event.preventDefault();
-    const dialog = (event.currentTarget as HTMLElement).closest('dialog');
-    dialog?.close();
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const [open, setOpen] = useState(false);
+
+  const closeDialog = () => {
+    dialogRef.current?.close();
+    setOpen(false);
   };
 
   return (
     <div className={classes.container}>
-      <DsDialog.TriggerContext>
-        <DsDialog.Trigger
-          data-color={color}
-          data-size={size}
-          variant={variant}
-          disabled={isDeleteLoading || disabled}
-        >
-          {icon && <MinusCircleIcon />}
-          {t('common.delete_poa')}
-        </DsDialog.Trigger>
-        <DsDialog>
-          <div className={classes.dialogContent}>
-            <DsHeading level={3}>{t('common.confirm_delete_heading')}</DsHeading>
-            <DsParagraph>{warningText}</DsParagraph>
-            <div className={classes.dialogButtons}>
-              <DsButton
-                data-color='danger'
-                onClick={(event) => {
-                  handleDeletion();
-                  closeDialog(event);
-                }}
-              >
-                {t('common.yes_delete')}
-              </DsButton>
-              <DsButton
-                variant='secondary'
-                onClick={closeDialog}
-              >
-                {t('common.cancel')}
-              </DsButton>
+      <DsDialog.Trigger
+        data-color={color}
+        data-size={size}
+        variant={variant}
+        disabled={isDeleteLoading || disabled}
+        onClick={() => {
+          setOpen(true);
+          requestAnimationFrame(() => dialogRef.current?.showModal());
+        }}
+      >
+        {icon && <MinusCircleIcon />}
+        {t('common.delete_poa')}
+      </DsDialog.Trigger>
+      {open &&
+        createPortal(
+          <DsDialog
+            ref={dialogRef}
+            onClose={() => setOpen(false)}
+          >
+            <div className={classes.dialogContent}>
+              <DsHeading level={3}>{t('common.confirm_delete_heading')}</DsHeading>
+              <DsParagraph>{warningText}</DsParagraph>
+              <div className={classes.dialogButtons}>
+                <DsButton
+                  data-color='danger'
+                  onClick={() => {
+                    handleDeletion();
+                    closeDialog();
+                  }}
+                >
+                  {t('common.yes_delete')}
+                </DsButton>
+                <DsButton
+                  variant='secondary'
+                  onClick={closeDialog}
+                >
+                  {t('common.cancel')}
+                </DsButton>
+              </div>
             </div>
-          </div>
-        </DsDialog>
-      </DsDialog.TriggerContext>
+          </DsDialog>,
+          document.body,
+        )}
       {isDeleteLoading && (
         <DsSpinner
           aria-label={loadingAriaLabel}

--- a/src/features/amUI/common/DeletePoaConfirmation/DeletePoaConfirmation.tsx
+++ b/src/features/amUI/common/DeletePoaConfirmation/DeletePoaConfirmation.tsx
@@ -1,9 +1,9 @@
 import { useTranslation } from 'react-i18next';
-import { DsButton, DsDialog, DsHeading, DsParagraph, DsSpinner } from '@altinn/altinn-components';
-import classes from './DeletePoaConfirmation.module.css';
 import { MinusCircleIcon } from '@navikt/aksel-icons';
 import { useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { DsButton, DsDialog, DsHeading, DsParagraph, DsSpinner } from '@altinn/altinn-components';
+import classes from './DeletePoaConfirmation.module.css';
 
 export interface DeletePoaConfirmationProps {
   warningText: string;
@@ -45,8 +45,10 @@ export const DeletePoaConfirmation = ({
         variant={variant}
         disabled={isDeleteLoading || disabled}
         onClick={() => {
-          setOpen(true);
-          requestAnimationFrame(() => dialogRef.current?.showModal());
+          if (!open) {
+            setOpen(true);
+            requestAnimationFrame(() => dialogRef.current?.showModal());
+          }
         }}
       >
         {icon && <MinusCircleIcon />}

--- a/src/features/amUI/reporteeRightsPage/ReporteeRoleSection.tsx
+++ b/src/features/amUI/reporteeRightsPage/ReporteeRoleSection.tsx
@@ -1,12 +1,12 @@
-import { useTranslation } from 'react-i18next';
 import { useRef, useState } from 'react';
-import { DsHeading, DsParagraph } from '@altinn/altinn-components';
 
 import type { Role } from '@/rtk/features/roleApi';
 
 import { RoleInfoModal } from '../common/DelegationModal/RoleInfoModal';
 import { RoleList } from '../common/RoleList/RoleList';
 import { OldRolesAlert } from '../common/OldRolesAlert/OldRolesAlert';
+import { usePartyRepresentation } from '../common/PartyRepresentationContext/PartyRepresentationContext';
+import { ActionError } from '@/resources/hooks/useActionError';
 
 interface ReporteeRoleSectionProps {
   numberOfAccesses?: number;
@@ -15,20 +15,28 @@ interface ReporteeRoleSectionProps {
 export const ReporteeRoleSection = ({ numberOfAccesses }: ReporteeRoleSectionProps) => {
   const modalRef = useRef<HTMLDialogElement>(null);
   const [modalItem, setModalItem] = useState<Role | undefined>(undefined);
+  const [deleteError, setDeleteError] = useState<unknown>(null);
+  const { isLoading } = usePartyRepresentation();
 
   return (
     <>
       <OldRolesAlert />
       <RoleList
-        onSelect={(role) => {
+        onSelect={(role, error) => {
           setModalItem(role);
+          setDeleteError(error ?? null);
           modalRef.current?.showModal();
         }}
+        isLoading={isLoading}
       />
       <RoleInfoModal
         modalRef={modalRef}
         role={modalItem}
-        onClose={() => setModalItem(undefined)}
+        onClose={() => {
+          setModalItem(undefined);
+          setDeleteError(null);
+        }}
+        openWithError={deleteError as ActionError}
       />
     </>
   );

--- a/src/features/amUI/reporteeRightsPage/ReporteeRoleSection.tsx
+++ b/src/features/amUI/reporteeRightsPage/ReporteeRoleSection.tsx
@@ -1,12 +1,12 @@
 import { useRef, useState } from 'react';
 
 import type { Role } from '@/rtk/features/roleApi';
+import type { ActionError } from '@/resources/hooks/useActionError';
 
 import { RoleInfoModal } from '../common/DelegationModal/RoleInfoModal';
 import { RoleList } from '../common/RoleList/RoleList';
 import { OldRolesAlert } from '../common/OldRolesAlert/OldRolesAlert';
 import { usePartyRepresentation } from '../common/PartyRepresentationContext/PartyRepresentationContext';
-import { ActionError } from '@/resources/hooks/useActionError';
 
 interface ReporteeRoleSectionProps {
   numberOfAccesses?: number;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<img width="1260" height="773" alt="image" src="https://github.com/user-attachments/assets/d5a6143b-4068-483a-bd62-ccf5ed7da12d" />

## Description
<!--- Describe your changes in detail -->

The bug was caused by the secondary modal (the confirmation on deletion) being closed, which triggered the onClose for the RoleInfo/EditModal modal as well. Adding a portal to separate the two modals fixes the bug.

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/3257

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added loading state indicator for party representation operations

* **Bug Fixes**
  * Improved error handling and user feedback in role selection workflow
  * Enhanced dialog closing behavior for more reliable interactions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-access-management-frontend/pull/2252?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->