### PR TITLE
Map `variant` for some parties

### DIFF
--- a/src/features/amUI/clientAdministration/ClientAdministrationAgentsTab.tsx
+++ b/src/features/amUI/clientAdministration/ClientAdministrationAgentsTab.tsx
@@ -50,6 +50,7 @@ export const ClientAdministrationAgentsTab = ({ isActive }: ClientAdministration
             parent: null,
             addedAt: agent.agentAddedAt,
             isDeleted: agent.agent.isDeleted ?? undefined,
+            variant: agent.agent.variant ?? undefined,
             roles: [],
           },
           roles: [],

--- a/src/features/amUI/clientAdministration/ClientAdministrationClientsTab.tsx
+++ b/src/features/amUI/clientAdministration/ClientAdministrationClientsTab.tsx
@@ -24,6 +24,7 @@ const buildClientConnections = (clients?: Client[]): Connection[] => {
         parent: null,
         roles: [],
         isDeleted: client.client.isDeleted ?? undefined,
+        variant: client.client.variant ?? undefined,
       },
       sortKey,
       roles: [],

--- a/src/features/amUI/maskinporten/ConsumerPage.tsx
+++ b/src/features/amUI/maskinporten/ConsumerPage.tsx
@@ -49,6 +49,7 @@ export const ConsumerPage = () => {
       partyTypeName: PartyType.Organization,
       orgNumber: party.organizationIdentifier ?? '',
       isDeleted: party.isDeleted ?? false,
+      variant: party.variant ?? '',
     };
   }, [consumer]);
 

--- a/src/features/amUI/maskinporten/SupplierPage.tsx
+++ b/src/features/amUI/maskinporten/SupplierPage.tsx
@@ -49,6 +49,7 @@ export const SupplierPage = () => {
       partyTypeName: PartyType.Organization,
       orgNumber: party.organizationIdentifier ?? '',
       isDeleted: party.isDeleted ?? false,
+      variant: party.variant ?? '',
     };
   }, [supplier]);
 


### PR DESCRIPTION
## Description
- Map `variant` for some parties to display correct avatar for subunits. Not sure if all of these parties can ever be subunits

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved display of organization and party variant details in client administration, consumer, and supplier views.
  * Search and connection entries now preserve variant information where available, helping surface more accurate identity details across pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->