### PR TITLE
Add static area heading instead of description to package list 

### DIFF
--- a/src/features/amUI/common/AccessPackageList/AccessPackageList.module.css
+++ b/src/features/amUI/common/AccessPackageList/AccessPackageList.module.css
@@ -24,6 +24,10 @@
   width: fit-content;
 }
 
+.packagesTitle {
+  font-size: var(--ds-font-size-2);
+}
+
 .noAccessPackages {
   display: flex;
   align-items: center;

--- a/src/features/amUI/common/AccessPackageList/AccessPackageList.module.css
+++ b/src/features/amUI/common/AccessPackageList/AccessPackageList.module.css
@@ -25,7 +25,7 @@
 }
 
 .packagesTitle {
-  font-size: var(--ds-font-size-2);
+  font-size: var(--ds-font-size-minus-1);
 }
 
 .noAccessPackages {

--- a/src/features/amUI/common/AccessPackageList/AreaItemContent.tsx
+++ b/src/features/amUI/common/AccessPackageList/AreaItemContent.tsx
@@ -1,6 +1,6 @@
 import { List, DsHeading, DsButton, DsSpinner } from '@altinn/altinn-components';
 import { useTranslation } from 'react-i18next';
-import React, { useMemo, useState } from 'react';
+import React, { useState } from 'react';
 import cn from 'classnames';
 import { ChevronDownIcon, ChevronUpIcon } from '@navikt/aksel-icons';
 
@@ -102,6 +102,7 @@ export const AreaItemContent = ({
                     {...props}
                   />
                 )}
+                titleAs='span'
                 key={pkg.id}
                 pkg={pkg}
                 onSelect={onSelect}

--- a/src/features/amUI/common/AccessPackageList/AreaItemContent.tsx
+++ b/src/features/amUI/common/AccessPackageList/AreaItemContent.tsx
@@ -61,8 +61,6 @@ export const AreaItemContent = ({
   );
 
   const isSm = useIsMobileOrSmaller();
-  const hasPackages = packages.assigned.length > 0 || packages.available.length > 0;
-
   const { canDelegatePackage } = useAccessPackageDelegationCheck();
 
   const revokeActionControl = (pkg: AccessPackage) => {
@@ -86,14 +84,12 @@ export const AreaItemContent = ({
 
   return (
     <div className={cn(classes.accessAreaContent, !isSm && classes.accessAreaContentMargin)}>
-      {hasPackages && (
-        <DsHeading
-          level={4}
-          className={classes.packagesTitle}
-        >
-          {t('access_packages.access_packages_in_area_title')}
-        </DsHeading>
-      )}
+      <DsHeading
+        level={4}
+        className={classes.packagesTitle}
+      >
+        {t('access_packages.access_packages_in_area_title')}
+      </DsHeading>
       {packages.assigned.length > 0 && (
         <List aria-label={t('access_packages.given_packages_title')}>
           {packages.assigned.map((pkg) => {

--- a/src/features/amUI/common/AccessPackageList/AreaItemContent.tsx
+++ b/src/features/amUI/common/AccessPackageList/AreaItemContent.tsx
@@ -1,4 +1,4 @@
-import { List, DsParagraph, DsButton, DsSpinner } from '@altinn/altinn-components';
+import { List, DsHeading, DsButton, DsSpinner } from '@altinn/altinn-components';
 import { useTranslation } from 'react-i18next';
 import React, { useMemo, useState } from 'react';
 import cn from 'classnames';
@@ -61,6 +61,7 @@ export const AreaItemContent = ({
   );
 
   const isSm = useIsMobileOrSmaller();
+  const hasPackages = packages.assigned.length > 0 || packages.available.length > 0;
 
   const { canDelegatePackage } = useAccessPackageDelegationCheck();
 
@@ -85,7 +86,14 @@ export const AreaItemContent = ({
 
   return (
     <div className={cn(classes.accessAreaContent, !isSm && classes.accessAreaContentMargin)}>
-      <DsParagraph>{area.description}</DsParagraph>
+      {hasPackages && (
+        <DsHeading
+          level={4}
+          className={classes.packagesTitle}
+        >
+          {t('access_packages.access_packages_in_area_title')}
+        </DsHeading>
+      )}
       {packages.assigned.length > 0 && (
         <List aria-label={t('access_packages.given_packages_title')}>
           {packages.assigned.map((pkg) => {

--- a/src/features/amUI/common/AccessPackageList/PackageItem.tsx
+++ b/src/features/amUI/common/AccessPackageList/PackageItem.tsx
@@ -1,4 +1,4 @@
-import { AccessPackageListItem, AccessPackageListItemProps } from '@altinn/altinn-components';
+import { AccessPackageListItem, type AccessPackageListItemProps } from '@altinn/altinn-components';
 import { useTranslation } from 'react-i18next';
 
 import type { AccessPackage } from '@/rtk/features/accessPackageApi';
@@ -32,7 +32,7 @@ export const PackageItem = ({
     <AccessPackageListItem
       id={pkg.id}
       name={pkg.name}
-      titleAs={titleAs || 'span'}
+      titleAs={titleAs || 'h4'}
       description={t('access_packages.package_number_of_resources', {
         count: pkg.resources.length,
       })}

--- a/src/features/amUI/common/AccessPackageList/PackageItem.tsx
+++ b/src/features/amUI/common/AccessPackageList/PackageItem.tsx
@@ -1,4 +1,4 @@
-import { AccessPackageListItem } from '@altinn/altinn-components';
+import { AccessPackageListItem, AccessPackageListItemProps } from '@altinn/altinn-components';
 import { useTranslation } from 'react-i18next';
 
 import type { AccessPackage } from '@/rtk/features/accessPackageApi';
@@ -12,6 +12,7 @@ interface PackageItemProps {
   badge?: React.ReactNode;
   as?: React.ElementType;
   partyType: PartyType;
+  titleAs?: AccessPackageListItemProps['titleAs'];
 }
 
 export const PackageItem = ({
@@ -22,6 +23,7 @@ export const PackageItem = ({
   badge,
   as,
   partyType,
+  titleAs,
 }: PackageItemProps) => {
   const { t } = useTranslation();
   const partyTypeColor = partyType === PartyType.Person ? 'person' : 'company';
@@ -30,7 +32,7 @@ export const PackageItem = ({
     <AccessPackageListItem
       id={pkg.id}
       name={pkg.name}
-      titleAs='h4'
+      titleAs={titleAs || 'span'}
       description={t('access_packages.package_number_of_resources', {
         count: pkg.resources.length,
       })}

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -335,6 +335,7 @@
   "access_packages": {
     "helptext_button": "What are access packages?",
     "helptext_content": "Access packages are a collection of forms and services that deal with the same topic. These will replace Altinn roles and will be filled with more services over time.",
+    "access_packages_in_area_title": "Access packages in this area",
     "given_packages_title": "Currently held access packages",
     "available_packages_title": "Available access packages",
     "other_available": "Other available",

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -335,7 +335,7 @@
   "access_packages": {
     "helptext_button": "What are access packages?",
     "helptext_content": "Access packages are a collection of forms and services that deal with the same topic. These will replace Altinn roles and will be filled with more services over time.",
-    "access_packages_in_area_title": "Access packages in this area",
+    "access_packages_in_area_title": "Access packages in this area:",
     "given_packages_title": "Currently held access packages",
     "available_packages_title": "Available access packages",
     "other_available": "Other available",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -332,7 +332,7 @@
   "access_packages": {
     "helptext_button": "Hva er tilgangspakker?",
     "helptext_content": "Tilgangspakker er en samling av skjema og tjenester som handler om samme tema. Disse skal erstatte Altinn-roller og vil fylles med flere tjenester etter hvert.",
-    "access_packages_in_area_title": "Tilgangspakker i området",
+    "access_packages_in_area_title": "Tilgangspakker i området:",
     "given_packages_title": "Mottatte tilgangspakker",
     "available_packages_title": "Tilgjengelige tilgangspakker",
     "other_available": "Andre tilgjengelige",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -332,6 +332,7 @@
   "access_packages": {
     "helptext_button": "Hva er tilgangspakker?",
     "helptext_content": "Tilgangspakker er en samling av skjema og tjenester som handler om samme tema. Disse skal erstatte Altinn-roller og vil fylles med flere tjenester etter hvert.",
+    "access_packages_in_area_title": "Tilgangspakker i området",
     "given_packages_title": "Mottatte tilgangspakker",
     "available_packages_title": "Tilgjengelige tilgangspakker",
     "other_available": "Andre tilgjengelige",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -332,6 +332,7 @@
   "access_packages": {
     "helptext_button": "Kva er tilgangspakkar?",
     "helptext_content": "Tilgangspakkar er ei samling av skjema og tenester som handlar om same tema. Desse skal erstatte Altinn-roller og vil bli fylte med fleire tenester etter kvart.",
+    "access_packages_in_area_title": "Tilgangspakkar i området",
     "given_packages_title": "Mottatte tilgangspakkar",
     "available_packages_title": "Tilgjengelege tilgangspakkar",
     "other_available": "Andre tilgjengelege",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -332,7 +332,7 @@
   "access_packages": {
     "helptext_button": "Kva er tilgangspakkar?",
     "helptext_content": "Tilgangspakkar er ei samling av skjema og tenester som handlar om same tema. Desse skal erstatte Altinn-roller og vil bli fylte med fleire tenester etter kvart.",
-    "access_packages_in_area_title": "Tilgangspakkar i området",
+    "access_packages_in_area_title": "Tilgangspakkar i området:",
     "given_packages_title": "Mottatte tilgangspakkar",
     "available_packages_title": "Tilgjengelege tilgangspakkar",
     "other_available": "Andre tilgjengelege",


### PR DESCRIPTION

## Description
Replace area description with a static title text "Tilgangspakker i området"
<img height="300" alt="Skjermbilde 2026-06-04 kl  15 38 28" src="https://github.com/user-attachments/assets/2c680b97-67a4-4e31-8376-7adc0af4e257" />


<!--- Describe your changes in detail -->

## Related Issue(s)
https://github.com/Altinn/altinn-authorization-tmp/issues/2864

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-language support for access packages display (English, Norwegian Bokmål, Norwegian Nynorsk)

* **UI/UX Improvements**
  * Access packages section now displays with a dedicated heading ("Access packages in this area:") for improved clarity and visual hierarchy
  * Enhanced semantic structure for better readability
<!-- end of auto-generated comment: release notes by coderabbit.ai -->