### PR TITLE
Display migrated correspondances if they are not marked as deprecated

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/ResourceService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/ResourceService.cs
@@ -126,7 +126,6 @@ namespace Altinn.AccessManagement.UI.Core.Services
         private static bool IsExpiredResource(ServiceResource resource)
         {
             return resource.ResourceType == ResourceType.MigratedApp ||
-                (resource.Identifier?.Contains("migratedcorrespondence", StringComparison.OrdinalIgnoreCase) == true) ||
                 resource.Status?.ToLower() == "deprecated";
         }
 

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/ResourceRegistry/resources.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/ResourceRegistry/resources.json
@@ -1286,6 +1286,7 @@
       "nn": "Arkivert teneste - MigratedCorrespondence"
     },
     "identifier": "migratedcorrespondence-test-resource",
+    "status": "Deprecated",
     "visible": true,
     "delegable": true,
     "description": {
@@ -1304,6 +1305,44 @@
       {
         "id": "urn:altinn:resource",
         "value": "migratedcorrespondence-test-resource"
+      }
+    ],
+    "hasCompetentAuthority": {
+      "orgcode": "TTD",
+      "organization": "974760746",
+      "name": {
+        "en": "Testdepartementet",
+        "nb": "Testdepartementet",
+        "nn": "Testdepartementet"
+      }
+    }
+  },
+  {
+    "title": {
+      "en": "Active Service - MigratedCorrespondence",
+      "nb": "Aktiv tjeneste - MigratedCorrespondence",
+      "nn": "Aktiv teneste - MigratedCorrespondence"
+    },
+    "identifier": "migratedcorrespondence-active-resource",
+    "status": "Active",
+    "visible": true,
+    "delegable": true,
+    "description": {
+      "en": "An active correspondence resource",
+      "nb": "En aktiv korrespondanseressurs",
+      "nn": "Ein aktiv korrespondanseressurs"
+    },
+    "rightDescription": {
+      "en": "Grants access to correspondence data",
+      "nb": "Gir tilgang til korrespondansedata",
+      "nn": "Gir tilgang til korrespondansedata"
+    },
+    "resourceType": "GenericAccessResource",
+    "resourceReferences": [],
+    "authorizationReference": [
+      {
+        "id": "urn:altinn:resource",
+        "value": "migratedcorrespondence-active-resource"
       }
     ],
     "hasCompetentAuthority": {

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/ResourceRegistry/resourcesfe.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/ResourceRegistry/resourcesfe.json
@@ -850,6 +850,7 @@
   {
     "title": "Arkivert tjeneste - MigratedCorrespondence",
     "identifier": "migratedcorrespondence-test-resource",
+    "status": "Deprecated",
     "visible": true,
     "delegable": true,
     "description": "En arkivert korrespondanseressurs",
@@ -860,6 +861,27 @@
       {
         "id": "urn:altinn:resource",
         "value": "migratedcorrespondence-test-resource"
+      }
+    ],
+    "resourceOwnerName": "Testdepartementet",
+    "resourceOwnerOrgcode": "TTD",
+    "resourceOwnerOrgNumber": "974760746",
+    "keywords": []
+  },
+  {
+    "title": "Aktiv tjeneste - MigratedCorrespondence",
+    "identifier": "migratedcorrespondence-active-resource",
+    "status": "Active",
+    "visible": true,
+    "delegable": true,
+    "description": "En aktiv korrespondanseressurs",
+    "rightDescription": "Gir tilgang til korrespondansedata",
+    "resourceType": "GenericAccessResource",
+    "resourceReferences": [],
+    "authorizationReference": [
+      {
+        "id": "urn:altinn:resource",
+        "value": "migratedcorrespondence-active-resource"
       }
     ],
     "resourceOwnerName": "Testdepartementet",

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/ResourceControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/ResourceControllerTest.cs
@@ -349,7 +349,8 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             List<ServiceResourceFE> allExpectedResources = TestDataUtil.GetSingleRightsResources();
 
             int totalPages = (int)Math.Ceiling((double)allExpectedResources.Count / resultsPerPage);
-            int resultsFinalPage = allExpectedResources.Count % resultsPerPage;
+            int bleedoverLastPage = allExpectedResources.Count % resultsPerPage;
+            int resultsFinalPage = bleedoverLastPage == 0 ? resultsPerPage : bleedoverLastPage;
 
             List<PaginatedList<ServiceResourceFE>> allActualPages = new List<PaginatedList<ServiceResourceFE>>();
 

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/ResourceControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/ResourceControllerTest.cs
@@ -550,7 +550,8 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
 
         /// <summary>
         ///     Test case: PaginatedSearch with includeExpired not set (defaults to false)
-        ///     Expected: Archived resources (MigratedApp type and migratedcorrespondence identifier) are excluded from results
+        ///     Expected: Archived resources (MigratedApp type and deprecated status) are excluded from results.
+        ///     MigratedCorrespondence resources that are not deprecated should be included.
         /// </summary>
         [Fact]
         public async Task GetSingleRightsSearch_IncludeExpiredNotSet_ExcludesArchivedResources()
@@ -570,12 +571,14 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             PaginatedList<ServiceResourceFE> actualResult = JsonSerializer.Deserialize<PaginatedList<ServiceResourceFE>>(await response.Content.ReadAsStringAsync(), options);
             Assert.Equal(expectedResources.Count, actualResult.NumEntriesTotal);
             Assert.DoesNotContain(actualResult.PageList, r => r.ResourceType == ResourceType.MigratedApp);
-            Assert.DoesNotContain(actualResult.PageList, r => r.Identifier.Contains("migratedcorrespondence", StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotContain(actualResult.PageList, r => r.Identifier == "migratedcorrespondence-test-resource");
+            Assert.Contains(actualResult.PageList, r => r.Identifier == "migratedcorrespondence-active-resource");
         }
 
         /// <summary>
         ///     Test case: PaginatedSearch with includeExpired=true
-        ///     Expected: Archived resources (MigratedApp type and migratedcorrespondence identifier) are included in results
+        ///     Expected: Archived resources (MigratedApp type and deprecated status) are included in results.
+        ///     MigratedCorrespondence resources with deprecated status should be included.
         /// </summary>
         [Fact]
         public async Task GetSingleRightsSearch_IncludeExpiredTrue_IncludesExpiredResources()
@@ -595,7 +598,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             PaginatedList<ServiceResourceFE> actualResult = JsonSerializer.Deserialize<PaginatedList<ServiceResourceFE>>(await response.Content.ReadAsStringAsync(), options);
             Assert.Equal(expectedResources.Count, actualResult.NumEntriesTotal);
             Assert.Contains(actualResult.PageList, r => r.ResourceType == ResourceType.MigratedApp);
-            Assert.Contains(actualResult.PageList, r => r.Identifier.Contains("migratedcorrespondence", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(actualResult.PageList, r => r.Identifier == "migratedcorrespondence-test-resource");
         }
 
         private static IHttpContextAccessor GetHttpContextAccessorMock(string partytype, string id)

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Utils/TestDataUtil.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Utils/TestDataUtil.cs
@@ -83,7 +83,7 @@ namespace Altinn.AccessManagement.UI.Tests.Utils
                 r.ResourceType != ResourceType.MaskinportenSchema &&
                 (includeExpired ||
                     (r.ResourceType != ResourceType.MigratedApp &&
-                     !(r.Identifier?.IndexOf("migratedcorrespondence", StringComparison.OrdinalIgnoreCase) >= 0) && r.Status?.ToLower() != "deprecated")));
+                     r.Status?.ToLower() != "deprecated")));
         }
 
         /// <summary>

--- a/src/features/amUI/common/ResourceList/ResourceList.test.tsx
+++ b/src/features/amUI/common/ResourceList/ResourceList.test.tsx
@@ -130,10 +130,27 @@ describe('ResourceList', () => {
     expect(screen.getByText('resource_list.expired_badge')).toBeInTheDocument();
   });
 
-  it('renders the expired badge for a resource whose identifier includes migratedcorrespondence', () => {
+  it('does not render the expired badge for a migratedcorrespondence resource that is not deprecated', () => {
+    const nonExpiredResource = {
+      ...createResource({ name: 'Migrated Correspondence Service' }),
+      identifier: 'some-migratedcorrespondence-service',
+    } as ResourceListItemResource;
+
+    render(
+      <ResourceList
+        resources={[nonExpiredResource]}
+        enableSearch={false}
+      />,
+    );
+
+    expect(screen.queryByText('resource_list.expired_badge')).not.toBeInTheDocument();
+  });
+
+  it('renders the expired badge for a migratedcorrespondence resource with deprecated status', () => {
     const expiredResource = {
       ...createResource({ name: 'Migrated Correspondence Service' }),
       identifier: 'some-migratedcorrespondence-service',
+      status: 'deprecated',
     } as ResourceListItemResource;
 
     render(

--- a/src/features/amUI/common/ResourceList/ResourceList.test.tsx
+++ b/src/features/amUI/common/ResourceList/ResourceList.test.tsx
@@ -150,7 +150,7 @@ describe('ResourceList', () => {
     const expiredResource = {
       ...createResource({ name: 'Migrated Correspondence Service' }),
       identifier: 'some-migratedcorrespondence-service',
-      status: 'deprecated',
+      status: 'Deprecated',
     } as ResourceListItemResource;
 
     render(

--- a/src/features/amUI/common/ResourceList/utils.tsx
+++ b/src/features/amUI/common/ResourceList/utils.tsx
@@ -80,12 +80,9 @@ export const extractResourceId = (resource: ResourceListItemResource): string | 
 
 export const isExpiredResource = (resource: ResourceListItemResource): boolean => {
   const resourceType = 'resourceType' in resource ? resource.resourceType : undefined;
-  const identifier = 'identifier' in resource ? resource.identifier : undefined;
   const status = 'status' in resource ? resource.status : undefined;
   return (
     resourceType === 'MigratedApp' ||
-    (typeof identifier === 'string' &&
-      identifier.toLowerCase().includes('migratedcorrespondence')) ||
-    (typeof status === 'string' && status?.toLowerCase() === 'expired')
+    (typeof status === 'string' && status?.toLowerCase() === 'deprecated')
   );
 };

--- a/src/features/amUI/common/ResourceList/utils.tsx
+++ b/src/features/amUI/common/ResourceList/utils.tsx
@@ -83,6 +83,6 @@ export const isExpiredResource = (resource: ResourceListItemResource): boolean =
   const status = 'status' in resource ? resource.status : undefined;
   return (
     resourceType === 'MigratedApp' ||
-    (typeof status === 'string' && status?.toLowerCase() === 'deprecated')
+    (typeof status === 'string' && status.toLowerCase() === 'deprecated')
   );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<img width="1437" height="801" alt="image" src="https://github.com/user-attachments/assets/1343aa6d-a1af-41ad-8882-a1f1d87dd62a" />

## Description
<!--- Describe your changes in detail -->

Before, we had three cases that marked a resource as "Expired":
1. The resource is a migrated app
2. The resource is a migrated correspondance
3. The resource has status "Deprecated" in Resource Registry

Now, all migrated correspondances have automatically been set to status "Deprecated" and service owners are encouraged to change this if they do not agree. Thus, we want to remove case nr 2 so that service owners are free to choose to mark even old correspondace services as active if they want.

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/3604

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed resource expiration logic: Resources are now correctly identified as expired based on their status field (when "deprecated") or resource type, rather than identifier patterns. This change ensures active migrated resources appear correctly in search results and enables more accurate filtering when excluding expired resources from the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->