### PR TITLE
KeyRole message on external packages

### DIFF
--- a/src/dataObjects/dtos/Common.tsx
+++ b/src/dataObjects/dtos/Common.tsx
@@ -16,4 +16,5 @@ export interface CompactRole {
   code: string;
   children: CompactRole[];
   roleCodes: string[];
+  urn?: string;
 }

--- a/src/features/amUI/common/useInheritedStatus.ts
+++ b/src/features/amUI/common/useInheritedStatus.ts
@@ -41,7 +41,8 @@ const resolveInheritanceStatus = (
     !permission.viaRole &&
     !hasRightholderRole &&
     permission.from &&
-    permission.reason?.items.some((r) => r.name !== 'direct')
+    (permission.reason?.items.some((r) => r.name !== 'direct') ||
+      permission?.role?.urn?.includes('external-role'))
   ) {
     return {
       type: InheritedStatusType.ViaKeyRole,


### PR DESCRIPTION
Fixes a bug where the inherited message "ViaKeyRole" was not shown on external role inheritance. 

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced permission inheritance status resolution to better support external role management scenarios.
  * Updated role data structures to capture additional role identification information for improved tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->