### PR TITLE
Focus management on instance and role tabs

### DIFF
--- a/src/features/amUI/common/DelegationModal/Role/RoleInfo.tsx
+++ b/src/features/amUI/common/DelegationModal/Role/RoleInfo.tsx
@@ -53,7 +53,7 @@ export const RoleInfo = ({ role }: RoleInfoProps) => {
     },
   );
 
-  // restore focus on only when the permissions query refetches
+  // restore focus only when the permissions query refetches
   const requestFocusOnDataChange = useRestoreFocusOnDataChange(permissions);
 
   const sectionId = fromParty?.partyUuid === actingParty?.partyUuid ? 9 : 8;

--- a/src/features/amUI/common/DelegationModal/Role/RoleInfo.tsx
+++ b/src/features/amUI/common/DelegationModal/Role/RoleInfo.tsx
@@ -17,6 +17,9 @@ import { useState } from 'react';
 import { TechnicalErrorParagraphs } from '../../TechnicalErrorParagraphs';
 import { createErrorDetails } from '../../TechnicalErrorParagraphs/TechnicalErrorParagraphs';
 import { useDelegationModalContext } from '../DelegationModalContext';
+import { useRestoreFocusOnDataChange, useRestoreFocusTarget } from '../../RestoreFocus';
+
+export const ROLE_MODAL_HEADING_ID = 'role_modal_heading';
 
 export interface RoleInfoProps {
   role: Role;
@@ -25,6 +28,7 @@ export interface RoleInfoProps {
 export const RoleInfo = ({ role }: RoleInfoProps) => {
   const { t } = useTranslation();
   const [deleteError, setDeleteError] = useState<unknown>(null);
+  useRestoreFocusTarget(ROLE_MODAL_HEADING_ID);
 
   const isExternalRole = role?.provider?.code === 'sys-ccr';
   const isLegacyRole = role?.provider?.code === 'sys-altinn2';
@@ -48,6 +52,9 @@ export const RoleInfo = ({ role }: RoleInfoProps) => {
       skip: !actingParty?.partyUuid || !fromParty?.partyUuid || !toParty?.partyUuid,
     },
   );
+
+  // restore focus on only when the permissions query refetches
+  const requestFocusOnDataChange = useRestoreFocusOnDataChange(permissions);
 
   const sectionId = fromParty?.partyUuid === actingParty?.partyUuid ? 9 : 8;
   const oldSolutionUrl = getRedirectToA2UsersListSectionUrl(sectionId);
@@ -80,8 +87,11 @@ export const RoleInfo = ({ role }: RoleInfoProps) => {
     <div className={classes.container}>
       <div className={classes.header}>
         <DsHeading
+          id={ROLE_MODAL_HEADING_ID}
           level={2}
           data-size='sm'
+          // Programmatically focusable so it can hold focus when the delete button is removed.
+          tabIndex={-1}
         >
           {role?.name}
         </DsHeading>
@@ -142,6 +152,7 @@ export const RoleInfo = ({ role }: RoleInfoProps) => {
         <div className={classes.deleteRoleButtonContainer}>
           <RoleDeleteButton
             role={role}
+            onSuccess={() => requestFocusOnDataChange(ROLE_MODAL_HEADING_ID)}
             onError={setDeleteError}
             disabled={!roleIsRevocable}
           />

--- a/src/features/amUI/common/DeletePoaConfirmation/DeletePoaConfirmation.tsx
+++ b/src/features/amUI/common/DeletePoaConfirmation/DeletePoaConfirmation.tsx
@@ -1,7 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { MinusCircleIcon } from '@navikt/aksel-icons';
 import { useRef, useState } from 'react';
-import { createPortal } from 'react-dom';
 import { DsButton, DsDialog, DsHeading, DsParagraph, DsSpinner } from '@altinn/altinn-components';
 import classes from './DeletePoaConfirmation.module.css';
 
@@ -54,36 +53,34 @@ export const DeletePoaConfirmation = ({
         {icon && <MinusCircleIcon />}
         {t('common.delete_poa')}
       </DsDialog.Trigger>
-      {open &&
-        createPortal(
-          <DsDialog
-            ref={dialogRef}
-            onClose={() => setOpen(false)}
-          >
-            <div className={classes.dialogContent}>
-              <DsHeading level={3}>{t('common.confirm_delete_heading')}</DsHeading>
-              <DsParagraph>{warningText}</DsParagraph>
-              <div className={classes.dialogButtons}>
-                <DsButton
-                  data-color='danger'
-                  onClick={() => {
-                    handleDeletion();
-                    closeDialog();
-                  }}
-                >
-                  {t('common.yes_delete')}
-                </DsButton>
-                <DsButton
-                  variant='secondary'
-                  onClick={closeDialog}
-                >
-                  {t('common.cancel')}
-                </DsButton>
-              </div>
+      {open && (
+        <DsDialog
+          ref={dialogRef}
+          onClose={() => setOpen(false)}
+        >
+          <div className={classes.dialogContent}>
+            <DsHeading level={3}>{t('common.confirm_delete_heading')}</DsHeading>
+            <DsParagraph>{warningText}</DsParagraph>
+            <div className={classes.dialogButtons}>
+              <DsButton
+                data-color='danger'
+                onClick={() => {
+                  handleDeletion();
+                  closeDialog();
+                }}
+              >
+                {t('common.yes_delete')}
+              </DsButton>
+              <DsButton
+                variant='secondary'
+                onClick={closeDialog}
+              >
+                {t('common.cancel')}
+              </DsButton>
             </div>
-          </DsDialog>,
-          document.body,
-        )}
+          </div>
+        </DsDialog>
+      )}
       {isDeleteLoading && (
         <DsSpinner
           aria-label={loadingAriaLabel}

--- a/src/features/amUI/common/InstanceList/InstanceList.tsx
+++ b/src/features/amUI/common/InstanceList/InstanceList.tsx
@@ -1,4 +1,4 @@
-import { ElementType, useMemo, useState } from 'react';
+import { type ComponentProps, ElementType, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   DialogListItem,
@@ -11,15 +11,32 @@ import type { TFunction } from 'i18next';
 import { DebouncedSearchField } from '../DebouncedSearchField/DebouncedSearchField';
 import { InstanceDelegation } from '@/rtk/features/instanceApi';
 import { useProviderLogoUrl } from '@/resources/hooks';
+import { useRestoreFocusTarget } from '@/features/amUI/common/RestoreFocus';
 
 import { InstanceListSkeleton } from './InstanceListSkeleton';
 import { InstanceInboxLink } from './InstanceInboxLink';
 import {
   getInstanceShortId,
+  instanceRowId,
   resolveInstanceTitle,
   toInstancePresentationData,
 } from './instanceListUtils';
 import classes from './InstanceList.module.css';
+
+// `interactive` is accepted by DialogListItem at runtime but missing from its prop types (same as
+// the original inline usage); keep it on the wrapper so the call site stays clean.
+const InstanceListItemRow = ({
+  id,
+  ...props
+}: ComponentProps<typeof DialogListItem> & { interactive?: boolean }) => {
+  useRestoreFocusTarget(id ?? '');
+  return (
+    <DialogListItem
+      id={id}
+      {...props}
+    />
+  );
+};
 
 interface InstanceListProps {
   instances: InstanceDelegation[];
@@ -93,7 +110,7 @@ export const InstanceList = ({
               const title = getResolvedInstanceTitle(instanceDelegation, t, i18n.language);
               const serviceTitle = resource.title ?? resource.identifier;
               const item: DialogListItemProps = {
-                id: `${resource.identifier}-${instance.refId}`,
+                id: instanceRowId(instanceDelegation),
                 title,
                 description: `${instance.refId} ${title}`,
                 sender: {
@@ -113,7 +130,7 @@ export const InstanceList = ({
                 dialogLookup && dialogLookup.status !== 'Success' ? classes.subtleTitle : undefined;
 
               return (
-                <DialogListItem
+                <InstanceListItemRow
                   key={item.id}
                   size='md'
                   as={Component ?? (onSelect ? 'button' : undefined)}

--- a/src/features/amUI/common/InstanceList/InstanceList.tsx
+++ b/src/features/amUI/common/InstanceList/InstanceList.tsx
@@ -23,8 +23,6 @@ import {
 } from './instanceListUtils';
 import classes from './InstanceList.module.css';
 
-// `interactive` is accepted by DialogListItem at runtime but missing from its prop types (same as
-// the original inline usage); keep it on the wrapper so the call site stays clean.
 const InstanceListItemRow = ({
   id,
   ...props

--- a/src/features/amUI/common/InstanceList/instanceListUtils.ts
+++ b/src/features/amUI/common/InstanceList/instanceListUtils.ts
@@ -14,6 +14,11 @@ export interface InstancePresentationData {
   dialogLookup?: DialogLookup;
 }
 
+// DOM id used both for the list row and for restoring focus to it when the modal closes. Keep the
+// two call sites in sync by deriving the id here instead of formatting the string by hand.
+export const instanceRowId = (instanceDelegation: InstanceDelegation): string =>
+  `${instanceDelegation.resource.identifier}-${instanceDelegation.instance.refId}`;
+
 export const isCorrespondenceInstanceUrn = (instanceUrn?: string): boolean =>
   instanceUrn?.startsWith('urn:altinn:correspondence-id:') ?? false;
 

--- a/src/features/amUI/common/InstanceList/instanceListUtils.ts
+++ b/src/features/amUI/common/InstanceList/instanceListUtils.ts
@@ -14,8 +14,7 @@ export interface InstancePresentationData {
   dialogLookup?: DialogLookup;
 }
 
-// DOM id used both for the list row and for restoring focus to it when the modal closes. Keep the
-// two call sites in sync by deriving the id here instead of formatting the string by hand.
+// DOM id used both for the list row and for restoring focus to it when the modal closes.
 export const instanceRowId = (instanceDelegation: InstanceDelegation): string =>
   `${instanceDelegation.resource.identifier}-${instanceDelegation.instance.refId}`;
 

--- a/src/features/amUI/common/RoleList/RoleDeleteButton.tsx
+++ b/src/features/amUI/common/RoleList/RoleDeleteButton.tsx
@@ -9,6 +9,7 @@ import { usePartyRepresentation } from '../PartyRepresentationContext/PartyRepre
 
 interface RoleDeleteButtonProps {
   role: Role;
+  onSuccess?: () => void;
   onError?: (error: FetchBaseQueryError | SerializedError) => void;
   size?: 'xs' | 'sm' | 'md' | 'lg';
   color?: 'danger' | 'neutral';
@@ -19,6 +20,7 @@ interface RoleDeleteButtonProps {
 
 export const RoleDeleteButton = ({
   role,
+  onSuccess,
   onError,
   size,
   color,
@@ -42,6 +44,7 @@ export const RoleDeleteButton = ({
       .unwrap()
       .then(() => {
         openSnackbar({ message: t('role.delete_role_success'), color: 'success' });
+        onSuccess?.();
       })
       .catch((error: FetchBaseQueryError | SerializedError) => {
         onError?.(error);

--- a/src/features/amUI/common/RoleList/RoleList.tsx
+++ b/src/features/amUI/common/RoleList/RoleList.tsx
@@ -15,6 +15,9 @@ import classes from './roleSection.module.css';
 import { useRoleMetadata } from '../UserRoles/useRoleMetadata';
 import { RoleDeleteButton } from './RoleDeleteButton';
 import { useIsMobileOrSmaller } from '@/resources/utils/screensizeUtils';
+import { useRestoreFocusOnDataChange } from '../RestoreFocus';
+
+export const ROLE_LIST_HEADING_ID = 'role_list_heading';
 
 interface RoleListProps {
   onSelect: (role: Role, error?: unknown) => void;
@@ -50,6 +53,8 @@ export const RoleList = ({ onSelect, isLoading }: RoleListProps) => {
   const { altinn2Roles } = useGroupedRoleListEntries({
     permissions,
   });
+
+  const requestFocusOnDataChange = useRestoreFocusOnDataChange(permissions);
 
   const mappedRoles = mapRoles(altinn2Roles?.map(({ role }) => role ?? ([] as Role[])));
 
@@ -87,6 +92,7 @@ export const RoleList = ({ onSelect, isLoading }: RoleListProps) => {
       <DsHeading
         level={2}
         data-size='xs'
+        id={ROLE_LIST_HEADING_ID}
       >
         {t('role.current_roles_title', { count: mappedRoles.length })}
       </DsHeading>
@@ -110,6 +116,7 @@ export const RoleList = ({ onSelect, isLoading }: RoleListProps) => {
                       color='neutral'
                       size='sm'
                       icon={true}
+                      onSuccess={() => requestFocusOnDataChange(role.id, ROLE_LIST_HEADING_ID)}
                       onError={(error) => onSelect(role, error)}
                     />
                   ) : undefined

--- a/src/features/amUI/common/RoleList/RoleListItem.tsx
+++ b/src/features/amUI/common/RoleList/RoleListItem.tsx
@@ -1,5 +1,6 @@
 import { ListItem } from '@altinn/altinn-components';
 import type { Role } from '@/rtk/features/roleApi';
+import { useRestoreFocusTarget } from '@/features/amUI/common/RestoreFocus';
 
 interface RoleLIstItemProps {
   role: Role;
@@ -9,6 +10,7 @@ interface RoleLIstItemProps {
 }
 
 export const RoleListItem = ({ role, onClick, loading, deleteButton }: RoleLIstItemProps) => {
+  useRestoreFocusTarget(role.id);
   return (
     <ListItem
       id={role.id}

--- a/src/features/amUI/reporteeRightsPage/ReporteeRoleSection.tsx
+++ b/src/features/amUI/reporteeRightsPage/ReporteeRoleSection.tsx
@@ -41,6 +41,12 @@ export const ReporteeRoleSection = ({ numberOfAccesses }: ReporteeRoleSectionPro
         modalRef={modalRef}
         role={modalItem}
         onClose={() => {
+          // The confirm-deletion dialog is a nested <dialog>. Closing it can fire a spurious close
+          // on this modal while it is still open. Ignore those: only treat it as a real close when
+          // this dialog is actually closed.
+          if (modalRef.current?.open) {
+            return;
+          }
           // Request focus synchronously before clearing state. If the role was deleted inside the
           // modal its row is gone, so fall back to the list heading instead of <body>.
           if (modalItem) {

--- a/src/features/amUI/reporteeRightsPage/ReporteeRoleSection.tsx
+++ b/src/features/amUI/reporteeRightsPage/ReporteeRoleSection.tsx
@@ -4,9 +4,14 @@ import type { Role } from '@/rtk/features/roleApi';
 import type { ActionError } from '@/resources/hooks/useActionError';
 
 import { RoleInfoModal } from '../common/DelegationModal/RoleInfoModal';
-import { RoleList } from '../common/RoleList/RoleList';
+import { RoleList, ROLE_LIST_HEADING_ID } from '../common/RoleList/RoleList';
 import { OldRolesAlert } from '../common/OldRolesAlert/OldRolesAlert';
 import { usePartyRepresentation } from '../common/PartyRepresentationContext/PartyRepresentationContext';
+import {
+  RestoreFocusFallback,
+  RestoreFocusProvider,
+  useRestoreFocus,
+} from '../common/RestoreFocus';
 
 interface ReporteeRoleSectionProps {
   numberOfAccesses?: number;
@@ -17,27 +22,35 @@ export const ReporteeRoleSection = ({ numberOfAccesses }: ReporteeRoleSectionPro
   const [modalItem, setModalItem] = useState<Role | undefined>(undefined);
   const [deleteError, setDeleteError] = useState<unknown>(null);
   const { isLoading } = usePartyRepresentation();
+  const restoreFocus = useRestoreFocus();
 
   return (
-    <>
+    <RestoreFocusProvider restoreFocus={restoreFocus}>
       <OldRolesAlert />
-      <RoleList
-        onSelect={(role, error) => {
-          setModalItem(role);
-          setDeleteError(error ?? null);
-          modalRef.current?.showModal();
-        }}
-        isLoading={isLoading}
-      />
+      <RestoreFocusFallback>
+        <RoleList
+          onSelect={(role, error) => {
+            setModalItem(role);
+            setDeleteError(error ?? null);
+            modalRef.current?.showModal();
+          }}
+          isLoading={isLoading}
+        />
+      </RestoreFocusFallback>
       <RoleInfoModal
         modalRef={modalRef}
         role={modalItem}
         onClose={() => {
+          // Request focus synchronously before clearing state. If the role was deleted inside the
+          // modal its row is gone, so fall back to the list heading instead of <body>.
+          if (modalItem) {
+            restoreFocus.requestFocus(modalItem.id, ROLE_LIST_HEADING_ID);
+          }
           setModalItem(undefined);
           setDeleteError(null);
         }}
         openWithError={deleteError as ActionError}
       />
-    </>
+    </RestoreFocusProvider>
   );
 };

--- a/src/features/amUI/userRightsPage/InstanceSection/InstanceSection.tsx
+++ b/src/features/amUI/userRightsPage/InstanceSection/InstanceSection.tsx
@@ -4,18 +4,28 @@ import { DsAlert, DsHeading, DsParagraph } from '@altinn/altinn-components';
 
 import { usePartyRepresentation } from '../../common/PartyRepresentationContext/PartyRepresentationContext';
 import { InstanceList } from '@/features/amUI/common/InstanceList/InstanceList';
+import { instanceRowId } from '@/features/amUI/common/InstanceList/instanceListUtils';
 import { DelegationAction, EditModal } from '@/features/amUI/common/DelegationModal/EditModal';
 import { type InstanceDelegation, useGetInstancesQuery } from '@/rtk/features/instanceApi';
+import {
+  RestoreFocusFallback,
+  RestoreFocusProvider,
+  useRestoreFocus,
+  useRestoreFocusContext,
+} from '@/features/amUI/common/RestoreFocus';
 import classes from './InstanceSection.module.css';
 import { useCanGiveAccess } from '@/resources/hooks/useCanGiveAccess';
 import { useParams } from 'react-router';
 
-export const InstanceSection = ({ isReportee = false }: { isReportee?: boolean }) => {
+const INSTANCES_HEADING_ID = 'instances_title';
+
+const InstanceSectionContent = ({ isReportee = false }: { isReportee?: boolean }) => {
   const { t, i18n } = useTranslation();
   const { toParty, actingParty, fromParty } = usePartyRepresentation();
 
   const modalRef = React.useRef<HTMLDialogElement>(null);
   const [selectedInstance, setSelectedInstance] = React.useState<InstanceDelegation | null>(null);
+  const restoreFocusContext = useRestoreFocusContext();
 
   const { id } = useParams();
   const canGiveAccess = useCanGiveAccess(id ?? '', isReportee);
@@ -41,6 +51,7 @@ export const InstanceSection = ({ isReportee = false }: { isReportee?: boolean }
       <DsHeading
         level={2}
         data-size='xs'
+        id={INSTANCES_HEADING_ID}
       >
         {t('user_rights_page.instances_title')}
       </DsHeading>
@@ -53,14 +64,16 @@ export const InstanceSection = ({ isReportee = false }: { isReportee?: boolean }
         </DsAlert>
       )}
       {!isError && (
-        <InstanceList
-          instances={instances}
-          isLoading={isLoading}
-          onSelect={(instance) => {
-            setSelectedInstance(instance);
-            modalRef.current?.showModal();
-          }}
-        />
+        <RestoreFocusFallback>
+          <InstanceList
+            instances={instances}
+            isLoading={isLoading}
+            onSelect={(instance) => {
+              setSelectedInstance(instance);
+              modalRef.current?.showModal();
+            }}
+          />
+        </RestoreFocusFallback>
       )}
       <EditModal
         ref={modalRef}
@@ -73,12 +86,31 @@ export const InstanceSection = ({ isReportee = false }: { isReportee?: boolean }
               }
             : undefined
         }
-        onClose={() => setSelectedInstance(null)}
+        onClose={() => {
+          // Request focus synchronously before clearing state. If the instance was revoked inside
+          // the modal its row is gone, so fall back to the section heading instead of <body>.
+          if (selectedInstance) {
+            restoreFocusContext?.requestFocus(
+              instanceRowId(selectedInstance),
+              INSTANCES_HEADING_ID,
+            );
+          }
+          setSelectedInstance(null);
+        }}
         availableActions={[
           ...(canGiveAccess ? [DelegationAction.DELEGATE] : []),
           DelegationAction.REVOKE,
         ]}
       />
     </div>
+  );
+};
+
+export const InstanceSection = ({ isReportee = false }: { isReportee?: boolean }) => {
+  const restoreFocus = useRestoreFocus();
+  return (
+    <RestoreFocusProvider restoreFocus={restoreFocus}>
+      <InstanceSectionContent isReportee={isReportee} />
+    </RestoreFocusProvider>
   );
 };

--- a/src/features/amUI/userRightsPage/RoleSection/RoleSection.tsx
+++ b/src/features/amUI/userRightsPage/RoleSection/RoleSection.tsx
@@ -1,40 +1,53 @@
 import React, { useRef, useState } from 'react';
 import type { Role } from '@/rtk/features/roleApi';
 
-import { RoleList } from '../../common/RoleList/RoleList';
+import { RoleList, ROLE_LIST_HEADING_ID } from '../../common/RoleList/RoleList';
 import { RoleInfoModal } from '../../common/DelegationModal/RoleInfoModal';
 import { OldRolesAlert } from '../../common/OldRolesAlert/OldRolesAlert';
 import { usePartyRepresentation } from '../../common/PartyRepresentationContext/PartyRepresentationContext';
 import { ActionError } from '@/resources/hooks/useActionError';
+import {
+  RestoreFocusFallback,
+  RestoreFocusProvider,
+  useRestoreFocus,
+} from '../../common/RestoreFocus';
 
 export const RoleSection = () => {
   const modalRef = useRef<HTMLDialogElement>(null);
   const [modalItem, setModalItem] = useState<Role | undefined>(undefined);
   const [deleteError, setDeleteError] = useState<unknown>(null);
   const { toParty, isLoading } = usePartyRepresentation();
+  const restoreFocus = useRestoreFocus();
 
   return (
-    <>
+    <RestoreFocusProvider restoreFocus={restoreFocus}>
       <OldRolesAlert />
-      <RoleList
-        onSelect={(role, error) => {
-          setModalItem(role);
-          setDeleteError(error ?? null);
-          modalRef.current?.showModal();
-        }}
-        isLoading={isLoading}
-      />
+      <RestoreFocusFallback>
+        <RoleList
+          onSelect={(role, error) => {
+            setModalItem(role);
+            setDeleteError(error ?? null);
+            modalRef.current?.showModal();
+          }}
+          isLoading={isLoading}
+        />
+      </RestoreFocusFallback>
       {toParty && (
         <RoleInfoModal
           modalRef={modalRef}
           role={modalItem}
           onClose={() => {
+            // Request focus synchronously before clearing state. If the role was deleted inside the
+            // modal its row is gone, so fall back to the list heading instead of <body>.
+            if (modalItem) {
+              restoreFocus.requestFocus(modalItem.id, ROLE_LIST_HEADING_ID);
+            }
             setModalItem(undefined);
             setDeleteError(null);
           }}
           openWithError={deleteError as ActionError}
         />
       )}
-    </>
+    </RestoreFocusProvider>
   );
 };

--- a/src/features/amUI/userRightsPage/RoleSection/RoleSection.tsx
+++ b/src/features/amUI/userRightsPage/RoleSection/RoleSection.tsx
@@ -37,6 +37,12 @@ export const RoleSection = () => {
           modalRef={modalRef}
           role={modalItem}
           onClose={() => {
+            // The confirm-deletion dialog is a nested <dialog>. Closing it can fire a spurious close
+            // on this modal while it is still open. Ignore those: only treat it as a real close when
+            // this dialog is actually closed.
+            if (modalRef.current?.open) {
+              return;
+            }
             // Request focus synchronously before clearing state. If the role was deleted inside the
             // modal its row is gone, so fall back to the list heading instead of <body>.
             if (modalItem) {

--- a/src/features/amUI/userRightsPage/RoleSection/RoleSection.tsx
+++ b/src/features/amUI/userRightsPage/RoleSection/RoleSection.tsx
@@ -43,8 +43,6 @@ export const RoleSection = () => {
             if (modalRef.current?.open) {
               return;
             }
-            // Request focus synchronously before clearing state. If the role was deleted inside the
-            // modal its row is gone, so fall back to the list heading instead of <body>.
             if (modalItem) {
               restoreFocus.requestFocus(modalItem.id, ROLE_LIST_HEADING_ID);
             }


### PR DESCRIPTION
Håndtering av fokus + fallback i "rolle" og "instans" fanene

For å teste kan man for eksempel gå inn på siden til "ETTERPÅKLOK MANN" (15857098592). Denne har fortsatt noen roller for "Diskret Nær Tiger AS".

FIkser også en bug hvor lukking av bekreftelse-modal fjernet innholdet i rolle-modalen (ødela også fokus-håndteringen): 
- Fjerner create-portal rendrer heller bekreftelses-dialogen inne i rolle-modalen + en guard på onClose som hindrer at rolle-modalen lukkes mens bekreftelsesmodalen fortsatt er åpen.

https://github.com/user-attachments/assets/c7e20240-9fa1-4453-9415-c887f49c8e3b


## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard focus recovery after closing role and instance dialogs, making navigation smoother.
  * After deleting roles or closing detail dialogs, focus now returns to the most relevant list item or heading.
  * Fixed dialog closing behavior so nested confirmation dialogs no longer trigger premature close actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->