### PR TITLE
Redirect back to /received-from, if party is deleted from /received-from page

### DIFF
--- a/src/features/amUI/common/DeleteUserModal/DeleteUserModalContent.tsx
+++ b/src/features/amUI/common/DeleteUserModal/DeleteUserModalContent.tsx
@@ -11,7 +11,7 @@ import { TrashIcon, XMarkOctagonFillIcon } from '@navikt/aksel-icons';
 import { useEffect, useMemo, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
-import { Link, useNavigate } from 'react-router';
+import { Link, useLocation, useNavigate } from 'react-router';
 
 import { getRedirectToA2UsersListSectionUrl } from '@/resources/utils';
 import { amUIPath } from '@/routes/paths';
@@ -72,6 +72,7 @@ export const DeleteUserModalContent = ({
   const { t } = useTranslation();
   const navigate = useNavigate();
   const dispatch = useDispatch();
+  const { pathname } = useLocation();
   const [isSuccess, setIsSuccess] = useState(false);
   const [dialogVisible, setDialogVisible] = useState(false);
 
@@ -146,7 +147,11 @@ export const DeleteUserModalContent = ({
 
   const onDeleteComplete = () => {
     if (shouldNavigateOnDeleteComplete) {
-      navigate(`/${amUIPath.Users}`);
+      if (pathname?.includes(`/${amUIPath.Reportees}`)) {
+        navigate(`/${amUIPath.Reportees}`);
+      } else {
+        navigate(`/${amUIPath.Users}`);
+      }
       return;
     }
 


### PR DESCRIPTION
## Description
- Redirect back to /received-from, if party is deleted from /received-from page, instead of always redirecting to /users page when party is deleted

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/1715

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed navigation behavior after deleting a user to correctly return to the appropriate section based on where the deletion was initiated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->