### PR TITLE
File download: Limit subunit inclusion to less than 500

### DIFF
--- a/src/features/amUI/common/DownloadFileButton/DownloadFileButton.tsx
+++ b/src/features/amUI/common/DownloadFileButton/DownloadFileButton.tsx
@@ -10,7 +10,11 @@ import { DownloadIcon } from '@navikt/aksel-icons';
 import { useTranslation } from 'react-i18next';
 import { useRef, useState } from 'react';
 import { usePartyRepresentation } from '../PartyRepresentationContext/PartyRepresentationContext';
-import { PartyType, useGetIsAdminQuery } from '@/rtk/features/userInfoApi';
+import {
+  PartyType,
+  useGetIsAdminQuery,
+  useGetReporteeListForAuthorizedUserQuery,
+} from '@/rtk/features/userInfoApi';
 
 import classes from './DownloadFileButton.module.css';
 import { isSubUnitByType } from '@/resources/utils/reporteeUtils';
@@ -34,6 +38,14 @@ export const DownloadFileButton = ({
   const { data: isAdmin } = useGetIsAdminQuery();
   const { fromParty } = usePartyRepresentation();
   const reporteeName = formatDisplayName({ fullName: fromParty?.name || '', type: 'company' });
+  const { data: accountList } = useGetReporteeListForAuthorizedUserQuery();
+  const fromAccountSubunitsNumber =
+    accountList?.find((account) => account.partyUuid === fromParty?.partyUuid)?.subunits?.length ||
+    0;
+  const allowSubunitDownload =
+    !isSubUnitByType(fromParty?.variant) &&
+    fromAccountSubunitsNumber > 0 &&
+    fromAccountSubunitsNumber < 500;
 
   const handleDownload = () => {
     if (!fromParty) return;
@@ -90,7 +102,7 @@ export const DownloadFileButton = ({
               {t('download_file.description_p1', { reportee: reporteeName })}
             </DsParagraph>
             <DsParagraph>{t('download_file.description_p2')}</DsParagraph>
-            {!isSubUnitByType(fromParty?.variant) && (
+            {allowSubunitDownload && (
               <DsSwitch
                 checked={includeSubunits}
                 onChange={(event) => setIncludeSubunits(event.target.checked)}

--- a/src/features/amUI/common/DownloadFileButton/DownloadFileButton.tsx
+++ b/src/features/amUI/common/DownloadFileButton/DownloadFileButton.tsx
@@ -40,7 +40,9 @@ export const DownloadFileButton = ({
   const { data: isAdmin } = useGetIsAdminQuery();
   const { fromParty } = usePartyRepresentation();
   const reporteeName = formatDisplayName({ fullName: fromParty?.name || '', type: 'company' });
-  const { data: accountList } = useGetReporteeListForAuthorizedUserQuery();
+  const { data: accountList } = useGetReporteeListForAuthorizedUserQuery(undefined, {
+    skip: !isAdmin || fromParty?.partyTypeName !== PartyType.Organization,
+  });
   const fromAccountSubunitsNumber =
     accountList?.find((account) => account.partyUuid === fromParty?.partyUuid)?.subunits?.length ||
     0;

--- a/src/features/amUI/common/DownloadFileButton/DownloadFileButton.tsx
+++ b/src/features/amUI/common/DownloadFileButton/DownloadFileButton.tsx
@@ -19,6 +19,8 @@ import {
 import classes from './DownloadFileButton.module.css';
 import { isSubUnitByType } from '@/resources/utils/reporteeUtils';
 
+const MAX_SUBUNITS_FOR_DOWNLOAD_OPTION = 500;
+
 export interface DownloadFileButtonProps {
   size?: 'xs' | 'sm' | 'md' | 'lg';
   iconOnly?: boolean;
@@ -45,7 +47,7 @@ export const DownloadFileButton = ({
   const allowSubunitDownload =
     !isSubUnitByType(fromParty?.variant) &&
     fromAccountSubunitsNumber > 0 &&
-    fromAccountSubunitsNumber < 500;
+    fromAccountSubunitsNumber < MAX_SUBUNITS_FOR_DOWNLOAD_OPTION;
 
   const handleDownload = () => {
     if (!fromParty) return;

--- a/src/features/amUI/common/DownloadFileButton/DownloadFileButton.tsx
+++ b/src/features/amUI/common/DownloadFileButton/DownloadFileButton.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  DsAlert,
   DsDialog,
   DsHeading,
   DsParagraph,
@@ -49,7 +50,7 @@ export const DownloadFileButton = ({
   const allowSubunitDownload =
     !isSubUnitByType(fromParty?.variant) &&
     fromAccountSubunitsNumber > 0 &&
-    fromAccountSubunitsNumber < MAX_SUBUNITS_FOR_DOWNLOAD_OPTION;
+    fromAccountSubunitsNumber <= MAX_SUBUNITS_FOR_DOWNLOAD_OPTION;
 
   const handleDownload = () => {
     if (!fromParty) return;
@@ -112,6 +113,15 @@ export const DownloadFileButton = ({
                 onChange={(event) => setIncludeSubunits(event.target.checked)}
                 label={t('download_file.include_subunits_label', { reportee: reporteeName })}
               />
+            )}
+            {fromAccountSubunitsNumber > MAX_SUBUNITS_FOR_DOWNLOAD_OPTION && (
+              <DsAlert
+                data-color='warning'
+                data-size='sm'
+                className={classes.warning}
+              >
+                <DsParagraph>{t('download_file.too_many_subunits_warning')}</DsParagraph>
+              </DsAlert>
             )}
             <div className={classes.buttons}>
               <Button

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -110,7 +110,8 @@
     "description_p1": "Here you can download an overview of all powers of attorney that {{reportee}} has given to others and those who have received them.",
     "description_p2": "The content will be downloaded as CSV files in a ZIP container. \nThe files are not intended for machine reading and we reserve the right to change the format.",
     "start_download": "Start download",
-    "include_subunits_label": "Include powers of attorney in {{reportee}}'s subunits"
+    "include_subunits_label": "Include powers of attorney in {{reportee}}'s subunits",
+    "too_many_subunits_warning": "This organization has too many subunits to include them in the download. We are working on a solution for this, but for now, you must download each subunit separately if you want their information."
   },
   "info_banner": {
     "info": "June 19: the old Altinn will be shut down.",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -107,7 +107,8 @@
     "description_p1": "Her kan du laste ned en oversikt over alle fullmakter som {{reportee}} har gitt til andre og hvem som har fått dem.",
     "description_p2": "Innholdet lastes ned som csv-filer i en zip-konteiner. \nFilen er ikke ment til maskinell innlesning og vi tar forbehold om at formatet kan endre seg.",
     "start_download": "Start nedlasting",
-    "include_subunits_label": "Inkluder fullmakter i {{reportee}} sine underenheter"
+    "include_subunits_label": "Inkluder fullmakter i {{reportee}} sine underenheter",
+    "too_many_subunits_warning": "Denne virksomheten har for mange underenheter til å inkludere dem i nedlastingen. Dette er noe vi jobber med å løse, men for nå må du laste ned hver underenhet for seg hvis du ønsker denne informasjonen."
   },
   "info_banner": {
     "info": "19. juni skrus gamle Altinn av.",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -107,7 +107,8 @@
     "description_p1": "Her kan du laste ned ei oversikt over alle fullmakter som {{reportee}} har gitt til andre og kven som har fått dei.",
     "description_p2": "Innhaldet lastes ned som csv-filer i ein zip-konteiner. \nFila er ikkje meint til maskinell innlesing og vi tek forbehald om at formatet kan endre seg.",
     "start_download": "Start nedlastninga",
-    "include_subunits_label": "Inkluder fullmakter i {{reportee}} sine undereiningar"
+    "include_subunits_label": "Inkluder fullmakter i {{reportee}} sine undereiningar",
+    "too_many_subunits_warning": "Denne verksemda har for mange underenheter til å inkludere dem i nedlastingen. Dette er noko vi jobbar med å løyse, men for no må du laste ned kvar underenhet for seg dersom du ønskjer denne informasjonen."
   },
   "info_banner": {
     "info": "19. juni blir gamle Altinn skrudd av.",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -108,7 +108,7 @@
     "description_p2": "Innhaldet lastes ned som csv-filer i ein zip-konteiner. \nFila er ikkje meint til maskinell innlesing og vi tek forbehald om at formatet kan endre seg.",
     "start_download": "Start nedlastninga",
     "include_subunits_label": "Inkluder fullmakter i {{reportee}} sine undereiningar",
-    "too_many_subunits_warning": "Denne verksemda har for mange underenheter til å inkludere dem i nedlastingen. Dette er noko vi jobbar med å løyse, men for no må du laste ned kvar underenhet for seg dersom du ønskjer denne informasjonen."
+    "too_many_subunits_warning": "Denne verksemda har for mange undereiningar til å inkludere dei i nedlastinga. Dette er noko vi jobbar med å løyse, men for no må du laste ned kvar undereining for seg dersom du ønskjer denne informasjonen."
   },
   "info_banner": {
     "info": "19. juni blir gamle Altinn skrudd av.",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

If an org has 500 or more subunits, they will not get the option of including subunits in file download.

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/3505

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced the download file button to show the “include subunits” option based on the selected account type and a subunit-count threshold.
  * When subunits exceed the limit, the option is gated and a warning is displayed to encourage separate downloads.
* **Localization**
  * Added new localized labels and a “too many subunits” warning message in Norwegian variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->