### PR TITLE
Hide A2-links in production

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.json
@@ -75,7 +75,7 @@
     "EnableMaskinportenAdministration": true,
     "EnableRoleDeletion": false,
     "RouteChangeReporteeViaAltinn2": false,
-    "HideA2Links": false,
+    "HideA2Links": true,
     "AddAltinn2Account": false
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
With this, we hide all links back to the "old Altinn" (Altinn2) in production. (By flipping the feature flag to true in all environments. In practice, though, this only affects production)

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * A2 Links are now hidden from the application interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->