### PR TITLE
File download: Hide toggle on subunit and block paralell requests

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/DelegationExportControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/DelegationExportControllerTest.cs
@@ -1,6 +1,8 @@
+using System.Collections.Concurrent;
 using System.IO.Compression;
 using System.Net;
 using System.Net.Http.Headers;
+using System.Reflection;
 using Altinn.AccessManagement.UI.Controllers;
 using Altinn.AccessManagement.UI.Mocks.Utils;
 using Altinn.AccessManagement.UI.Tests.Utils;
@@ -200,6 +202,29 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
             string body = await response.Content.ReadAsStringAsync();
             Assert.Contains("Unexpected httpStatus returned from backend (Instances)", body);
+        }
+
+        [Fact]
+        public async Task Export_ConcurrentRequestBySameUser_ReturnsTooManyRequests()
+        {
+            // Simulate an already-active export by the same user (userId=1234) via the static dictionary.
+            var field = typeof(DelegationExportController)
+                .GetField("_activeExports", BindingFlags.NonPublic | BindingFlags.Static);
+            var activeExports = (ConcurrentDictionary<int, byte>)field.GetValue(null);
+            activeExports.TryAdd(1234, 0);
+
+            try
+            {
+                HttpResponseMessage response = await _client.GetAsync($"{BaseUrl}?partyUuid={OrgPartyUuid}&types=roles");
+
+                Assert.Equal(HttpStatusCode.TooManyRequests, response.StatusCode);
+                string body = await response.Content.ReadAsStringAsync();
+                Assert.Contains("An export is already in progress", body);
+            }
+            finally
+            {
+                activeExports.TryRemove(1234, out _);
+            }
         }
 
         private static async Task<Dictionary<string, string>> ReadZipEntries(HttpResponseMessage response)

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/DelegationExportControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/DelegationExportControllerTest.cs
@@ -208,10 +208,12 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         public async Task Export_ConcurrentRequestBySameUser_ReturnsTooManyRequests()
         {
             // Simulate an already-active export by the same user (userId=1234) via the static dictionary.
-            var field = typeof(DelegationExportController)
-                .GetField("_activeExports", BindingFlags.NonPublic | BindingFlags.Static);
-            var activeExports = (ConcurrentDictionary<int, byte>)field.GetValue(null);
-            activeExports.TryAdd(1234, 0);
+var field = typeof(DelegationExportController)
+    .GetField("_activeExports", BindingFlags.NonPublic | BindingFlags.Static);
+Assert.NotNull(field);
+
+var activeExports = (ConcurrentDictionary<int, byte>)field.GetValue(null)!;
+activeExports.TryAdd(1234, 0);
 
             try
             {

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/DelegationExportController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/DelegationExportController.cs
@@ -70,11 +70,16 @@ namespace Altinn.AccessManagement.UI.Controllers
                 return BadRequest("partyUuid must be provided.");
             }
 
-            int userId = AuthenticationHelper.GetUserId(_httpContextAccessor.HttpContext);
-            if (!_activeExports.TryAdd(userId, 0))
-            {
-                return StatusCode(StatusCodes.Status429TooManyRequests, "An export is already in progress. Please wait for it to complete.");
-            }
+int userId = AuthenticationHelper.GetUserId(_httpContextAccessor.HttpContext);
+if (userId == 0)
+{
+    return BadRequest("The userId is not provided in the context.");
+}
+
+if (!_activeExports.TryAdd(userId, 0))
+{
+    return StatusCode(StatusCodes.Status429TooManyRequests, "An export is already in progress. Please wait for it to complete.");
+}
 
             try
             {

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/DelegationExportController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/DelegationExportController.cs
@@ -70,16 +70,16 @@ namespace Altinn.AccessManagement.UI.Controllers
                 return BadRequest("partyUuid must be provided.");
             }
 
-int userId = AuthenticationHelper.GetUserId(_httpContextAccessor.HttpContext);
-if (userId == 0)
-{
-    return BadRequest("The userId is not provided in the context.");
-}
+            int userId = AuthenticationHelper.GetUserId(_httpContextAccessor.HttpContext);
+            if (userId == 0)
+            {
+                return BadRequest("The userId is not provided in the context.");
+            }
 
-if (!_activeExports.TryAdd(userId, 0))
-{
-    return StatusCode(StatusCodes.Status429TooManyRequests, "An export is already in progress. Please wait for it to complete.");
-}
+            if (!_activeExports.TryAdd(userId, 0))
+            {
+                return StatusCode(StatusCodes.Status429TooManyRequests, "An export is already in progress. Please wait for it to complete.");
+            }
 
             try
             {

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/DelegationExportController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/DelegationExportController.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Altinn.AccessManagement.UI.Core.Helpers;
 using Altinn.AccessManagement.UI.Core.Models.DelegationExport;
 using Altinn.AccessManagement.UI.Core.Services.Interfaces;
@@ -18,6 +19,8 @@ namespace Altinn.AccessManagement.UI.Controllers
         {
             "roles", "accesspackages", "singlerights", "instances",
         };
+
+        private static readonly ConcurrentDictionary<int, byte> _activeExports = new();
 
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly ILogger _logger;
@@ -67,6 +70,12 @@ namespace Altinn.AccessManagement.UI.Controllers
                 return BadRequest("partyUuid must be provided.");
             }
 
+            int userId = AuthenticationHelper.GetUserId(_httpContextAccessor.HttpContext);
+            if (!_activeExports.TryAdd(userId, 0))
+            {
+                return StatusCode(StatusCodes.Status429TooManyRequests, "An export is already in progress. Please wait for it to complete.");
+            }
+
             try
             {
                 ISet<string> typeSet = ParseTypes(types);
@@ -105,6 +114,10 @@ namespace Altinn.AccessManagement.UI.Controllers
             {
                 _logger.LogError(ex, "Error exporting delegated rights for party {PartyUuid}", partyUuid);
                 return StatusCode(StatusCodes.Status500InternalServerError, "An error occurred while building the export.");
+            }
+            finally
+            {
+                _activeExports.TryRemove(userId, out _);
             }
         }
 

--- a/src/features/amUI/common/DownloadFileButton/DownloadFileButton.tsx
+++ b/src/features/amUI/common/DownloadFileButton/DownloadFileButton.tsx
@@ -13,6 +13,7 @@ import { usePartyRepresentation } from '../PartyRepresentationContext/PartyRepre
 import { PartyType, useGetIsAdminQuery } from '@/rtk/features/userInfoApi';
 
 import classes from './DownloadFileButton.module.css';
+import { isSubUnitByType } from '@/resources/utils/reporteeUtils';
 
 export interface DownloadFileButtonProps {
   size?: 'xs' | 'sm' | 'md' | 'lg';
@@ -89,11 +90,13 @@ export const DownloadFileButton = ({
               {t('download_file.description_p1', { reportee: reporteeName })}
             </DsParagraph>
             <DsParagraph>{t('download_file.description_p2')}</DsParagraph>
-            <DsSwitch
-              checked={includeSubunits}
-              onChange={(event) => setIncludeSubunits(event.target.checked)}
-              label={t('download_file.include_subunits_label', { reportee: reporteeName })}
-            />
+            {!isSubUnitByType(fromParty?.variant) && (
+              <DsSwitch
+                checked={includeSubunits}
+                onChange={(event) => setIncludeSubunits(event.target.checked)}
+                label={t('download_file.include_subunits_label', { reportee: reporteeName })}
+              />
+            )}
             <div className={classes.buttons}>
               <Button
                 variant='primary'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<img width="1167" height="705" alt="image" src="https://github.com/user-attachments/assets/1c59b62f-337b-451f-a0e1-293cd202d00b" />

## Description
<!--- Describe your changes in detail -->
This PR removes the toggle button (asking to include subunits in the download) from the UI if the chosen actor is already a subunit. (Subunits cannot have their own subunits)

In addition to this, it adds blocking of parallel requests.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Concurrent delegation export requests from the same user now return 429 Too Many Requests with an explanatory message when an export is already in progress.
  * The "include subunits" toggle is hidden when initiating exports from a subunit type.

* **Tests**
  * Added automated test covering concurrent export request handling to verify the throttling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->