### PR TITLE
Legg til alt-text på ressurseier logo

### DIFF
--- a/src/features/amUI/common/DelegationModal/SingleRights/ResourceHeading.tsx
+++ b/src/features/amUI/common/DelegationModal/SingleRights/ResourceHeading.tsx
@@ -21,6 +21,7 @@ export const ResourceHeading = ({ resource }: { resource: ServiceResource }) => 
           iconUrl={emblem ?? resource.resourceOwnerLogoUrl}
           size={small ? 'sm' : 'xl'}
           className={!small ? classes.lgAvatar : undefined}
+          altText={`${resource.resourceOwnerName || t('resource_list.service_owner')} logo`}
         />
       ) : (
         <Avatar

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -1128,7 +1128,8 @@
     "show_expired_services": "Show expired services",
     "show_expired_services_helptext": "Some services are expired and will not let you submit/receive new data. You can still grant others access to them, but they will only be able to view old submissions/messages on that service.",
     "show_expired_services_helptext_button": "What are expired services?",
-    "expired_badge": "Expired"
+    "expired_badge": "Expired",
+    "service_owner": "Service owner"
   },
   "landing_page": {
     "page_title": "Access management - Altinn",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -1125,7 +1125,8 @@
     "show_expired_services": "Vis utgåtte tjenester",
     "show_expired_services_helptext": "Noen tjenester er utgått og vil ikke la deg sende inn eller motta ny data. Du kan likevel gi andre fullmakter til dem, men de vil da bare kunne se gamle innsendinger eller meldinger på tjenesten.",
     "show_expired_services_helptext_button": "Hva er utgåtte tjenester?",
-    "expired_badge": "Utgått"
+    "expired_badge": "Utgått",
+    "service_owner": "Tjenesteeier"
   },
   "landing_page": {
     "page_title": "Tilgangsstyring - Altinn",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -1125,7 +1125,8 @@
     "show_expired_services": "Vis utgåtte tenester",
     "show_expired_services_helptext": "Nokre tenester er utgåtte og vil ikkje la deg sende inn eller motta nye data. Du kan likevel gi andre fullmakter til dei, men dei vil då berre kunne sjå gamle innsendingar eller meldingar på tenesta.",
     "show_expired_services_helptext_button": "Kva er utgåtte tenester?",
-    "expired_badge": "Utgått"
+    "expired_badge": "Utgått",
+    "service_owner": "Tenesteeigar"
   },
   "landing_page": {
     "page_title": "Tilgangsstyring - Altinn",


### PR DESCRIPTION
## Description
-  Legg til alt-text på ressurseier logo (vi kan ikke bruke aria-hidden prop uten å endre altinn-components, siden den ikke blir sendt videre til `Icon` komponent i altinn-components)

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/3133

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Service owner information is now displayed throughout resource lists, providing users with improved visibility and clarity regarding the service providers associated with their resources
  * Accessibility improvements include descriptive alternative text for resource owner icons, enhancing support for users relying on screen readers and assistive technologies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->