### PR TITLE
Fixed too large loading spinner

### DIFF
--- a/src/features/amUI/common/AccessPackageList/AccessPackageList.module.css
+++ b/src/features/amUI/common/AccessPackageList/AccessPackageList.module.css
@@ -13,6 +13,13 @@
   height: 90%;
 }
 
+.loadingSpinner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: auto;
+}
+
 .showAvailablePackagesButton {
   width: fit-content;
 }

--- a/src/features/amUI/common/AccessPackageList/AccessPackageList.tsx
+++ b/src/features/amUI/common/AccessPackageList/AccessPackageList.tsx
@@ -106,11 +106,8 @@ export const AccessPackageList = ({
 
   if (fetchingSearch && searchString && searchString.length > 0) {
     return (
-      <div className={classes.accessAreaList}>
-        <DsSpinner
-          aria-label={t('common.loading')}
-          className={classes.noAccessPackages}
-        />
+      <div className={classes.loadingSpinner}>
+        <DsSpinner aria-label={t('common.loading')} />
       </div>
     );
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<img width="1085" height="673" alt="image" src="https://github.com/user-attachments/assets/0a311762-a1e6-4745-8186-feba6fa068c1" />

## Description
<!--- Describe your changes in detail -->

Some change in Designsystemet seems to have made the spinner more sensitive to outside scaling, regardless of the data-size set. Adding a more simplified css class, seems to have fixed the issue

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/3253

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a loading spinner that displays during search operations to provide visual feedback while results are being retrieved.

* **Style**
  * Enhanced the loading state styling for improved user experience during search interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->