### PR TITLE
Unify first-level page headings

### DIFF
--- a/src/features/amUI/clientAdministration/ClientAdministrationPageContent.module.css
+++ b/src/features/amUI/clientAdministration/ClientAdministrationPageContent.module.css
@@ -1,18 +1,7 @@
-.headerSection {
-  display: flex;
-  flex-direction: column;
-  gap: var(--ds-size-6);
-  margin-bottom: var(--ds-size-6);
-}
-
-.pageHeader {
-  display: flex;
-  flex-direction: column;
-  gap: var(--ds-size-1);
-}
-
 .pageDescription {
   max-width: 80ch;
+  margin-bottom: var(--ds-size-6);
+  margin-top: var(--ds-size-6);
 }
 
 .tab {

--- a/src/features/amUI/clientAdministration/ClientAdministrationPageContent.tsx
+++ b/src/features/amUI/clientAdministration/ClientAdministrationPageContent.tsx
@@ -78,19 +78,17 @@ export const ClientAdministrationPageContent = () => {
 
   return (
     <>
-      <div className={classes.headerSection}>
-        <div className={classes.pageHeader}>
-          <ReporteePageHeading
-            title={t('client_administration_page.page_heading', {
-              name: formatDisplayName({
-                fullName: actingParty?.name ?? '',
-                type: actingParty?.partyTypeName === PartyType.Person ? 'person' : 'company',
-              }),
-            })}
-            reportee={reportee}
-            isLoading={isLoadingReportee || actorLoading}
-          />
-        </div>
+      <div>
+        <ReporteePageHeading
+          title={t('client_administration_page.page_heading', {
+            name: formatDisplayName({
+              fullName: actingParty?.name ?? '',
+              type: actingParty?.partyTypeName === PartyType.Person ? 'person' : 'company',
+            }),
+          })}
+          reportee={reportee}
+          isLoading={isLoadingReportee || actorLoading}
+        />
         <DsParagraph
           data-size='md'
           className={classes.pageDescription}

--- a/src/features/amUI/maskinporten/MaskinportenPage.module.css
+++ b/src/features/amUI/maskinporten/MaskinportenPage.module.css
@@ -1,10 +1,3 @@
-.headerSection {
-  display: flex;
-  flex-direction: column;
-  gap: var(--ds-spacing-1);
-  margin-bottom: var(--ds-spacing-6);
-}
-
 .panelContent {
   margin-top: var(--ds-spacing-4);
   display: flex;

--- a/src/features/amUI/maskinporten/MaskinportenPage.tsx
+++ b/src/features/amUI/maskinporten/MaskinportenPage.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import { Navigate } from 'react-router';
 import { useTranslation } from 'react-i18next';
-import { DsHeading, DsTabs, Snackbar, SnackbarProvider } from '@altinn/altinn-components';
+import { DsTabs, formatDisplayName, Snackbar, SnackbarProvider } from '@altinn/altinn-components';
 import { DatabaseIcon, PersonGroupIcon } from '@navikt/aksel-icons';
 
 import { PageWrapper } from '@/components/PageWrapper/PageWrapper';
 import { getCookie } from '@/resources/Cookie/CookieMethods';
 import { useDocumentTitle } from '@/resources/hooks/useDocumentTitle';
 import { enableMaskinportenAdministration } from '@/resources/utils/featureFlagUtils';
-import { useGetIsMaskinportenAdminQuery } from '@/rtk/features/userInfoApi';
+import { useGetIsMaskinportenAdminQuery, useGetReporteeQuery } from '@/rtk/features/userInfoApi';
 
 import { Breadcrumbs } from '../common/Breadcrumbs/Breadcrumbs';
 import { PageLayoutWrapper } from '../common/PageLayoutWrapper';
@@ -16,8 +16,8 @@ import { PartyRepresentationProvider } from '../common/PartyRepresentationContex
 import { useUrlParamState } from '../common/useUrlParamState';
 
 import { ConsumersTab } from './ConsumersTab';
-import classes from './MaskinportenPage.module.css';
 import { SuppliersTab } from './SuppliersTab';
+import ReporteePageHeading from '../common/ReporteePageHeading';
 
 const maskinportenTabs = ['suppliers', 'consumers'] as const;
 
@@ -32,6 +32,7 @@ export const MaskinportenPage = () => {
   const { data: isMaskinportenAdmin, isLoading } = useGetIsMaskinportenAdminQuery(undefined, {
     skip: !enableMaskinportenAdministration(),
   });
+  const { data: reportee, isLoading: isLoadingReportee } = useGetReporteeQuery();
   const canFetchTabData = isMaskinportenAdmin === true && enableMaskinportenAdministration();
   useDocumentTitle(t('maskinporten_page.document_title'));
 
@@ -58,14 +59,16 @@ export const MaskinportenPage = () => {
           <SnackbarProvider>
             <>
               <Breadcrumbs items={['root', 'maskinporten']} />
-              <div className={classes.headerSection}>
-                <DsHeading
-                  level={1}
-                  data-size='lg'
-                >
-                  {t('maskinporten_page.heading')}
-                </DsHeading>
-              </div>
+              <ReporteePageHeading
+                title={t('maskinporten_page.heading', {
+                  name: formatDisplayName({
+                    fullName: reportee?.name ?? '',
+                    type: reportee?.type === 'Person' ? 'person' : 'company',
+                  }),
+                })}
+                reportee={reportee}
+                isLoading={isLoadingReportee}
+              />
               <DsTabs
                 data-size='sm'
                 value={activeTab}

--- a/src/features/amUI/settings/SettingsPageContent.module.css
+++ b/src/features/amUI/settings/SettingsPageContent.module.css
@@ -1,11 +1,9 @@
-.pageContent {
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
+.notAdminAlert {
   margin-top: 1rem;
 }
 
 .settingsListContainer {
+  margin-top: 1.5rem;
   padding: 1rem;
   background-color: white;
   box-shadow:
@@ -14,6 +12,7 @@
 }
 
 .settingsHeaderAndInfo {
+  margin-top: 1.5rem;
   display: flex;
   align-items: center;
   gap: 0.5rem;

--- a/src/features/amUI/settings/SettingsPageContent.tsx
+++ b/src/features/amUI/settings/SettingsPageContent.tsx
@@ -68,7 +68,7 @@ export const SettingsPageContent = () => {
   // Show not-admin alert when loaded and user lacks permission
   if (!isCompanyProfileAdmin && !isCompanyProfileAdminLoading) {
     return (
-      <div className={classes.pageContent}>
+      <div className={classes.notAdminAlert}>
         <DsAlert data-color='warning'>
           {t('settings_page.not_admin_alert', {
             name: formattedActingPartyName,
@@ -79,7 +79,7 @@ export const SettingsPageContent = () => {
   }
 
   return (
-    <div className={classes.pageContent}>
+    <div>
       <ReporteePageHeading
         title={t('settings_page.page_heading', { name: formattedActingPartyName })}
         reportee={reportee}

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -597,7 +597,7 @@
     "org_search_result_label": "You will add:"
   },
   "maskinporten_page": {
-    "heading": "Maskinporten administration",
+    "heading": "Maskinporten administration for {{name}}",
     "document_title": "Maskinporten administration - Altinn",
     "suppliers_tab": "Suppliers",
     "breadcrumb_suppliers": "Maskinporten – Suppliers",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -594,7 +594,7 @@
     "org_search_result_label": "Du legger til:"
   },
   "maskinporten_page": {
-    "heading": "Maskinporten\u00ADadministrasjon",
+    "heading": "Maskinporten\u00ADadministrasjon for {{name}}",
     "document_title": "Maskinportenadministrasjon - Altinn",
     "suppliers_tab": "Leverandører",
     "breadcrumb_suppliers": "Maskinporten – Leverandører",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -594,7 +594,7 @@
     "org_search_result_label": "Du legg til:"
   },
   "maskinporten_page": {
-    "heading": "Maskinporten\u00ADadministrasjon",
+    "heading": "Maskinporten\u00ADadministrasjon for {{name}}",
     "document_title": "Maskinportenadministrasjon - Altinn",
     "suppliers_tab": "Leverandørar",
     "breadcrumb_suppliers": "Maskinporten – Leverandørar",


### PR DESCRIPTION
## Description
- Use `ReporteePageHeading` in Maskinporten page (so first-level page headers look the same)
- Change css to make sure spacing between breadcrumbs and h1 is the same across all first-level pages

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Adjusted spacing and margins on client administration and settings pages

* **Localization**
  * Maskinporten administration page heading now displays the organization/actor name dynamically

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-access-management-frontend/pull/2263?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->