### PR TITLE
Fixed failing header button test

### DIFF
--- a/playwright/e2eTests/altinn3/navigation/headertest.spec.ts
+++ b/playwright/e2eTests/altinn3/navigation/headertest.spec.ts
@@ -1,4 +1,4 @@
-import { test } from 'playwright/fixture/pomFixture';
+import { test, expect } from 'playwright/fixture/pomFixture';
 import { EnduserConnection } from '../../../api-requests/EnduserConnection';
 
 test.describe('Aktørvalg, valg og visning av avgiver', () => {
@@ -42,7 +42,7 @@ test.describe('Aktørvalg, valg og visning av avgiver', () => {
     });
 
     await test.step('Open Global Menu', async () => {
-      await aktorvalgHeader.menuButton.isVisible();
+      await expect(aktorvalgHeader.menuButton).toBeVisible();
       await aktorvalgHeader.menuButton.click();
     });
 

--- a/playwright/e2eTests/altinn3/navigation/headertest.spec.ts
+++ b/playwright/e2eTests/altinn3/navigation/headertest.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from 'playwright/fixture/pomFixture';
+import { test } from 'playwright/fixture/pomFixture';
 import { EnduserConnection } from '../../../api-requests/EnduserConnection';
 
 test.describe('Aktørvalg, valg og visning av avgiver', () => {
@@ -39,15 +39,6 @@ test.describe('Aktørvalg, valg og visning av avgiver', () => {
       await login.LoginToAccessManagement(HEADER_TEST_USER);
       await aktorvalgHeader.selectActorFromHeaderMenu(DEFAULT_ACTOR_NAME);
       await aktorvalgHeader.chooseBokmalLanguage();
-    });
-
-    await test.step('Open Global Menu', async () => {
-      await expect(aktorvalgHeader.menuButton).toBeVisible();
-      await aktorvalgHeader.menuButton.click();
-    });
-
-    await test.step('Check Search button', async () => {
-      await aktorvalgHeader.checkSearchButton();
     });
 
     await test.step('Check visibility for all menu buttons', async () => {

--- a/playwright/e2eTests/altinn3/navigation/headertest.spec.ts
+++ b/playwright/e2eTests/altinn3/navigation/headertest.spec.ts
@@ -41,9 +41,13 @@ test.describe('Aktørvalg, valg og visning av avgiver', () => {
       await aktorvalgHeader.chooseBokmalLanguage();
     });
 
-    await test.step('Click Search button', async () => {
+    await test.step('Open Global Menu', async () => {
+      await aktorvalgHeader.menuButton.isVisible();
       await aktorvalgHeader.menuButton.click();
-      await aktorvalgHeader.clickSearchButton();
+    });
+
+    await test.step('Check Search button', async () => {
+      await aktorvalgHeader.checkSearchButton();
     });
 
     await test.step('Check visibility for all menu buttons', async () => {

--- a/playwright/pages/AktorvalgHeader.ts
+++ b/playwright/pages/AktorvalgHeader.ts
@@ -145,10 +145,6 @@ export class AktorvalgHeader {
     await this.closePopups();
   }
 
-  async checkSearchButton() {
-    await expect(this.searchButton).toBeVisible();
-  }
-
   async typeInSearchField(text: string) {
     await this.aktorvalgSearch.fill(text);
   }
@@ -158,6 +154,8 @@ export class AktorvalgHeader {
   }
 
   async checkAllMenuButtons() {
+    await this.menuButton.click();
+    await expect(this.searchButton).toBeVisible();
     await expect(this.menuInbox).toBeVisible();
     await expect(this.menuAccessManagement).toBeVisible();
     await expect(this.menuApps).toBeVisible();

--- a/playwright/pages/AktorvalgHeader.ts
+++ b/playwright/pages/AktorvalgHeader.ts
@@ -145,9 +145,8 @@ export class AktorvalgHeader {
     await this.closePopups();
   }
 
-  async clickSearchButton() {
-    await this.searchButton.click();
-    await expect(this.searchBar).toBeVisible();
+  async checkSearchButton() {
+    await expect(this.searchButton).toBeVisible();
   }
 
   async typeInSearchField(text: string) {
@@ -159,8 +158,6 @@ export class AktorvalgHeader {
   }
 
   async checkAllMenuButtons() {
-    await this.page.waitForTimeout(1000);
-    await this.menuButton.click();
     await expect(this.menuInbox).toBeVisible();
     await expect(this.menuAccessManagement).toBeVisible();
     await expect(this.menuApps).toBeVisible();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This test was failing because it did not just check if the search button was present, it clicked it.
Since the global search exists only in InfoPortal, clicking it caused the browser to navigate to InfoPortal and perform the rest of the test there. Any following errors are thus not part of our solution and thus, should not be par of our playwright tests.
Our tests should test our solution.

Changing the test to only observe the existence of the search button without clicking it, makes the rest of the test run in our solution.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated header navigation test to directly verify visibility of menu and search buttons after actor/language selection, removing an extra pre-click and explicit search click.
  * Simplified test helpers to make menu visibility checks more immediate and reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->