### PR TITLE
Revert "Hide download button with display: none"

### DIFF
--- a/src/features/amUI/common/DownloadFileButton/DownloadFileButton.module.css
+++ b/src/features/amUI/common/DownloadFileButton/DownloadFileButton.module.css
@@ -2,7 +2,6 @@
   display: flex;
   align-items: center;
   gap: var(--ds-spacing-3);
-  display: none;
 }
 
 .dialog {


### PR DESCRIPTION
Reverts Altinn/altinn-access-management-frontend#2302

The hotfix is out, so the button can resurface 🧟‍♂️

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the download file button visibility and styling, ensuring it now displays correctly with proper alignment and spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->