### PR TITLE
Fix typo in access_package_plural localization

### DIFF
--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -886,7 +886,7 @@
     "assigned_customers_header": "Clients connected to system access",
     "no_assigned_customers": "This system access has no clients",
     "access_package_single": "Power of attorney for 1 access package",
-    "access_package_plural": "Power of attorney for {{accessPackageCount}} access packages`",
+    "access_package_plural": "Power of attorney for {{accessPackageCount}} access packages",
     "add_customers": "Add clients",
     "edit_customers": "Add or remove clients",
     "customer_search": "Search in clients",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a text formatting issue in English localization for customer access package information display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->