### PR TITLE
Enable role deletion in prod

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.Prod.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.Prod.json
@@ -36,7 +36,7 @@
     "EnableAddSelfToSystemuser": true,
     "EnableDialogportenDialogLookup": true,
     "EnableMaskinportenAdministration": true,
-    "EnableRoleDeletion": false,
+    "EnableRoleDeletion": true,
     "UseConnectionsForAgentSystemuser": true,
     "AddAltinn2Account": false
   }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.json
@@ -20,7 +20,10 @@
   "GeneralSettings": {
     "FrontendBaseUrl": "http://localhost:5101",
     "Hostname": "localhost",
-    "AllowedRedirectDomains": ["altinn.no", "altinn.cloud"]
+    "AllowedRedirectDomains": [
+      "altinn.no",
+      "altinn.cloud"
+    ]
   },
   "MockSettings": {
     "PDP": false,
@@ -73,7 +76,7 @@
     "EnableDialogportenDialogLookup": false,
     "UseConnectionsForAgentSystemuser": false,
     "EnableMaskinportenAdministration": true,
-    "EnableRoleDeletion": false,
+    "EnableRoleDeletion": true,
     "RouteChangeReporteeViaAltinn2": false,
     "HideA2Links": true,
     "AddAltinn2Account": false

--- a/src/features/amUI/common/DeleteUserModal/DeleteUserModal.stories.tsx
+++ b/src/features/amUI/common/DeleteUserModal/DeleteUserModal.stories.tsx
@@ -13,7 +13,6 @@ import {
   DeletionTarget,
   ER_ROLE_REASON,
   GUARDIANSHIP_ROLE_REASON,
-  OLD_ALTINN_REASON,
   type DeletionStatus,
   type NonDeletableReason,
 } from './deletionModalUtils';
@@ -26,7 +25,6 @@ type DeleteUserModalStoryArgs = {
 };
 
 const allReasons: NonDeletableReason[] = [
-  OLD_ALTINN_REASON,
   ER_ROLE_REASON,
   AGENT_ROLE_REASON,
   GUARDIANSHIP_ROLE_REASON,

--- a/src/features/amUI/common/DeleteUserModal/DeleteUserModalContent.tsx
+++ b/src/features/amUI/common/DeleteUserModal/DeleteUserModalContent.tsx
@@ -13,7 +13,6 @@ import { Trans, useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { Link, useNavigate } from 'react-router';
 
-import { getRedirectToA2UsersListSectionUrl } from '@/resources/utils';
 import { amUIPath } from '@/routes/paths';
 import { accessPackageApi } from '@/rtk/features/accessPackageApi';
 import { useRemoveRightHolderMutation } from '@/rtk/features/connectionApi';
@@ -37,7 +36,6 @@ import {
   GUARDIANSHIP_ROLE_REASON,
   getDeleteUserDialogModelFromStatus,
   ER_ROLE_REASON,
-  OLD_ALTINN_REASON,
   type NonDeletableReason,
 } from './deletionModalUtils';
 
@@ -52,7 +50,6 @@ const srmLink =
 const guardianshipInfoLink = 'https://www.vergemal.no/';
 
 const nonDeletableReasonKeys: Record<NonDeletableReason, string> = {
-  [OLD_ALTINN_REASON]: 'delete_user.non_deletable_reason_old_altinn',
   [ER_ROLE_REASON]: 'delete_user.non_deletable_reason_er_roles',
   [AGENT_ROLE_REASON]: 'delete_user.non_deletable_reason_agent_role',
   [GUARDIANSHIP_ROLE_REASON]: 'delete_user.non_deletable_reason_guardianship',
@@ -97,7 +94,6 @@ export const DeleteUserModalContent = ({
     () => getDeleteUserDialogModelFromStatus({ status, nonDeletableReasons }),
     [nonDeletableReasons, status],
   );
-  const a2ProfileLink = getRedirectToA2UsersListSectionUrl(9);
 
   const formattedToPartyName = formatDisplayName({
     fullName: toParty?.name || '',
@@ -164,13 +160,6 @@ export const DeleteUserModalContent = ({
     erLink: (
       <Link
         to={srmLink}
-        target='_blank'
-        rel='noopener noreferrer'
-      ></Link>
-    ),
-    a2Link: (
-      <Link
-        to={a2ProfileLink}
         target='_blank'
         rel='noopener noreferrer'
       ></Link>

--- a/src/features/amUI/common/DeleteUserModal/deletionModalUtils.test.ts
+++ b/src/features/amUI/common/DeleteUserModal/deletionModalUtils.test.ts
@@ -10,7 +10,6 @@ import {
   getNonDeletableReasons,
   getDeletionStatus,
   getTextKeysForDeletionStatus,
-  OLD_ALTINN_REASON,
   DeletionTarget,
   DeletionLevel,
   RIGHTHOLDER_ROLE,
@@ -19,11 +18,7 @@ import {
 } from './deletionModalUtils';
 import { RolePermission } from '@/rtk/features/roleApi';
 import { Entity } from '@/dataObjects/dtos/Common';
-import {
-  A2_PROVIDER_CODE,
-  CRA_PROVIDER_CODE,
-  ECC_PROVIDER_CODE,
-} from '../UserRoles/useRoleMetadata';
+import { CRA_PROVIDER_CODE, ECC_PROVIDER_CODE } from '../UserRoles/useRoleMetadata';
 
 type rolePermissionSetting = {
   code: string;
@@ -246,13 +241,6 @@ describe('getNonDeletableReasons', () => {
     expect(getNonDeletableReasons(rolePermissions)).toEqual([]);
   });
 
-  it('returns old Altinn reason when at least one role has the old Altinn provider', () => {
-    const rolePermissions = mockRolePermissions([
-      { code: RIGHTHOLDER_ROLE, via: [null], providerCode: A2_PROVIDER_CODE },
-    ]);
-    expect(getNonDeletableReasons(rolePermissions)).toEqual([OLD_ALTINN_REASON]);
-  });
-
   it('does not return old Altinn reason when access is inherited without old Altinn provider', () => {
     const rolePermissions = mockRolePermissions([{ code: RIGHTHOLDER_ROLE, via: ['via-org'] }]);
     expect(getNonDeletableReasons(rolePermissions)).toEqual([]);
@@ -279,13 +267,11 @@ describe('getNonDeletableReasons', () => {
 
   it('returns all matching reasons in stable order', () => {
     const rolePermissions = mockRolePermissions([
-      { code: RIGHTHOLDER_ROLE, via: ['via-org'], providerCode: A2_PROVIDER_CODE },
       { code: 'dagl', via: ['via-org'], providerCode: ECC_PROVIDER_CODE },
       { code: AGENT_ROLE, via: ['via-org'] },
       { code: 'role-code', via: ['via-org'], providerCode: CRA_PROVIDER_CODE },
     ]);
     expect(getNonDeletableReasons(rolePermissions)).toEqual([
-      OLD_ALTINN_REASON,
       ER_ROLE_REASON,
       AGENT_ROLE_REASON,
       GUARDIANSHIP_ROLE_REASON,
@@ -413,7 +399,7 @@ describe('getDeleteUserDialogModel', () => {
 
   it('returns partially deletable state with reasons and partial confirmation key', () => {
     const rolePermissions = mockRolePermissions([
-      { code: RIGHTHOLDER_ROLE, via: [null, 'via-org'], providerCode: A2_PROVIDER_CODE },
+      { code: RIGHTHOLDER_ROLE, via: [null, 'via-org'] },
       { code: AGENT_ROLE, via: ['via-org'] },
       { code: 'dagl', via: ['via-org'], providerCode: ECC_PROVIDER_CODE },
     ]);
@@ -427,11 +413,7 @@ describe('getDeleteUserDialogModel', () => {
     expect(model.partialConfirmationMessageKey).toBe(
       'delete_user.yourself_partial_confirmation_message',
     );
-    expect(model.nonDeletableReasons).toEqual([
-      OLD_ALTINN_REASON,
-      ER_ROLE_REASON,
-      AGENT_ROLE_REASON,
-    ]);
+    expect(model.nonDeletableReasons).toEqual([ER_ROLE_REASON, AGENT_ROLE_REASON]);
     expect(model.textKeys.headingKey).toBe('delete_user.yourself_limited_deletion_heading');
   });
 

--- a/src/features/amUI/common/DeleteUserModal/deletionModalUtils.test.ts
+++ b/src/features/amUI/common/DeleteUserModal/deletionModalUtils.test.ts
@@ -241,7 +241,7 @@ describe('getNonDeletableReasons', () => {
     expect(getNonDeletableReasons(rolePermissions)).toEqual([]);
   });
 
-  it('does not return old Altinn reason when access is inherited without old Altinn provider', () => {
+  it('returns no reasons when all access is inherited', () => {
     const rolePermissions = mockRolePermissions([{ code: RIGHTHOLDER_ROLE, via: ['via-org'] }]);
     expect(getNonDeletableReasons(rolePermissions)).toEqual([]);
   });

--- a/src/features/amUI/common/DeleteUserModal/deletionModalUtils.ts
+++ b/src/features/amUI/common/DeleteUserModal/deletionModalUtils.ts
@@ -1,22 +1,15 @@
 import { RolePermission } from '@/rtk/features/roleApi';
-import {
-  A2_PROVIDER_CODE,
-  CRA_PROVIDER_CODE,
-  ECC_PROVIDER_CODE,
-} from '../UserRoles/useRoleMetadata';
-import { enableRoleDeletion } from '@/resources/utils/featureFlagUtils';
+import { CRA_PROVIDER_CODE, ECC_PROVIDER_CODE } from '../UserRoles/useRoleMetadata';
 
 export const RIGHTHOLDER_ROLE = 'rettighetshaver';
 export const AGENT_ROLE = 'agent';
 
 export const ER_ROLE_REASON = 'er_roles';
-export const OLD_ALTINN_REASON = 'old_altinn';
 export const AGENT_ROLE_REASON = 'agent_role';
 export const GUARDIANSHIP_ROLE_REASON = 'guardianship_role';
 
 export type NonDeletableReason =
   | typeof ER_ROLE_REASON
-  | typeof OLD_ALTINN_REASON
   | typeof AGENT_ROLE_REASON
   | typeof GUARDIANSHIP_ROLE_REASON;
 
@@ -80,10 +73,6 @@ export const getNonDeletableReasons = (
     return [];
   }
 
-  const hasOldAltinnAccess = rolePermissions.some(
-    (rolePermission) => rolePermission?.role?.provider?.code === A2_PROVIDER_CODE,
-  );
-
   const hasERRoles = rolePermissions.some(
     (rolePermission) => rolePermission?.role?.provider?.code === ECC_PROVIDER_CODE,
   );
@@ -97,9 +86,6 @@ export const getNonDeletableReasons = (
   );
 
   const reasons: NonDeletableReason[] = [];
-  if (hasOldAltinnAccess && !enableRoleDeletion()) {
-    reasons.push(OLD_ALTINN_REASON);
-  }
   if (hasERRoles) {
     reasons.push(ER_ROLE_REASON);
   }

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -473,7 +473,6 @@
     "user_non_deletable_reasons_intro": "{{to_name}} has authorizations that cannot be deleted here",
     "yourself_non_deletable_reasons_intro": "You have authorizations that cannot be deleted here",
     "reportee_non_deletable_reasons_intro": "{{to_name}} has authorizations for {{from_name}} that cannot be deleted here",
-    "non_deletable_reason_old_altinn": "Authorizations granted in the <a2Link>old Altinn solution</a2Link> must be deleted there.",
     "non_deletable_reason_er_roles": "Authorizations that follow roles in the Central Coordinating Register for Legal Entities must be changed via <erLink>the Coordinated Register Notification</erLink>.",
     "non_deletable_reason_agent_role": "Client accesses can be managed in <agentLink>{{linkText}}</agentLink>.",
     "non_deletable_reason_guardianship": "Authorizations granted through guardianship from <guardianshipLink>the Norwegian Civil Affairs Authority</guardianshipLink>.",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -470,7 +470,6 @@
     "user_non_deletable_reasons_intro": "{{to_name}} har fullmakter som ikke kan slettes her",
     "yourself_non_deletable_reasons_intro": "Du har fullmakter som ikke kan slettes her",
     "reportee_non_deletable_reasons_intro": "{{to_name}} har fullmakter for {{from_name}} som ikke kan slettes her",
-    "non_deletable_reason_old_altinn": "Fullmakter gitt i <a2Link>den gamle Altinn-løsningen</a2Link> må slettes der.",
     "non_deletable_reason_er_roles": "Fullmakter som følger roller i Enhetsregisteret må endres via <erLink>Samordnet registermelding</erLink>.",
     "non_deletable_reason_agent_role": "Klienttilganger kan administreres på <agentLink>{{linkText}}</agentLink>.",
     "non_deletable_reason_guardianship": "Fullmakter gitt gjennom vergemål fra <guardianshipLink>Sivilrettsforvaltningen</guardianshipLink>.",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -470,7 +470,6 @@
     "user_non_deletable_reasons_intro": "{{to_name}} har fullmakter som ikkje kan slettast her",
     "yourself_non_deletable_reasons_intro": "Du har fullmakter som ikkje kan slettast her",
     "reportee_non_deletable_reasons_intro": "{{to_name}} har fullmakter for {{from_name}} som ikkje kan slettast her",
-    "non_deletable_reason_old_altinn": "Fullmakter gitt i <a2Link>den gamle Altinn-løysinga</a2Link> må slettast der.",
     "non_deletable_reason_er_roles": "Fullmakter som følgjer roller i Einingsregisteret må endrast via <erLink>Samordna registermelding</erLink>.",
     "non_deletable_reason_agent_role": "Klienttilgangar kan administrerast i <agentLink>{{linkText}}</agentLink>.",
     "non_deletable_reason_guardianship": "Fullmakter gitt gjennom verjemål frå <guardianshipLink>Sivilrettsforvaltninga</guardianshipLink>.",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<img width="1496" height="768" alt="image" src="https://github.com/user-attachments/assets/fe994af4-8199-4444-8470-3d95aacbf65b" />

## Description
<!--- Describe your changes in detail -->
This PR does two things:
1. Enables role deletion in prod (and every other environment that wasn't already enabled)
2. Removes block that stops a user from being deleted if they have A2 roles. (Now that A2 roles can be deleted in A3, the user can also be deleted as a whole)

Note: The enabling of the feature flag already disables the code in point nr 2, so the change is essentially just removing unused code.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Role deletion feature is now enabled.

* **Improvements**
  * Removed old Altinn-related messaging from the user deletion workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->