### PR TITLE
Legg til url-parameter for org på systembruker-oversikt siden

### DIFF
--- a/src/features/amUI/systemUser/SystemUsersOverviewPage/SystemUserOverviewPage.tsx
+++ b/src/features/amUI/systemUser/SystemUsersOverviewPage/SystemUserOverviewPage.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Link } from 'react-router';
+import React, { useEffect } from 'react';
+import { Link, useSearchParams } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { PlusIcon } from '@navikt/aksel-icons';
 import {
@@ -25,15 +25,21 @@ import { SystemUserPath } from '@/routes/paths';
 import { PageLayoutWrapper } from '@/features/amUI/common/PageLayoutWrapper';
 
 import classes from './SystemUserOverviewPage.module.css';
-import { useGetIsAdminQuery, useGetIsClientAdminQuery } from '@/rtk/features/userInfoApi';
+import {
+  useGetIsAdminQuery,
+  useGetIsClientAdminQuery,
+  useGetReporteeListForAuthorizedUserQuery,
+} from '@/rtk/features/userInfoApi';
 import { hasCreateSystemUserPermission } from '@/resources/utils/permissionUtils';
 import { SystemUserList } from './SystemUserList';
 import { Breadcrumbs } from '../../common/Breadcrumbs/Breadcrumbs';
 import ReporteePageHeading from '../../common/ReporteePageHeading';
+import { redirectToChangeReporteeAndRedirect } from '@/resources/utils/changeReporteeUtils';
 
 export const SystemUserOverviewPage = () => {
   const { t } = useTranslation();
   useDocumentTitle(t('systemuser_overviewpage.page_title'));
+  const [searchParams, setSearchParams] = useSearchParams();
 
   const partyId = getCookie('AltinnPartyId');
   const partyUuid = getCookie('AltinnPartyUuid') || '';
@@ -68,6 +74,28 @@ export const SystemUserOverviewPage = () => {
   } = useGetPendingSystemUserRequestsQuery(partyUuid, {
     skip: !hasCreateSystemUserPermission(reporteeData, isAdmin),
   });
+
+  const { data: reporteeList } = useGetReporteeListForAuthorizedUserQuery(undefined, {
+    skip: !searchParams.get('org'),
+  });
+
+  useEffect(() => {
+    const org = searchParams.get('org');
+    if (org && reporteeData?.partyUuid && reporteeList) {
+      const matchingReportee = reporteeList?.find((r) => r.organizationNumber === org);
+      setSearchParams((prev) => {
+        const next = new URLSearchParams(prev);
+        next.delete('org');
+        return next;
+      });
+      if (matchingReportee && reporteeData?.organizationNumber !== org) {
+        redirectToChangeReporteeAndRedirect(
+          matchingReportee.partyUuid,
+          window.location.origin + window.location.pathname,
+        );
+      }
+    }
+  }, [searchParams, setSearchParams, reporteeData, reporteeList]);
 
   const isLoading =
     isLoadingSystemUsers ||


### PR DESCRIPTION
## Description
- Legg til org parameter som tar inn et organisasjonsnummer på systembruker-oversikt siden. Hvis dette er satt, last aktørlisten for gitt bruker, og se om dette orgnr finnes der. Hvis det gjør det, bytt til denne orgen. Systemleverandører vil bruke dette for å linke til systembrukeroversikten fra sitt system, så slipper de at etter bruker logger inn havner på systembruker-oversikt for seg selv som privatperson 

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/3296

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * System User Overview page now properly handles organization parameters in the URL and automatically redirects to the correct reportee when an organization mismatch is detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->