### PR TITLE
Forbedringer for glemt passord

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/AccountLink/Altinn2ForgotPasswordRequest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/AccountLink/Altinn2ForgotPasswordRequest.cs
@@ -12,5 +12,10 @@ namespace Altinn.AccessManagement.UI.Core.Models.SelfIdentifiedUser
         /// </summary>
         [Required]
         public string UserName { get; set; }
+
+        /// <summary>
+        /// The requested email language
+        /// </summary>
+        public string Language { get; set; }
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/SelfIdentifiedUserClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/SelfIdentifiedUserClient.cs
@@ -55,7 +55,8 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
         public async Task<Altinn2ForgotPasswordResponse> SendForgotPasswordEmail(Altinn2ForgotPasswordRequest request, CancellationToken cancellationToken)
         {
             string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
-            string endpointUrl = "enduser/selfidentified/link-request";
+            string languageQueryParam = string.IsNullOrEmpty(request.Language) ? string.Empty : $"?lang={request.Language}";
+            string endpointUrl = $"enduser/selfidentified/link-request{languageQueryParam}";
 
             var content = JsonContent.Create(request);
             HttpResponseMessage response = await _httpClient.PostAsync(token, endpointUrl, content, cancellationToken);

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/SelfIdentifiedUserClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/SelfIdentifiedUserClient.cs
@@ -55,8 +55,11 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
         public async Task<Altinn2ForgotPasswordResponse> SendForgotPasswordEmail(Altinn2ForgotPasswordRequest request, CancellationToken cancellationToken)
         {
             string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
-            string languageQueryParam = string.IsNullOrEmpty(request.Language) ? string.Empty : $"?lang={request.Language}";
-            string endpointUrl = $"enduser/selfidentified/link-request{languageQueryParam}";
+            string endpointUrl = "enduser/selfidentified/link-request";
+            if (!string.IsNullOrWhiteSpace(request.Language))
+            {
+                endpointUrl = $"{endpointUrl}?lang={Uri.EscapeDataString(request.Language)}";
+            }
 
             var content = JsonContent.Create(request);
             HttpResponseMessage response = await _httpClient.PostAsync(token, endpointUrl, content, cancellationToken);

--- a/src/features/amUI/altinn2Account/AddAltinn2AccountPage.tsx
+++ b/src/features/amUI/altinn2Account/AddAltinn2AccountPage.tsx
@@ -22,7 +22,7 @@ import { PageLayoutWrapper } from '../common/PageLayoutWrapper';
 import { Altinn2AccountForm } from './Altinn2AccountForm';
 
 export const AddAltinn2AccountPage = () => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const [searchParams] = useSearchParams();
   const token = searchParams.get('token') ?? '';
 
@@ -60,7 +60,8 @@ export const AddAltinn2AccountPage = () => {
   };
 
   const onSendForgotPasswordEmail = (userName: string) => {
-    sendForgotPasswordEmail({ userName })
+    const lang = i18n.language as 'no_nb' | 'no_nn' | 'en';
+    sendForgotPasswordEmail({ userName, lang })
       .unwrap()
       .then((payload) => {
         if (payload.maskedEmail) {

--- a/src/features/amUI/altinn2Account/AddAltinn2AccountPage.tsx
+++ b/src/features/amUI/altinn2Account/AddAltinn2AccountPage.tsx
@@ -96,9 +96,9 @@ export const AddAltinn2AccountPage = () => {
 
   const getAddUserFromTokenErrorMessage = () => {
     if ((addUserFromTokenError as { status: number }).status === 401) {
-      return 'Invalid or expired link token.';
+      return t('add_altinn2_account_page.add_account_from_token_invalid_token');
     } else if ((addUserFromTokenError as { status: number }).status === 403) {
-      return 'Link token does not belong to the authenticated user.';
+      return t('add_altinn2_account_page.add_account_from_token_not_from_caller');
     }
     return t('add_altinn2_account_page.add_account_from_token_error');
   };

--- a/src/features/amUI/altinn2Account/AddAltinn2AccountPage.tsx
+++ b/src/features/amUI/altinn2Account/AddAltinn2AccountPage.tsx
@@ -93,6 +93,15 @@ export const AddAltinn2AccountPage = () => {
     }
   }, [reportee, token]);
 
+  const getAddUserFromTokenErrorMessage = () => {
+    if ((addUserFromTokenError as { status: number }).status === 401) {
+      return 'Invalid or expired link token.';
+    } else if ((addUserFromTokenError as { status: number }).status === 403) {
+      return 'Link token does not belong to the authenticated user.';
+    }
+    return t('add_altinn2_account_page.add_account_from_token_error');
+  };
+
   const step1Component = (
     <DsDialog.Block className={classes.addAltinn2Account}>
       <DsHeading level={1}>{t('add_altinn2_account_page.add_account_heading')}</DsHeading>
@@ -181,9 +190,7 @@ export const AddAltinn2AccountPage = () => {
         />
       )}
       {addUserFromTokenError && (
-        <DsAlert data-color='danger'>
-          {t('add_altinn2_account_page.add_account_from_token_error')}
-        </DsAlert>
+        <DsAlert data-color='danger'>{getAddUserFromTokenErrorMessage()}</DsAlert>
       )}
       <DsDialog
         ref={modalRef}

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -1241,6 +1241,8 @@
     "no_email_for_username": "We found no email for this username. Check that the username is correct.",
     "send_link": "Send link",
     "forgot_password_sent": "We have sent an email to {{email}}.",
-    "add_account_from_token_error": "Could not add account"
+    "add_account_from_token_error": "Could not add account",
+    "add_account_from_token_invalid_token": "Invalid or expired link",
+    "add_account_from_token_not_from_caller": "Link does not belong to the logged-in user"
   }
 }

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -1239,7 +1239,7 @@
     "send_link": "Send lenke",
     "forgot_password_sent": "Vi har sendt en e-post til {{email}}.",
     "add_account_from_token_error": "Kunne ikke legge til konto",
-    "add_account_from_token_invalid_token": "Lenken er uyldig eller utløpt",
+    "add_account_from_token_invalid_token": "Lenken er ugyldig eller utløpt",
     "add_account_from_token_not_from_caller": "Lenken ble ikke forespurt av pålogget bruker"
   }
 }

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -1238,6 +1238,8 @@
     "no_email_for_username": "Vi fant ingen e-post for dette brukernavnet. Sjekk at brukernavnet er riktig.",
     "send_link": "Send lenke",
     "forgot_password_sent": "Vi har sendt en e-post til {{email}}.",
-    "add_account_from_token_error": "Kunne ikke legge til konto"
+    "add_account_from_token_error": "Kunne ikke legge til konto",
+    "add_account_from_token_invalid_token": "Lenken er uyldig eller utløpt",
+    "add_account_from_token_not_from_caller": "Lenken ble ikke forespurt av pålogget bruker"
   }
 }

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -1239,7 +1239,7 @@
     "send_link": "Send lenke",
     "forgot_password_sent": "Vi har sendt ein e-post til {{email}}.",
     "add_account_from_token_error": "Kunne ikkje legge til konto",
-    "add_account_from_token_invalid_token": "Lenka er uyldig eller utgått",
+    "add_account_from_token_invalid_token": "Lenka er ugyldig eller utgått",
     "add_account_from_token_not_from_caller": "Lenka blei ikkje forespurt av pålogga brukar"
   }
 }

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -1238,6 +1238,8 @@
     "no_email_for_username": "Vi fann ingen e-post for dette brukarnamnet. Sjekk at brukarnamnet er riktig.",
     "send_link": "Send lenke",
     "forgot_password_sent": "Vi har sendt ein e-post til {{email}}.",
-    "add_account_from_token_error": "Kunne ikkje legge til konto"
+    "add_account_from_token_error": "Kunne ikkje legge til konto",
+    "add_account_from_token_invalid_token": "Lenka er uyldig eller utgått",
+    "add_account_from_token_not_from_caller": "Lenka blei ikkje forespurt av pålogga brukar"
   }
 }

--- a/src/rtk/features/selfIdentifiedUserApi.ts
+++ b/src/rtk/features/selfIdentifiedUserApi.ts
@@ -22,11 +22,14 @@ export const selfIdentifiedUserApi = createApi({
         body: { userName: userName, password: password },
       }),
     }),
-    sendForgotPasswordEmail: builder.mutation<{ maskedEmail: string }, { userName: string }>({
-      query: ({ userName }) => ({
+    sendForgotPasswordEmail: builder.mutation<
+      { maskedEmail: string },
+      { userName: string; lang: string }
+    >({
+      query: ({ userName, lang }) => ({
         url: `altinn2account/forgotpassword`,
         method: 'POST',
-        body: { userName: userName },
+        body: { userName: userName, language: lang },
       }),
     }),
     addAltinn2AccountFromToken: builder.mutation<string, { token: string }>({


### PR DESCRIPTION
## Description
- Vis bedre feilmeldinger ved feil på å følge lenke fra epost
- Send med valgt språk ved glemt passord, så eposten også kan komme på nynorsk og engelsk

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/3601

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Password reset emails for Altinn2 account recovery are now sent in the user's preferred language based on their current interface language setting
  * Enhanced error messaging when adding accounts via token/account link, providing distinct and helpful feedback for scenarios such as invalid or expired links versus links not issued to the current user

<!-- end of auto-generated comment: release notes by coderabbit.ai -->