### PR TITLE
Minor fixes for consent and systemuser list items for screen readers

### DIFF
--- a/src/features/amUI/consent/ActiveConsentsPage/ConsentListItem.tsx
+++ b/src/features/amUI/consent/ActiveConsentsPage/ConsentListItem.tsx
@@ -55,11 +55,15 @@ export const ConsentListItem = ({
             title={{ as: 'div', children: item.title }}
             description={item.description}
             as='button'
+            ariaLabel={`${item.title} ${item.description} ${item.badgeText}`}
             loading={isLoading}
             interactive={!!onClick}
             onClick={onClick ? () => onClick(item.id) : undefined}
             badge={
-              <div className={classes.consentBadge}>
+              <div
+                className={classes.consentBadge}
+                aria-hidden
+              >
                 {item.isNew && <Badge label={t('active_consents.newly_consented')} />}
                 <div className={classes.consentBadgeAction}>
                   {isLoading ? (

--- a/src/features/amUI/consent/ActiveConsentsPage/ConsentListItem.tsx
+++ b/src/features/amUI/consent/ActiveConsentsPage/ConsentListItem.tsx
@@ -55,7 +55,7 @@ export const ConsentListItem = ({
             title={{ as: 'div', children: item.title }}
             description={item.description}
             as='button'
-            ariaLabel={`${item.title} ${item.description} ${item.badgeText}`}
+            ariaLabel={`${item.title} ${item.isNew ? t('active_consents.newly_consented') : ''} ${item.description} ${item.badgeText}`}
             loading={isLoading}
             interactive={!!onClick}
             onClick={onClick ? () => onClick(item.id) : undefined}

--- a/src/features/amUI/systemUser/SystemUsersOverviewPage/SystemUserList.tsx
+++ b/src/features/amUI/systemUser/SystemUsersOverviewPage/SystemUserList.tsx
@@ -66,7 +66,10 @@ export const SystemUserList = ({
           }
 
           const badge = (
-            <div className={classes.systemUserBadge}>
+            <div
+              className={classes.systemUserBadge}
+              aria-hidden
+            >
               {newlyCreatedId === systemUser.id && (
                 <Badge
                   label={t('systemuser_overviewpage.new_system_user')}
@@ -88,6 +91,7 @@ export const SystemUserList = ({
               key={systemUser.id}
               size='lg'
               title={{ children: `${systemUser.integrationTitle} ${refText}`, as: 'div' }}
+              ariaLabel={`${systemUser.integrationTitle} ${refText} ${systemUser.system.systemVendorOrgName} ${badgeContent}`}
               description={systemUser.system.systemVendorOrgName}
               as={(props) => (
                 <Link

--- a/src/features/amUI/systemUser/SystemUsersOverviewPage/SystemUserList.tsx
+++ b/src/features/amUI/systemUser/SystemUsersOverviewPage/SystemUserList.tsx
@@ -91,7 +91,7 @@ export const SystemUserList = ({
               key={systemUser.id}
               size='lg'
               title={{ children: `${systemUser.integrationTitle} ${refText}`, as: 'div' }}
-              ariaLabel={`${systemUser.integrationTitle} ${refText} ${systemUser.system.systemVendorOrgName} ${badgeContent}`}
+              ariaLabel={`${systemUser.integrationTitle} ${newlyCreatedId === systemUser.id ? t('systemuser_overviewpage.new_system_user') : ''} ${refText} ${systemUser.system.systemVendorOrgName} ${badgeContent}`}
               description={systemUser.system.systemVendorOrgName}
               as={(props) => (
                 <Link


### PR DESCRIPTION
## Description
- Fix so each consent and systemuser list item is only read once, instead of title/description/badge

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved screen reader support for consent list items, ensuring proper announcement of item titles, descriptions, and badges while preventing redundant announcements.
* Enhanced screen reader compatibility for system user list items, including integration details and vendor information, providing complete information to assistive technology users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->