### PR TITLE
Allow klientadmins to use admin pages without Access management package

### DIFF
--- a/src/features/amUI/agentDetails/AgentDetailsPage.tsx
+++ b/src/features/amUI/agentDetails/AgentDetailsPage.tsx
@@ -37,7 +37,7 @@ export const AgentDetailsPage = () => {
         name: selectedAgent.agent.name,
         partyUuid: selectedAgent.agent.id,
         partyTypeName: PartyType.Person,
-        partyId: Number(selectedAgent.agent.partyId),
+        partyId: Number(selectedAgent.agent.partyId ?? 0),
       }
     : undefined;
 

--- a/src/features/amUI/agentDetails/AgentDetailsPage.tsx
+++ b/src/features/amUI/agentDetails/AgentDetailsPage.tsx
@@ -9,6 +9,9 @@ import { Navigate, useParams } from 'react-router';
 import { clientAdministrationPageEnabled } from '@/resources/utils/featureFlagUtils';
 import { PageWrapper } from '@/components';
 import { PageLayoutWrapper } from '../common/PageLayoutWrapper';
+import { useGetAgentsQuery } from '@/rtk/features/clientApi';
+import { Party } from '@/rtk/features/lookupApi';
+import { PartyType } from '@/rtk/features/userInfoApi';
 
 export const AgentDetailsPage = () => {
   const { t } = useTranslation();
@@ -17,6 +20,8 @@ export const AgentDetailsPage = () => {
   useDocumentTitle(t('client_administration_page.agent_page_title'));
 
   const pageIsEnabled = clientAdministrationPageEnabled();
+  const { data: agents } = useGetAgentsQuery();
+  const selectedAgent = agents?.find((item) => item.agent.id === id);
 
   if (!pageIsEnabled) {
     return (
@@ -27,13 +32,23 @@ export const AgentDetailsPage = () => {
     );
   }
 
+  const agentParty: Party | undefined = selectedAgent
+    ? {
+        name: selectedAgent.agent.name,
+        partyUuid: selectedAgent.agent.id,
+        partyTypeName: PartyType.Person,
+        partyId: Number(selectedAgent.agent.partyId),
+      }
+    : undefined;
+
   return (
     <PageWrapper>
       <PageLayoutWrapper>
         <PartyRepresentationProvider
           fromPartyUuid={getCookie('AltinnPartyUuid')}
           actingPartyUuid={getCookie('AltinnPartyUuid')}
-          toPartyUuid={id}
+          toPartyOverride={agentParty}
+          isLoading={!selectedAgent}
         >
           <AgentDetails />
         </PartyRepresentationProvider>

--- a/src/features/amUI/clientDetails/ClientDetailsPage.tsx
+++ b/src/features/amUI/clientDetails/ClientDetailsPage.tsx
@@ -9,6 +9,9 @@ import { useDocumentTitle } from '@/resources/hooks/useDocumentTitle';
 import { PartyRepresentationProvider } from '../common/PartyRepresentationContext/PartyRepresentationContext';
 import { PageLayoutWrapper } from '../common/PageLayoutWrapper';
 import { ClientDetails } from './ClientDetails';
+import { useGetClientsQuery } from '@/rtk/features/clientApi';
+import { PartyType } from '@/rtk/features/userInfoApi';
+import { Party } from '@/rtk/features/lookupApi';
 
 export const ClientDetailsPage = () => {
   const { t } = useTranslation();
@@ -17,6 +20,9 @@ export const ClientDetailsPage = () => {
   useDocumentTitle(t('client_administration_page.client_page_title'));
 
   const pageIsEnabled = clientAdministrationPageEnabled();
+
+  const { data: clients } = useGetClientsQuery();
+  const selectedClient = clients?.find((item) => item.client.id === id);
 
   if (!pageIsEnabled) {
     return (
@@ -27,13 +33,23 @@ export const ClientDetailsPage = () => {
     );
   }
 
+  const clientParty: Party | undefined = selectedClient
+    ? {
+        name: selectedClient.client.name,
+        partyUuid: selectedClient.client.id,
+        partyTypeName: PartyType.Organization,
+        partyId: Number(selectedClient.client.partyId),
+      }
+    : undefined;
+
   return (
     <PageWrapper>
       <PageLayoutWrapper>
         <PartyRepresentationProvider
-          fromPartyUuid={id}
+          fromPartyOverride={clientParty}
           actingPartyUuid={getCookie('AltinnPartyUuid')}
           toPartyUuid={getCookie('AltinnPartyUuid')}
+          isLoading={!selectedClient}
         >
           <ClientDetails />
         </PartyRepresentationProvider>

--- a/src/features/amUI/clientDetails/ClientDetailsPage.tsx
+++ b/src/features/amUI/clientDetails/ClientDetailsPage.tsx
@@ -38,7 +38,7 @@ export const ClientDetailsPage = () => {
         name: selectedClient.client.name,
         partyUuid: selectedClient.client.id,
         partyTypeName: PartyType.Organization,
-        partyId: Number(selectedClient.client.partyId),
+        partyId: Number(selectedClient.client.partyId ?? 0),
       }
     : undefined;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<img width="1844" height="1092" alt="image" src="https://github.com/user-attachments/assets/a9290655-4d32-4e60-a80f-b902ac94e82b" />
Logged in with Kantete Tøffel (21894099558) which only has the Clinent Admin package, without any other packages or accessess. Kantete Tøffel can now see client and agent pages.


## Description
<!--- Describe your changes in detail -->

The problem was that we used the standard PartyRepresentaionProvider to fetch party data, which uses an API that only Access Managers have access to. The fix is to use the ovverride function and instead fetch the party data from the agent/client endpoints. (Accessible for Client admins)

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/3395

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Agent Details Page: Enhanced data retrieval and party information handling for improved reliability.
  * Client Details Page: Optimized client data loading and party mapping to ensure accurate representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->