### PR TITLE
Hide download button with display: none

### DIFF
--- a/src/features/amUI/common/DownloadFileButton/DownloadFileButton.module.css
+++ b/src/features/amUI/common/DownloadFileButton/DownloadFileButton.module.css
@@ -2,6 +2,7 @@
   display: flex;
   align-items: center;
   gap: var(--ds-spacing-3);
+  display: none;
 }
 
 .dialog {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<img width="2464" height="838" alt="image" src="https://github.com/user-attachments/assets/d92d85d4-aa21-497c-9da8-e58649b22734" />

## Description
<!--- Describe your changes in detail -->

As a quick alternative to a feature toggle, we hide the download button with `display: none` while we run a hotfix of something else out to production. This allows us to also be able to test the functionality by disabling the display-property in the inspector.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
