### PR TITLE
fix: upgrade altinn-components to get new snackbar implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "vitest:ci": "vitest --coverage"
   },
   "dependencies": {
-    "@altinn/altinn-components": "0.66.1",
+    "@altinn/altinn-components": "^0.67.7",
     "@navikt/aksel-icons": "^8.11.1",
     "@reduxjs/toolkit": "^2.11.2",
     "@tanstack/react-query": "^5.95.2",

--- a/src/features/amUI/InstanceDetailPage/RequestInstanceAdminPackage/RequestInstanceAdminPackage.tsx
+++ b/src/features/amUI/InstanceDetailPage/RequestInstanceAdminPackage/RequestInstanceAdminPackage.tsx
@@ -1,5 +1,5 @@
 import { useRef } from 'react';
-import { Button, DsDialog, Snackbar, SnackbarProvider } from '@altinn/altinn-components';
+import { Button, DsDialog } from '@altinn/altinn-components';
 import { MinusCircleIcon, PlusCircleIcon } from '@navikt/aksel-icons';
 import { useTranslation } from 'react-i18next';
 
@@ -41,10 +41,7 @@ export const RequestInstanceAdminPackage = () => {
         closedby='any'
         closeButton={t('common.close')}
       >
-        <SnackbarProvider>
-          <RequestModalBody dialogRef={dialogRef} />
-          <Snackbar />
-        </SnackbarProvider>
+        <RequestModalBody dialogRef={dialogRef} />
       </DsDialog>
     </>
   );

--- a/src/features/amUI/common/DelegationModal/DelegationModalContent.tsx
+++ b/src/features/amUI/common/DelegationModal/DelegationModalContent.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { PlusIcon, ArrowLeftIcon } from '@navikt/aksel-icons';
 import { JSX, useEffect, useRef } from 'react';
-import { Button, DsDialog, Snackbar, SnackbarProvider } from '@altinn/altinn-components';
+import { Button, DsDialog } from '@altinn/altinn-components';
 
 import type { AccessPackage } from '@/rtk/features/accessPackageApi';
 import type { ServiceResource } from '@/rtk/features/singleRights/singleRightsApi';
@@ -151,25 +151,18 @@ export const DelegationModalContent = ({
         onClose={reset}
         ref={modalRef}
       >
-        <>
-          <SnackbarProvider>
-            {infoView && (
-              <Button
-                className={classes.backButton}
-                variant='tertiary'
-                data-color='neutral'
-                onClick={() => setInfoView(false)}
-              >
-                <ArrowLeftIcon aria-hidden='true' />
-                {t('common.back')}
-              </Button>
-            )}
-            <div className={classes.content}>
-              {infoView ? infoViewContent : searchViewContent}
-              <Snackbar />
-            </div>
-          </SnackbarProvider>
-        </>
+        {infoView && (
+          <Button
+            className={classes.backButton}
+            variant='tertiary'
+            data-color='neutral'
+            onClick={() => setInfoView(false)}
+          >
+            <ArrowLeftIcon aria-hidden='true' />
+            {t('common.back')}
+          </Button>
+        )}
+        <div className={classes.content}>{infoView ? infoViewContent : searchViewContent}</div>
       </DsDialog>
     </DsDialog.TriggerContext>
   );

--- a/src/features/amUI/common/DelegationModal/EditModal.tsx
+++ b/src/features/amUI/common/DelegationModal/EditModal.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { forwardRef, useEffect } from 'react';
-import { DsDialog, Snackbar, SnackbarProvider } from '@altinn/altinn-components';
+import { DsDialog } from '@altinn/altinn-components';
 
 import type { ActionError } from '@/resources/hooks/useActionError';
 import type { ServiceResource } from '@/rtk/features/singleRights/singleRightsApi';
@@ -82,21 +82,18 @@ export const EditModal = forwardRef<HTMLDialogElement, EditModalProps>(
           reset();
         }}
       >
-        <SnackbarProvider>
-          <div className={classes.content}>
-            {renderModalContent({
-              resource,
-              maskinportenScope,
-              accessPackage,
-              role,
-              instance,
-              toParty,
-              availableActions,
-              onSuccess,
-            })}
-          </div>
-          <Snackbar />
-        </SnackbarProvider>
+        <div className={classes.content}>
+          {renderModalContent({
+            resource,
+            maskinportenScope,
+            accessPackage,
+            role,
+            instance,
+            toParty,
+            availableActions,
+            onSuccess,
+          })}
+        </div>
       </DsDialog>
     );
   },

--- a/src/features/amUI/common/PageLayoutWrapper/PageLayoutWrapper.tsx
+++ b/src/features/amUI/common/PageLayoutWrapper/PageLayoutWrapper.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { LanguageCode } from '@altinn/altinn-components';
-import { Layout, RootProvider, Snackbar } from '@altinn/altinn-components';
+import { Layout, RootProvider, Snackbar, SnackbarProvider } from '@altinn/altinn-components';
 
 import { useGetReporteeQuery } from '@/rtk/features/userInfoApi';
 
@@ -43,39 +43,41 @@ export const PageLayoutWrapper = ({
   return (
     <RootProvider languageCode={languageCode as LanguageCode}>
       <NavigationFocus />
-      <Layout
-        color={reportee?.type ? getAccountType(reportee.type) : 'neutral'}
-        theme='subtle'
-        header={header}
-        banner={{
-          title: t('info_banner.info'),
-          link: { label: t('info_banner.link'), href: bannerLink },
-          color: escalateBannerSeverity ? 'warning' : undefined,
-          variant: escalateBannerSeverity ? 'alert' : undefined,
-        }}
-        skipLink={{
-          href: '#main-content',
-          color: 'inherit',
-          size: 'xs',
-          children: t('common.skiplink'),
-        }}
-        sidebar={
-          hideSidebar
-            ? undefined
-            : {
-                menu: {
-                  groups: menuGroups,
-                  items: [...sidebarItems, ...shortcutsMenuItem],
-                },
-              }
-        }
-        content={{ color: reportee?.type ? getAccountType(reportee.type) : 'neutral' }}
-        footer={footer}
-      >
-        <div>{children}</div>
-        <InfoModal />
-      </Layout>
-      <Snackbar />
+      <SnackbarProvider>
+        <Layout
+          color={reportee?.type ? getAccountType(reportee.type) : 'neutral'}
+          theme='subtle'
+          header={header}
+          banner={{
+            title: t('info_banner.info'),
+            link: { label: t('info_banner.link'), href: bannerLink },
+            color: escalateBannerSeverity ? 'warning' : undefined,
+            variant: escalateBannerSeverity ? 'alert' : undefined,
+          }}
+          skipLink={{
+            href: '#main-content',
+            color: 'inherit',
+            size: 'xs',
+            children: t('common.skiplink'),
+          }}
+          sidebar={
+            hideSidebar
+              ? undefined
+              : {
+                  menu: {
+                    groups: menuGroups,
+                    items: [...sidebarItems, ...shortcutsMenuItem],
+                  },
+                }
+          }
+          content={{ color: reportee?.type ? getAccountType(reportee.type) : 'neutral' }}
+          footer={footer}
+        >
+          <div>{children}</div>
+          <InfoModal />
+        </Layout>
+        <Snackbar />
+      </SnackbarProvider>
     </RootProvider>
   );
 };

--- a/src/features/amUI/maskinporten/ConsumerPage.tsx
+++ b/src/features/amUI/maskinporten/ConsumerPage.tsx
@@ -1,14 +1,7 @@
 import { useMemo } from 'react';
 import { Link, useParams } from 'react-router';
 import { useTranslation } from 'react-i18next';
-import {
-  DsAlert,
-  DsParagraph,
-  DsSkeleton,
-  Snackbar,
-  SnackbarProvider,
-  formatDisplayName,
-} from '@altinn/altinn-components';
+import { DsAlert, DsParagraph, DsSkeleton, formatDisplayName } from '@altinn/altinn-components';
 
 import { PageWrapper } from '@/components/PageWrapper/PageWrapper';
 import { getCookie } from '@/resources/Cookie/CookieMethods';
@@ -62,43 +55,40 @@ export const ConsumerPage = () => {
   const notFound = !!error || (!isLoading && !data?.length);
 
   return (
-    <SnackbarProvider>
-      <PageWrapper>
-        <PageLayoutWrapper>
-          <PartyRepresentationProvider
-            toPartyUuid={party}
-            actingPartyUuid={party}
-            fromPartyOverride={consumerParty}
-          >
-            <DelegationModalProvider>
-              <Breadcrumbs
-                items={['root', 'maskinporten_consumers']}
-                lastBreadcrumb={{ label: consumerName || t('maskinporten_page.consumer_title') }}
-              />
-              {isLoading ? (
-                <PageContainer backUrl={backUrl}>
-                  <DsSkeleton
-                    width='100%'
-                    height='2.5rem'
-                  />
-                </PageContainer>
-              ) : notFound ? (
-                <PageContainer backUrl={backUrl}>
-                  <DsAlert data-color='danger'>
-                    <DsParagraph>
-                      {t('maskinporten_page.consumer_not_found')}{' '}
-                      <Link to={backUrl}>{t('maskinporten_page.back_to_list')}</Link>
-                    </DsParagraph>
-                  </DsAlert>
-                </PageContainer>
-              ) : (
-                <ConsumerPageContent />
-              )}
-            </DelegationModalProvider>
-          </PartyRepresentationProvider>
-        </PageLayoutWrapper>
-      </PageWrapper>
-      <Snackbar />
-    </SnackbarProvider>
+    <PageWrapper>
+      <PageLayoutWrapper>
+        <PartyRepresentationProvider
+          toPartyUuid={party}
+          actingPartyUuid={party}
+          fromPartyOverride={consumerParty}
+        >
+          <DelegationModalProvider>
+            <Breadcrumbs
+              items={['root', 'maskinporten_consumers']}
+              lastBreadcrumb={{ label: consumerName || t('maskinporten_page.consumer_title') }}
+            />
+            {isLoading ? (
+              <PageContainer backUrl={backUrl}>
+                <DsSkeleton
+                  width='100%'
+                  height='2.5rem'
+                />
+              </PageContainer>
+            ) : notFound ? (
+              <PageContainer backUrl={backUrl}>
+                <DsAlert data-color='danger'>
+                  <DsParagraph>
+                    {t('maskinporten_page.consumer_not_found')}{' '}
+                    <Link to={backUrl}>{t('maskinporten_page.back_to_list')}</Link>
+                  </DsParagraph>
+                </DsAlert>
+              </PageContainer>
+            ) : (
+              <ConsumerPageContent />
+            )}
+          </DelegationModalProvider>
+        </PartyRepresentationProvider>
+      </PageLayoutWrapper>
+    </PageWrapper>
   );
 };

--- a/src/features/amUI/maskinporten/MaskinportenPage.tsx
+++ b/src/features/amUI/maskinporten/MaskinportenPage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Navigate } from 'react-router';
 import { useTranslation } from 'react-i18next';
-import { DsTabs, formatDisplayName, Snackbar, SnackbarProvider } from '@altinn/altinn-components';
+import { DsTabs, formatDisplayName } from '@altinn/altinn-components';
 import { DatabaseIcon, PersonGroupIcon } from '@navikt/aksel-icons';
 
 import { PageWrapper } from '@/components/PageWrapper/PageWrapper';
@@ -56,52 +56,49 @@ export const MaskinportenPage = () => {
           fromPartyUuid={party}
           actingPartyUuid={party}
         >
-          <SnackbarProvider>
-            <>
-              <Breadcrumbs items={['root', 'maskinporten']} />
-              <ReporteePageHeading
-                title={t('maskinporten_page.heading', {
-                  name: formatDisplayName({
-                    fullName: reportee?.name ?? '',
-                    type: reportee?.type === 'Person' ? 'person' : 'company',
-                  }),
-                })}
-                reportee={reportee}
-                isLoading={isLoadingReportee}
-              />
-              <DsTabs
-                data-size='sm'
-                value={activeTab}
-                onChange={setActiveTab}
-              >
-                <DsTabs.List>
-                  <DsTabs.Tab value='suppliers'>
-                    <PersonGroupIcon aria-hidden='true' />
-                    {t('maskinporten_page.suppliers_tab')}
-                  </DsTabs.Tab>
-                  <DsTabs.Tab value='consumers'>
-                    <DatabaseIcon aria-hidden='true' />
-                    {t('maskinporten_page.consumers_tab')}
-                  </DsTabs.Tab>
-                </DsTabs.List>
-                <DsTabs.Panel value='suppliers'>
-                  <SuppliersTab
-                    party={party}
-                    isActive={activeTab === 'suppliers'}
-                    canFetch={canFetchTabData}
-                  />
-                </DsTabs.Panel>
-                <DsTabs.Panel value='consumers'>
-                  <ConsumersTab
-                    party={party}
-                    isActive={activeTab === 'consumers'}
-                    canFetch={canFetchTabData}
-                  />
-                </DsTabs.Panel>
-              </DsTabs>
-              <Snackbar />
-            </>
-          </SnackbarProvider>
+          <>
+            <Breadcrumbs items={['root', 'maskinporten']} />
+            <ReporteePageHeading
+              title={t('maskinporten_page.heading', {
+                name: formatDisplayName({
+                  fullName: reportee?.name ?? '',
+                  type: reportee?.type === 'Person' ? 'person' : 'company',
+                }),
+              })}
+              reportee={reportee}
+              isLoading={isLoadingReportee}
+            />
+            <DsTabs
+              data-size='sm'
+              value={activeTab}
+              onChange={setActiveTab}
+            >
+              <DsTabs.List>
+                <DsTabs.Tab value='suppliers'>
+                  <PersonGroupIcon aria-hidden='true' />
+                  {t('maskinporten_page.suppliers_tab')}
+                </DsTabs.Tab>
+                <DsTabs.Tab value='consumers'>
+                  <DatabaseIcon aria-hidden='true' />
+                  {t('maskinporten_page.consumers_tab')}
+                </DsTabs.Tab>
+              </DsTabs.List>
+              <DsTabs.Panel value='suppliers'>
+                <SuppliersTab
+                  party={party}
+                  isActive={activeTab === 'suppliers'}
+                  canFetch={canFetchTabData}
+                />
+              </DsTabs.Panel>
+              <DsTabs.Panel value='consumers'>
+                <ConsumersTab
+                  party={party}
+                  isActive={activeTab === 'consumers'}
+                  canFetch={canFetchTabData}
+                />
+              </DsTabs.Panel>
+            </DsTabs>
+          </>
         </PartyRepresentationProvider>
       </PageLayoutWrapper>
     </PageWrapper>

--- a/src/features/amUI/maskinporten/SupplierPage.tsx
+++ b/src/features/amUI/maskinporten/SupplierPage.tsx
@@ -1,14 +1,7 @@
 import { useMemo } from 'react';
 import { Link, useParams } from 'react-router';
 import { useTranslation } from 'react-i18next';
-import {
-  DsAlert,
-  DsParagraph,
-  DsSkeleton,
-  Snackbar,
-  SnackbarProvider,
-  formatDisplayName,
-} from '@altinn/altinn-components';
+import { DsAlert, DsParagraph, DsSkeleton, formatDisplayName } from '@altinn/altinn-components';
 
 import { PageWrapper } from '@/components/PageWrapper/PageWrapper';
 import { getCookie } from '@/resources/Cookie/CookieMethods';
@@ -62,43 +55,40 @@ export const SupplierPage = () => {
   const notFound = !!error || (!isLoading && !data?.length);
 
   return (
-    <SnackbarProvider>
-      <PageWrapper>
-        <PageLayoutWrapper>
-          <PartyRepresentationProvider
-            fromPartyUuid={party}
-            actingPartyUuid={party}
-            toPartyOverride={supplierParty}
-          >
-            <DelegationModalProvider>
-              <Breadcrumbs
-                items={['root', 'maskinporten_suppliers']}
-                lastBreadcrumb={{ label: supplierName || t('maskinporten_page.supplier_title') }}
-              />
-              {isLoading ? (
-                <PageContainer backUrl={backUrl}>
-                  <DsSkeleton
-                    width='100%'
-                    height='2.5rem'
-                  />
-                </PageContainer>
-              ) : notFound ? (
-                <PageContainer backUrl={backUrl}>
-                  <DsAlert data-color='danger'>
-                    <DsParagraph>
-                      {t('maskinporten_page.supplier_not_found')}{' '}
-                      <Link to={backUrl}>{t('maskinporten_page.back_to_list')}</Link>
-                    </DsParagraph>
-                  </DsAlert>
-                </PageContainer>
-              ) : (
-                <SupplierPageContent />
-              )}
-            </DelegationModalProvider>
-          </PartyRepresentationProvider>
-        </PageLayoutWrapper>
-      </PageWrapper>
-      <Snackbar />
-    </SnackbarProvider>
+    <PageWrapper>
+      <PageLayoutWrapper>
+        <PartyRepresentationProvider
+          fromPartyUuid={party}
+          actingPartyUuid={party}
+          toPartyOverride={supplierParty}
+        >
+          <DelegationModalProvider>
+            <Breadcrumbs
+              items={['root', 'maskinporten_suppliers']}
+              lastBreadcrumb={{ label: supplierName || t('maskinporten_page.supplier_title') }}
+            />
+            {isLoading ? (
+              <PageContainer backUrl={backUrl}>
+                <DsSkeleton
+                  width='100%'
+                  height='2.5rem'
+                />
+              </PageContainer>
+            ) : notFound ? (
+              <PageContainer backUrl={backUrl}>
+                <DsAlert data-color='danger'>
+                  <DsParagraph>
+                    {t('maskinporten_page.supplier_not_found')}{' '}
+                    <Link to={backUrl}>{t('maskinporten_page.back_to_list')}</Link>
+                  </DsParagraph>
+                </DsAlert>
+              </PageContainer>
+            ) : (
+              <SupplierPageContent />
+            )}
+          </DelegationModalProvider>
+        </PartyRepresentationProvider>
+      </PageLayoutWrapper>
+    </PageWrapper>
   );
 };

--- a/src/features/amUI/myClients/MyClientsAccessSection.tsx
+++ b/src/features/amUI/myClients/MyClientsAccessSection.tsx
@@ -71,15 +71,13 @@ export const MyClientsAccessSection = ({
   );
 
   return (
-    <>
-      <ClientAccessList
-        clients={clients}
-        accessStateClients={clients}
-        removeDisabled={isRemovingMyClientAccessPackages || !actingPartyUuid}
-        onRemoveAccessPackage={onRemoveAccessPackage}
-        requireDelegableForActions={false}
-        searchPlaceholder={t('my_clients_page.search_placeholder')}
-      />
-    </>
+    <ClientAccessList
+      clients={clients}
+      accessStateClients={clients}
+      removeDisabled={isRemovingMyClientAccessPackages || !actingPartyUuid}
+      onRemoveAccessPackage={onRemoveAccessPackage}
+      requireDelegableForActions={false}
+      searchPlaceholder={t('my_clients_page.search_placeholder')}
+    />
   );
 };

--- a/src/features/amUI/myClients/MyClientsAccessSection.tsx
+++ b/src/features/amUI/myClients/MyClientsAccessSection.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { Snackbar, useSnackbar } from '@altinn/altinn-components';
+import { useSnackbar } from '@altinn/altinn-components';
 import { useTranslation } from 'react-i18next';
 
 import {
@@ -80,7 +80,6 @@ export const MyClientsAccessSection = ({
         requireDelegableForActions={false}
         searchPlaceholder={t('my_clients_page.search_placeholder')}
       />
-      <Snackbar />
     </>
   );
 };

--- a/src/features/amUI/myClients/MyClientsPage.tsx
+++ b/src/features/amUI/myClients/MyClientsPage.tsx
@@ -1,11 +1,5 @@
 import React, { useMemo } from 'react';
-import {
-  DsAlert,
-  DsParagraph,
-  DsSkeleton,
-  formatDisplayName,
-  SnackbarProvider,
-} from '@altinn/altinn-components';
+import { DsAlert, DsParagraph, DsSkeleton, formatDisplayName } from '@altinn/altinn-components';
 import { useTranslation } from 'react-i18next';
 
 import { PageContainer } from '../common/PageContainer/PageContainer';
@@ -124,13 +118,11 @@ export const MyClientsPage = () => {
                   height='220px'
                 />
               ) : clients.length > 0 ? (
-                <SnackbarProvider>
-                  <MyClientsAccessSection
-                    clients={clients}
-                    actingPartyUuid={actingPartyUuid}
-                    currentUserName={currentUserName}
-                  />
-                </SnackbarProvider>
+                <MyClientsAccessSection
+                  clients={clients}
+                  actingPartyUuid={actingPartyUuid}
+                  currentUserName={currentUserName}
+                />
               ) : (
                 <DsParagraph>
                   {t('my_clients_page.no_clients', { actingParty: actingPartyName })}

--- a/src/features/amUI/packagePoaDetailsPage/PartyInfoModal.tsx
+++ b/src/features/amUI/packagePoaDetailsPage/PartyInfoModal.tsx
@@ -1,5 +1,5 @@
 import { forwardRef } from 'react';
-import { DsDialog, Snackbar, SnackbarProvider } from '@altinn/altinn-components';
+import { DsDialog } from '@altinn/altinn-components';
 
 import classes from '../common/DelegationModal/DelegationModal.module.css';
 import { PartyInfo, type PartyInfoProps } from '../common/DelegationModal/Party/PartyInfo';
@@ -18,10 +18,7 @@ export const PartyInfoModal = forwardRef<HTMLDialogElement, PartyInfoModalProps>
         closedby='any'
         onClose={onClose}
       >
-        <SnackbarProvider>
-          <div className={classes.content}>{partyInfo && <PartyInfo {...partyInfo} />}</div>
-          <Snackbar />
-        </SnackbarProvider>
+        <div className={classes.content}>{partyInfo && <PartyInfo {...partyInfo} />}</div>
       </DsDialog>
     );
   },

--- a/src/features/amUI/requestPage/RequestReviewModal/RequestReviewModal.tsx
+++ b/src/features/amUI/requestPage/RequestReviewModal/RequestReviewModal.tsx
@@ -1,5 +1,5 @@
 import { useRef, useEffect } from 'react';
-import { DsDialog, Snackbar, SnackbarProvider } from '@altinn/altinn-components';
+import { DsDialog } from '@altinn/altinn-components';
 import { useTranslation } from 'react-i18next';
 import type { Request } from '../types';
 import { RequestReviewModalContent } from './RequestReviewModalContent';
@@ -31,13 +31,10 @@ export const RequestReviewModal = ({ request, onClose }: RequestReviewModalProps
       onClose={onClose}
       className={classes.reviewModal}
     >
-      <SnackbarProvider>
-        <RequestReviewModalContent
-          request={request}
-          onClose={onClose}
-        />
-        <Snackbar />
-      </SnackbarProvider>
+      <RequestReviewModalContent
+        request={request}
+        onClose={onClose}
+      />
     </DsDialog>
   );
 };

--- a/src/features/amUI/requestPage/SentRequestsCombinedModal.tsx
+++ b/src/features/amUI/requestPage/SentRequestsCombinedModal.tsx
@@ -1,11 +1,5 @@
 import React, { useState } from 'react';
-import {
-  DsButton,
-  DsDialog,
-  DsHeading,
-  Snackbar,
-  SnackbarProvider,
-} from '@altinn/altinn-components';
+import { DsButton, DsDialog, DsHeading } from '@altinn/altinn-components';
 import { useTranslation } from 'react-i18next';
 import { ServiceResource } from '@/rtk/features/singleRights/singleRightsApi';
 import { useGetSentRequestsQuery, type EnrichedPackageRequest } from '@/rtk/features/requestApi';
@@ -59,57 +53,54 @@ export const SentRequestsCombinedModal = ({
       }}
       className={classes.dialog}
     >
-      <SnackbarProvider>
-        {isModalOpen && (
-          <div className={classes.container}>
-            {!hasDetailView && (
-              <DsHeading
-                data-size='xs'
-                level={1}
-                className={classes.heading}
-              >
-                {heading}
-              </DsHeading>
-            )}
-            {(hasPendingSentPackageRequests || selectedPackageRequest) && !selectedResource && (
-              <div className={classes.requestList}>
-                {!hasDetailView && (
-                  <DsHeading
-                    data-size='2xs'
-                    level={2}
-                  >
-                    {t('request_page.package_list_title')}
-                  </DsHeading>
-                )}
+      {isModalOpen && (
+        <div className={classes.container}>
+          {!hasDetailView && (
+            <DsHeading
+              data-size='xs'
+              level={1}
+              className={classes.heading}
+            >
+              {heading}
+            </DsHeading>
+          )}
+          {(hasPendingSentPackageRequests || selectedPackageRequest) && !selectedResource && (
+            <div className={classes.requestList}>
+              {!hasDetailView && (
+                <DsHeading
+                  data-size='2xs'
+                  level={2}
+                >
+                  {t('request_page.package_list_title')}
+                </DsHeading>
+              )}
 
-                <DelegationModalProvider>
-                  <PendingPackageRequestsList
-                    selectedRequest={selectedPackageRequest}
-                    setSelectedRequest={setSelectedPackageRequest}
-                  />
-                </DelegationModalProvider>
-              </div>
-            )}
-            {(hasPendingSentResourceRequests || selectedResource) && !selectedPackageRequest && (
-              <div className={classes.requestList}>
-                {!hasDetailView && (
-                  <DsHeading
-                    data-size='2xs'
-                    level={2}
-                  >
-                    {t('request_page.resource_list_title')}
-                  </DsHeading>
-                )}
-                <PendingRequestsList
-                  selectedResource={selectedResource}
-                  setSelectedResource={setSelectedResource}
+              <DelegationModalProvider>
+                <PendingPackageRequestsList
+                  selectedRequest={selectedPackageRequest}
+                  setSelectedRequest={setSelectedPackageRequest}
                 />
-              </div>
-            )}
-          </div>
-        )}
-        <Snackbar />
-      </SnackbarProvider>
+              </DelegationModalProvider>
+            </div>
+          )}
+          {(hasPendingSentResourceRequests || selectedResource) && !selectedPackageRequest && (
+            <div className={classes.requestList}>
+              {!hasDetailView && (
+                <DsHeading
+                  data-size='2xs'
+                  level={2}
+                >
+                  {t('request_page.resource_list_title')}
+                </DsHeading>
+              )}
+              <PendingRequestsList
+                selectedResource={selectedResource}
+                setSelectedResource={setSelectedResource}
+              />
+            </div>
+          )}
+        </div>
+      )}
       {!hasDetailView && (
         <DsButton
           variant='primary'

--- a/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPage.module.css
+++ b/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPage.module.css
@@ -22,11 +22,6 @@
   margin-top: var(--ds-size-12);
 }
 
-.customerListSnackbar {
-  align-self: flex-end;
-  max-width: 20rem;
-}
-
 .addAllContainer {
   display: flex;
   flex-direction: column;

--- a/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router';
-import { SnackbarProvider, DsAlert, DsHeading, DsSkeleton } from '@altinn/altinn-components';
+import { DsAlert, DsHeading, DsSkeleton } from '@altinn/altinn-components';
 
 import {
   useGetAssignedCustomersQuery,
@@ -137,13 +137,11 @@ export const SystemUserAgentDelegationPage = (): React.ReactNode => {
             </DsAlert>
           )}
           {systemUser && customers && agentDelegations && !isLoading && (
-            <SnackbarProvider>
-              <SystemUserAgentDelegationPageContent
-                systemUser={systemUser}
-                customers={customers}
-                existingAgentDelegations={agentDelegations}
-              />
-            </SnackbarProvider>
+            <SystemUserAgentDelegationPageContent
+              systemUser={systemUser}
+              customers={customers}
+              existingAgentDelegations={agentDelegations}
+            />
           )}
         </PageContainer>
       </PageLayoutWrapper>

--- a/src/features/amUI/userRightsPage/AccessPackageSection/PendingPackageRequests/RequestsModal.tsx
+++ b/src/features/amUI/userRightsPage/AccessPackageSection/PendingPackageRequests/RequestsModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { DsButton, DsDialog, Snackbar, SnackbarProvider } from '@altinn/altinn-components';
+import { DsButton, DsDialog } from '@altinn/altinn-components';
 import { useTranslation } from 'react-i18next';
 import { type EnrichedPackageRequest } from '@/rtk/features/requestApi';
 import { PendingPackageRequestsList } from './RequestsList';
@@ -31,16 +31,14 @@ export const PendingPackageRequestsModal = ({
       }}
       className={classes.dialog}
     >
-      <SnackbarProvider>
-        {isModalOpen && (
-          <PendingPackageRequestsList
-            heading={heading}
-            selectedRequest={selectedRequest}
-            setSelectedRequest={setSelectedRequest}
-          />
-        )}
-        <Snackbar />
-      </SnackbarProvider>
+      {isModalOpen && (
+        <PendingPackageRequestsList
+          heading={heading}
+          selectedRequest={selectedRequest}
+          setSelectedRequest={setSelectedRequest}
+        />
+      )}
+
       {!selectedRequest && (
         <DsButton
           variant='primary'

--- a/src/features/amUI/userRightsPage/SingleRightsSection/PendingRequests.tsx
+++ b/src/features/amUI/userRightsPage/SingleRightsSection/PendingRequests.tsx
@@ -6,8 +6,6 @@ import {
   DsHeading,
   formatDisplayName,
   ListItem,
-  Snackbar,
-  SnackbarProvider,
 } from '@altinn/altinn-components';
 import { ResourceList } from '../../common/ResourceList/ResourceList';
 import { useSingleRightRequests } from '../../common/DelegationModal/SingleRights/hooks/useSingleRightRequests';
@@ -102,16 +100,14 @@ export const SentRequestsModal = ({
       }}
       className={classes.pendingRequestsModal}
     >
-      <SnackbarProvider>
-        {isModalOpen && (
-          <PendingRequestsList
-            heading={heading}
-            selectedResource={selectedResource}
-            setSelectedResource={setSelectedResource}
-          />
-        )}
-        <Snackbar />
-      </SnackbarProvider>
+      {isModalOpen && (
+        <PendingRequestsList
+          heading={heading}
+          selectedResource={selectedResource}
+          setSelectedResource={setSelectedResource}
+        />
+      )}
+
       {!selectedResource && (
         <DsButton
           variant='primary'

--- a/src/sites/ErrorPage/amUi/ErrorLayoutWrapper.tsx
+++ b/src/sites/ErrorPage/amUi/ErrorLayoutWrapper.tsx
@@ -2,7 +2,7 @@ import { InfoModal } from '@/features/amUI/common/PageLayoutWrapper/InfoModal';
 import { useFooter } from '@/features/amUI/common/PageLayoutWrapper/useFooter';
 import { useHeader } from '@/features/amUI/common/PageLayoutWrapper/useHeader';
 import { GeneralPath } from '@/routes/paths';
-import { LanguageCode, Layout, RootProvider, Snackbar } from '@altinn/altinn-components';
+import { LanguageCode, Layout, RootProvider } from '@altinn/altinn-components';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router';
 
@@ -45,7 +45,6 @@ export const ErrorLayoutWrapper = ({
         {children}
         <InfoModal />
       </Layout>
-      <Snackbar />
     </RootProvider>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,9 +19,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@altinn/altinn-components@npm:0.66.1":
-  version: 0.66.1
-  resolution: "@altinn/altinn-components@npm:0.66.1"
+"@altinn/altinn-components@npm:^0.67.7":
+  version: 0.67.7
+  resolution: "@altinn/altinn-components@npm:0.67.7"
   dependencies:
     "@digdir/designsystemet-css": "npm:^1.14.0"
     "@digdir/designsystemet-react": "npm:^1.14.0"
@@ -34,7 +34,7 @@ __metadata:
   peerDependencies:
     react: ">=18.3.1 || ^19.0.0"
     react-dom: ">=18.3.1 || ^19.0.0"
-  checksum: 10/ac9379319777acd6faa5548c3d98c06d6c3dd3788a29c45ccaa0058ad8e3241c882def90dca51eb755774fd4d04b8cbc2266f86d84e25bbc9f49a6b399033d4d
+  checksum: 10/ccd8e03deba55d321b850aeb03d1c2b553f97202072655634b6d3e9fef76bba6d489f6586e53e312c7ec8b94a23c3c5864f9b43386307f75f7e9d103a858e286
   languageName: node
   linkType: hard
 
@@ -3243,7 +3243,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "access-management@workspace:."
   dependencies:
-    "@altinn/altinn-components": "npm:0.66.1"
+    "@altinn/altinn-components": "npm:^0.67.7"
     "@axe-core/playwright": "npm:^4.10.2"
     "@navikt/aksel-icons": "npm:^8.11.1"
     "@playwright/test": "npm:^1.60.0"


### PR DESCRIPTION
## Description
- Upgrade altinn-components to get new snackbar implementation
- Remove local implementation of `Snackbar` and `SnackbarProvider`; one provider and one snackbar in PageLayoutWrapper is enough

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/3215

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dependencies**
  * Updated `@altinn/altinn-components` from `0.66.1` to `^0.67.7`

* **Refactoring**
  * Reorganized notification handling to be managed at the page layout level, ensuring consistent notification behavior across the application
  * Simplified modal and component structures by removing redundant provider wrappers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->