### PR TITLE
Support pressing enter in text fields in add user dialogs

### DIFF
--- a/src/features/amUI/InstanceDetailPage/AddUserModal.tsx
+++ b/src/features/amUI/InstanceDetailPage/AddUserModal.tsx
@@ -209,7 +209,7 @@ const AddUserModal = ({
             error={personIdentifierError}
             disabled={isSubmitting}
             onKeyDown={(event) => {
-              if (event.key === 'Enter' && !isSubmitting && isFormValid) {
+              if (event.key === 'Enter' && !event.repeat && !isSubmitting && isFormValid) {
                 handleSubmit();
               }
             }}
@@ -226,7 +226,7 @@ const AddUserModal = ({
             error={lastNameError}
             disabled={isSubmitting}
             onKeyDown={(event) => {
-              if (event.key === 'Enter' && !isSubmitting && isFormValid) {
+              if (event.key === 'Enter' && !event.repeat && !isSubmitting && isFormValid) {
                 handleSubmit();
               }
             }}

--- a/src/features/amUI/InstanceDetailPage/AddUserModal.tsx
+++ b/src/features/amUI/InstanceDetailPage/AddUserModal.tsx
@@ -208,6 +208,11 @@ const AddUserModal = ({
             }
             error={personIdentifierError}
             disabled={isSubmitting}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' && !isSubmitting && isFormValid) {
+                handleSubmit();
+              }
+            }}
           />
           <DsTextfield
             className={classes.textField}
@@ -220,6 +225,11 @@ const AddUserModal = ({
             }
             error={lastNameError}
             disabled={isSubmitting}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' && !isSubmitting && isFormValid) {
+                handleSubmit();
+              }
+            }}
           />
         </div>
 

--- a/src/features/amUI/users/NewUserModal/NewOrgContent.tsx
+++ b/src/features/amUI/users/NewUserModal/NewOrgContent.tsx
@@ -76,7 +76,7 @@ export const NewOrgContent = ({
         size='sm'
         onChange={(e) => setOrgNumber((e.target as HTMLInputElement).value.replace(/ /g, ''))}
         onKeyDown={(event) => {
-          if (event.key === 'Enter' && !isAddButtonDisabled && orgData && addOrg) {
+          if (event.key === 'Enter' && !event.repeat && !isAddButtonDisabled && orgData && addOrg) {
             addOrg(orgData);
           }
         }}

--- a/src/features/amUI/users/NewUserModal/NewOrgContent.tsx
+++ b/src/features/amUI/users/NewUserModal/NewOrgContent.tsx
@@ -39,6 +39,8 @@ export const NewOrgContent = ({
 
   const isOwnOrg = !!ownOrgNumber && orgNumber.length === 9 && orgNumber === ownOrgNumber;
   const isError = isGetOrgError || !!errorDetails;
+  const isAddButtonDisabled =
+    isOwnOrg || isGetOrgError || isLoading || !orgData || orgData.orgNumber !== orgNumber;
 
   return (
     <div className={classes.newOrgContent}>
@@ -73,6 +75,11 @@ export const NewOrgContent = ({
         label={t('common.org_number')}
         size='sm'
         onChange={(e) => setOrgNumber((e.target as HTMLInputElement).value.replace(/ /g, ''))}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' && !isAddButtonDisabled && orgData && addOrg) {
+            addOrg(orgData);
+          }
+        }}
       />
       <div aria-live='polite'>
         {!isGetOrgError && !orgDataLoading && orgData && orgData.orgNumber === orgNumber && (
@@ -98,9 +105,7 @@ export const NewOrgContent = ({
 
       <div className={classes.validationButton}>
         <DsButton
-          disabled={
-            isOwnOrg || isGetOrgError || isLoading || !orgData || orgData.orgNumber !== orgNumber
-          }
+          disabled={isAddButtonDisabled}
           onClick={() => addOrg && orgData && addOrg(orgData)}
         >
           <span className={classes.addButton}>

--- a/src/features/amUI/users/NewUserModal/NewPersonContent.tsx
+++ b/src/features/amUI/users/NewUserModal/NewPersonContent.tsx
@@ -72,7 +72,7 @@ export const NewPersonContent = ({ errorDetails, addPerson, isLoading }: NewPers
           setPersonIdentifierFormatErrorKey(getPersonIdentifierErrorKey(personIdentifier));
         }}
         onKeyDown={(event) => {
-          if (event.key === 'Enter' && !isAddPersonButtonDisabled) {
+          if (event.key === 'Enter' && !event.repeat && !isAddPersonButtonDisabled) {
             navigateIfValidPerson();
           }
         }}
@@ -89,7 +89,7 @@ export const NewPersonContent = ({ errorDetails, addPerson, isLoading }: NewPers
           setLastNameFormatError(error);
         }}
         onKeyDown={(event) => {
-          if (event.key === 'Enter' && !isAddPersonButtonDisabled) {
+          if (event.key === 'Enter' && !event.repeat && !isAddPersonButtonDisabled) {
             navigateIfValidPerson();
           }
         }}

--- a/src/features/amUI/users/NewUserModal/NewPersonContent.tsx
+++ b/src/features/amUI/users/NewUserModal/NewPersonContent.tsx
@@ -38,6 +38,11 @@ export const NewPersonContent = ({ errorDetails, addPerson, isLoading }: NewPers
   }
 
   const isValidLastnameFormat = () => lastName.trim().length >= 1;
+  const isAddPersonButtonDisabled =
+    personIdentifier.trim().length === 0 ||
+    getPersonIdentifierErrorKey(personIdentifier) !== null ||
+    !isValidLastnameFormat() ||
+    isLoading;
 
   return (
     <div className={classes.newPersonContent}>
@@ -66,6 +71,11 @@ export const NewPersonContent = ({ errorDetails, addPerson, isLoading }: NewPers
         onBlur={() => {
           setPersonIdentifierFormatErrorKey(getPersonIdentifierErrorKey(personIdentifier));
         }}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' && !isAddPersonButtonDisabled) {
+            navigateIfValidPerson();
+          }
+        }}
       />
       <DsTextfield
         className={classes.textField}
@@ -78,15 +88,15 @@ export const NewPersonContent = ({ errorDetails, addPerson, isLoading }: NewPers
           const error = isValidLastnameFormat() ? '' : t('new_user_modal.last_name_format_error');
           setLastNameFormatError(error);
         }}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' && !isAddPersonButtonDisabled) {
+            navigateIfValidPerson();
+          }
+        }}
       />
       <div className={classes.validationButton}>
         <Button
-          disabled={
-            personIdentifier.trim().length === 0 ||
-            getPersonIdentifierErrorKey(personIdentifier) !== null ||
-            !isValidLastnameFormat() ||
-            isLoading
-          }
+          disabled={isAddPersonButtonDisabled}
           loading={isLoading}
           onClick={navigateIfValidPerson}
         >


### PR DESCRIPTION
## Description
- After typing last name or organization number, users should be able to submit by pressing enter while focus is in the text field (instead of clicking the primary button)

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/2973

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **Enter key** support in user and organization management modals to streamline form submission. Users can now press Enter in relevant text fields to trigger the same actions as the submit buttons, as long as the form is valid and the modal isn’t busy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->