### PR TITLE
Fix for info popover on small screens

### DIFF
--- a/src/features/amUI/common/AccessPackageInfoPopover/AccessPackageInfoPopover.module.css
+++ b/src/features/amUI/common/AccessPackageInfoPopover/AccessPackageInfoPopover.module.css
@@ -11,6 +11,6 @@
 
 @media (max-width: 768px) {
   .popover {
-    min-width: 100%;
+    min-width: auto;
   }
 }

--- a/src/features/amUI/common/AccessPackageInfoPopover/AccessPackageInfoPopover.module.css
+++ b/src/features/amUI/common/AccessPackageInfoPopover/AccessPackageInfoPopover.module.css
@@ -11,6 +11,6 @@
 
 @media (max-width: 768px) {
   .popover {
-    min-width: auto;
+    min-width: 90%;
   }
 }

--- a/src/features/amUI/maskinporten/MaskinportenInfoPopover.module.css
+++ b/src/features/amUI/maskinporten/MaskinportenInfoPopover.module.css
@@ -11,6 +11,6 @@
 
 @media (max-width: 768px) {
   .popover {
-    min-width: 100%;
+    min-width: 90%;
   }
 }

--- a/src/features/amUI/poaOverview/AccessPackagePermissions.module.css
+++ b/src/features/amUI/poaOverview/AccessPackagePermissions.module.css
@@ -6,6 +6,5 @@
 .infoPopover {
   margin-top: calc(-1 * var(--ds-spacing-1));
   display: inline-flex;
-  white-space: nowrap;
   vertical-align: middle;
 }

--- a/src/features/amUI/poaOverview/AccessPackagePermissions.tsx
+++ b/src/features/amUI/poaOverview/AccessPackagePermissions.tsx
@@ -16,11 +16,13 @@ export const AccessPackagePermissions = () => {
   return (
     <>
       <div className={classes.description}>
-        <DsParagraph>
-          {t('poa_overview_page.packages_tab.description')}
-          <span className={classes.infoPopover}>
-            <AccessPackageInfoPopover />
-          </span>
+        <DsParagraph asChild>
+          <div>
+            {t('poa_overview_page.packages_tab.description')}
+            <span className={classes.infoPopover}>
+              <AccessPackageInfoPopover />
+            </span>
+          </div>
         </DsParagraph>
       </div>
       <DebouncedSearchField


### PR DESCRIPTION
## Description
- Allow text in popover to wrap
- Prevent horizontal scroll on small screens when popover is open
- Avoid having `div` as a child of a `p` element

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved text wrapping in the access package overview so long descriptions wrap correctly.
  * Adjusted popover sizing on small screens (now slightly narrower) for better fit and readability.
  * Tweaked paragraph rendering for descriptions to ensure more consistent spacing and layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->