### PR TITLE
Chore/fix broken url til client admin help page

### DIFF
--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -1141,7 +1141,7 @@
     "alert_body_p2": "Access rights you have previously granted in the old Altinn must now be replaced with new authorizations.",
     "alert_body_p3": "Select the \"Users\" menu item, find the desired user, and assign access packages or individual services.",
     "alert_link": "Step-by-step guide for assigning authorizations",
-    "alert_link_href": "https://info.altinn.no/en/help/ny-tilgangsstyring/steg-for-steg-guider/",
+    "alert_link_href": "https://info.altinn.no/en/hjelp/ny-tilgangsstyring/steg-for-steg-guider/",
     "your_content_heading": "Your powers of attorney",
     "shortcut_links_heading": "Other powers of attorney",
     "other_links_heading": "Other",

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -730,7 +730,7 @@
     "no_access_title": "You do not have access to client administration",
     "page_heading": "Client administration for {{name}}",
     "page_description": "Org.no. {{organisationidentifier}} ({{unitType}})",
-    "forwarding_accesses_info": "New! You can now forward accesses that your business has received from others. These can only be given to private individuals. <a href='https://info.altinn.no/en/help/ny-tilgangsstyring/klientadministrasjon/'>Read more about client administration on the help pages.</a>",
+    "forwarding_accesses_info": "New! You can now forward accesses that your business has received from others. These can only be given to private individuals. <a href='https://info.altinn.no/en/hjelp/klientadministrasjon/'>Read more about client administration on the help pages.</a>",
     "clients_tab_title": "Clients",
     "agents_tab_title": "Users",
     "add_agent_button": "Add new user",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -727,7 +727,7 @@
     "no_access_title": "Du har ikke tilgang til klientadministrasjon",
     "page_heading": "Klientadministrasjon for {{name}}",
     "page_description": "org.nr. {{organisationidentifier}} ({{unitType}})",
-    "forwarding_accesses_info": "Nyhet! Du kan nå gi videre fullmakter som din virksomhet har mottatt fra andre. Disse kan kun gis til privatpersoner. <a href='https://info.altinn.no/hjelp/ny-tilgangsstyring/klientadministrasjon/'>Les mer om klientadministrasjon på hjelpesidene.</a>",
+    "forwarding_accesses_info": "Nyhet! Du kan nå gi videre fullmakter som din virksomhet har mottatt fra andre. Disse kan kun gis til privatpersoner. <a href='https://info.altinn.no/hjelp/klientadministrasjon'>Les mer om klientadministrasjon på hjelpesidene.</a>",
     "clients_tab_title": "Klienter",
     "agents_tab_title": "Brukere",
     "add_agent_button": "Legg til ny bruker",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -727,7 +727,7 @@
     "no_access_title": "Du har ikkje tilgang til klientadministrasjon",
     "page_heading": "Klientadministrasjon for {{name}}",
     "page_description": "org.nr. {{organisationidentifier}} ({{unitType}})",
-    "forwarding_accesses_info": "Nyheit! Du kan no gi vidare fullmakter som verksemda di har motteke frå andre. Desse kan du berre gi til privatpersonar. <a href='https://info.altinn.no/nn/hjelp/ny-tilgangsstyring/klientadministrasjon/'>Les meir om klientadministrasjon på hjelpesidene.</a>",
+    "forwarding_accesses_info": "Nyheit! Du kan no gi vidare fullmakter som verksemda di har motteke frå andre. Desse kan du berre gi til privatpersonar. <a href='https://info.altinn.no/nn/hjelp/klientadministrasjon/'>Les meir om klientadministrasjon på hjelpesidene.</a>",
     "clients_tab_title": "Klientar",
     "agents_tab_title": "Brukarar",
     "add_agent_button": "Legg til ny brukar",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes a broken url to the help pages on client admin 

the [former page](https://info.altinn.no/hjelp/ny-tilgangsstyring/klientadministrasjon/) no longer exists. New url is [this](https://info.altinn.no/hjelp/klientadministrasjon/om-klientadministrasjon/) 

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated help documentation links across English, Norwegian Bokmål, and Norwegian Nynorsk localizations to point to refreshed help resources for client administration and access management features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->