### PR TITLE
Fix race condition in Single services tests

### DIFF
--- a/playwright/pages/AccessManagementFrontPage.ts
+++ b/playwright/pages/AccessManagementFrontPage.ts
@@ -51,6 +51,7 @@ export class AccessManagementFrontPage {
 
   async goToEnkelttjenester() {
     await this.page.getByRole('tab', { name: 'Enkelttjenester' }).click();
+    await expect(this.page.getByText(/Fullmakt til \d+ enkelttjeneste/)).toBeVisible();
   }
 
   async goToFullmakterHosAndre() {

--- a/playwright/pages/AccessManagementFrontPage.ts
+++ b/playwright/pages/AccessManagementFrontPage.ts
@@ -51,7 +51,7 @@ export class AccessManagementFrontPage {
 
   async goToEnkelttjenester() {
     await this.page.getByRole('tab', { name: 'Enkelttjenester' }).click();
-    await expect(this.page.getByText(/Fullmakt til \d+ enkelttjeneste/)).toBeVisible();
+    await expect(this.page.getByText(/Fullmakt til \d+ enkelttjeneste/)).toBeVisible(); // Use only partial text to match both singular and plural forms
   }
 
   async goToFullmakterHosAndre() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Several tests failed because they were not waiting for the tab to actually shift before proceeding to clicking buttons.
The tests now check that the UI has actually changed to the Single services tab before trying to delegate single services.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by enhancing UI element visibility checks when navigating to individual service authorizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->