### PR TITLE
Små tekstendringer - reportee -> actor, avgiver -> aktør

### DIFF
--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -184,8 +184,8 @@
     "unsynced_connection_link": "Click here to view your accesses in the old solution",
     "reportee_change_error": {
       "page_title": "Error page - Altinn",
-      "header": "We couldn't change reportee",
-      "description": "The selected reportee isn't available to you, or the link you followed was invalid.",
+      "header": "We couldn't change actor",
+      "description": "The selected actor isn't available to you, or the link you followed was invalid.",
       "if_persistent_contact_service": "If the problem persists, please contact Altinn support at 75 00 60 00.",
       "where_to_now": "Where would you like to go now?",
       "go_to_altinn": "Go to Altinn's start page",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -284,7 +284,7 @@
     "generic_error_try_again_title": "Oj, det oppstod en teknisk feil",
     "generic_error_try_again": "Prøv å legge til tjenesten på nytt ved å klikke på pluss-tegnet igjen. Ta kontakt med Altinn brukerservice hvis problemet fortsetter.",
     "unauthorized_for_party_title": "Mangler delegeringstilgang",
-    "unauthorized_for_party": "Du kan ikke delegere tjenester for valgte aktør. Dersom du mente å delegere på vegne av noen andre, vennligst gå til profilen og velg denne aktøren fra avgiverlisten.",
+    "unauthorized_for_party": "Du kan ikke delegere tjenester for valgte aktør. Dersom du mente å delegere på vegne av noen andre, vennligst gå til profilen og velg denne aktøren fra aktørlisten.",
     "missing_delegable_right": "Mangler rettighet",
     "missing_srr_right_access_title": "Du kan ikke gi fullmakt til denne tjenesten",
     "missing_srr_right_access_label": "Mangler tilgang",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -284,7 +284,7 @@
     "generic_error_try_again_title": "Oj, det oppstod en teknisk feil",
     "generic_error_try_again": "Prøv å legge til tjenesten på nytt ved å klikke på pluss-tegnet igjen. Ta kontakt med Altinn brukerservice hvis problemet fortsetter.",
     "unauthorized_for_party_title": "Mangler delegeringstilgang",
-    "unauthorized_for_party": "Du kan ikke delegere tjenester for valgte aktør. Dersom du mente å delegere på vegne av noen andre, vennligst gå til profilen og velg denne aktøren fra aktørlisten.",
+    "unauthorized_for_party": "Du kan ikke delegere tjenester for valgt aktør. Dersom du mente å delegere på vegne av noen andre, vennligst gå til profilen og velg denne aktøren fra aktørlisten.",
     "missing_delegable_right": "Mangler rettighet",
     "missing_srr_right_access_title": "Du kan ikke gi fullmakt til denne tjenesten",
     "missing_srr_right_access_label": "Mangler tilgang",


### PR DESCRIPTION
## Description
- Små tekstendringer:  ikke bruk ordet avgiver, og bruk actor i stedet for reportee på reportee-feilsiden

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/3233

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Refined error messages and user guidance text in English and Norwegian localizations for improved clarity and consistency.
  * Enhanced instructional language to provide clearer direction and better support for user navigation across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->