### PR TITLE
Restore focus on back in access package modal in systemuser views

### DIFF
--- a/src/features/amUI/systemUser/components/RightsList/AccessPackageInfo.tsx
+++ b/src/features/amUI/systemUser/components/RightsList/AccessPackageInfo.tsx
@@ -20,7 +20,6 @@ export const AccessPackageInfo = ({
   onSelectResource,
 }: AccessPackageInfoProps): React.ReactElement => {
   const { t } = useTranslation();
-  const { getProviderLogoUrl } = useProviderLogoUrl();
 
   return (
     <>
@@ -50,25 +49,42 @@ export const AccessPackageInfo = ({
         </DsHeading>
         <List>
           {accessPackage.resources.map((resource) => {
-            const emblem = getProviderLogoUrl(resource.resourceOwnerOrgcode ?? '');
-            useRestoreFocusTarget(resource.identifier);
             return (
-              <ResourceListItem
+              <PackageResourceItem
                 key={resource.identifier}
-                id={resource.identifier}
-                as='button'
-                titleAs='div'
-                size='xs'
-                ownerLogoUrl={emblem ?? resource.resourceOwnerLogoUrl}
-                ownerLogoUrlAlt={resource.resourceOwnerName ?? ''}
-                ownerName={resource.resourceOwnerName ?? ''}
-                resourceName={resource.title}
-                onClick={() => onSelectResource(resource)}
+                resource={resource}
+                onSelectResource={onSelectResource}
               />
             );
           })}
         </List>
       </div>
     </>
+  );
+};
+
+interface PackageResourceItemProps {
+  resource: ServiceResource;
+  onSelectResource: (resource: ServiceResource) => void;
+}
+
+const PackageResourceItem = ({ resource, onSelectResource }: PackageResourceItemProps) => {
+  const { getProviderLogoUrl } = useProviderLogoUrl();
+
+  useRestoreFocusTarget(resource.identifier);
+  const emblem = getProviderLogoUrl(resource.resourceOwnerOrgcode ?? '');
+
+  return (
+    <ResourceListItem
+      id={resource.identifier}
+      as='button'
+      titleAs='div'
+      size='xs'
+      ownerLogoUrl={emblem ?? resource.resourceOwnerLogoUrl}
+      ownerLogoUrlAlt={resource.resourceOwnerName ?? ''}
+      ownerName={resource.resourceOwnerName ?? ''}
+      resourceName={resource.title}
+      onClick={() => onSelectResource(resource)}
+    />
   );
 };

--- a/src/features/amUI/systemUser/components/RightsList/AccessPackageInfo.tsx
+++ b/src/features/amUI/systemUser/components/RightsList/AccessPackageInfo.tsx
@@ -9,6 +9,7 @@ import { useProviderLogoUrl } from '@/resources/hooks/useProviderLogoUrl';
 import type { SystemUserAccessPackage } from '../../types';
 
 import classes from './RightsList.module.css';
+import { useRestoreFocusTarget } from '@/features/amUI/common/RestoreFocus';
 
 interface AccessPackageInfoProps {
   accessPackage: SystemUserAccessPackage;
@@ -50,6 +51,7 @@ export const AccessPackageInfo = ({
         <List>
           {accessPackage.resources.map((resource) => {
             const emblem = getProviderLogoUrl(resource.resourceOwnerOrgcode ?? '');
+            useRestoreFocusTarget(resource.identifier);
             return (
               <ResourceListItem
                 key={resource.identifier}

--- a/src/features/amUI/systemUser/components/RightsList/RightsList.tsx
+++ b/src/features/amUI/systemUser/components/RightsList/RightsList.tsx
@@ -20,6 +20,12 @@ import type { SystemUserAccessPackage } from '../../types';
 import classes from './RightsList.module.css';
 import { AccessPackageInfo } from './AccessPackageInfo';
 import { ResourceDetails } from './ResourceDetails';
+import {
+  RestoreFocusFallback,
+  RestoreFocusProvider,
+  useRestoreFocus,
+} from '@/features/amUI/common/RestoreFocus';
+import { useAutoFocusRef } from '@/resources/hooks/useAutoFocusRef';
 
 interface RightsListProps {
   resources: ServiceResource[];
@@ -39,6 +45,9 @@ export const RightsList = ({
   const { t } = useTranslation();
   const { getProviderLogoUrl } = useProviderLogoUrl();
   const modalRef = React.useRef<HTMLDialogElement>(null);
+  const restoreFocus = useRestoreFocus();
+  const backButtonRef = useAutoFocusRef<HTMLButtonElement>();
+
   const [selectedResource, setSelectedResource] = React.useState<ServiceResource | null>(null);
   const [selectedAccessPackage, setSelectedAccessPackage] =
     React.useState<SystemUserAccessPackage | null>(null);
@@ -164,34 +173,45 @@ export const RightsList = ({
           </List>
         </div>
       )}
-      <DsDialog
-        ref={modalRef}
-        onClose={closeModal}
-        closedby='any'
-      >
-        {selectedAccessPackage && selectedResource && (
-          <DsButton
-            variant='tertiary'
-            data-color='neutral'
-            data-size='sm'
-            className={classes.backButton}
-            onClick={() => setSelectedResource(null)}
-          >
-            <ArrowLeftIcon
-              fontSize={getButtonIconSize(true)}
-              aria-hidden='true'
-            />
-            {t('common.back')}
-          </DsButton>
-        )}
-        {selectedAccessPackage && !selectedResource && (
-          <AccessPackageInfo
-            accessPackage={selectedAccessPackage}
-            onSelectResource={(resource: ServiceResource) => setSelectedResource(resource)}
-          />
-        )}
-        {selectedResource && <ResourceDetails resource={selectedResource} />}
-      </DsDialog>
+      <RestoreFocusProvider restoreFocus={restoreFocus}>
+        <DsDialog
+          ref={modalRef}
+          onClose={closeModal}
+          closedby='any'
+        >
+          {selectedAccessPackage && selectedResource && (
+            <DsButton
+              ref={backButtonRef}
+              variant='tertiary'
+              data-color='neutral'
+              data-size='sm'
+              className={classes.backButton}
+              onClick={() => {
+                const focusTargetId = selectedResource.identifier;
+                if (focusTargetId) {
+                  restoreFocus.requestFocus(focusTargetId);
+                }
+                setSelectedResource(null);
+              }}
+            >
+              <ArrowLeftIcon
+                fontSize={getButtonIconSize(true)}
+                aria-hidden='true'
+              />
+              {t('common.back')}
+            </DsButton>
+          )}
+          <RestoreFocusFallback>
+            {selectedAccessPackage && !selectedResource && (
+              <AccessPackageInfo
+                accessPackage={selectedAccessPackage}
+                onSelectResource={(resource: ServiceResource) => setSelectedResource(resource)}
+              />
+            )}
+          </RestoreFocusFallback>
+          {selectedResource && <ResourceDetails resource={selectedResource} />}
+        </DsDialog>
+      </RestoreFocusProvider>
     </div>
   );
 };


### PR DESCRIPTION
## Description
- Restore focus to resource list item, when going back after clicking resource list item in access package dialog in system user views.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved keyboard and focus behavior in the rights list flow, helping users return to previously selected items more smoothly.
  * Added focus restoration when navigating between access package details and resource details in the dialog.
* **Bug Fixes**
  * Back navigation now better preserves user focus after closing a resource view, reducing disorientation during browsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->