### PR TITLE
map unitType for systemuser clients and client delegation client heading to display subunit avatars

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/SystemUser/Customer.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/SystemUser/Customer.cs
@@ -21,6 +21,11 @@ namespace Altinn.AccessManagement.UI.Core.Models.SystemUser
         public required string OrganizationIdentifier { get; set; }
 
         /// <summary>
+        /// Gets or sets the unit type if the party is an organization
+        /// </summary>
+        public string UnitType { get; set; }
+
+        /// <summary>
         /// Gets or sets a collection of all access information for the client 
         /// </summary>
         public List<ClientRoleAccessPackages> Access { get; set; } = [];

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/SystemUser/Frontend/CustomerPartyFE.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Models/SystemUser/Frontend/CustomerPartyFE.cs
@@ -21,6 +21,11 @@ namespace Altinn.AccessManagement.UI.Core.Models.SystemUser.Frontend
         public string OrgNo { get; set; } = string.Empty;
 
         /// <summary>
+        /// Gets or sets the unit type if the party is an organization
+        /// </summary>
+        public string UnitType { get; set; }
+
+        /// <summary>
         /// Gets or sets a collection of all access information for the client 
         /// </summary>
         public List<ClientRoleAccessPackages> Access { get; set; } = [];

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/SystemUserAgentDelegationService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/SystemUserAgentDelegationService.cs
@@ -147,6 +147,7 @@ namespace Altinn.AccessManagement.UI.Core.Services
                     Id = x.PartyUuid,
                     Name = x.DisplayName,
                     OrgNo = x.OrganizationIdentifier,
+                    UnitType = x.UnitType,
                     Access = x.Access
                 };
             }).ToList();

--- a/src/features/amUI/clientDetails/ClientDetailsPage.tsx
+++ b/src/features/amUI/clientDetails/ClientDetailsPage.tsx
@@ -39,6 +39,8 @@ export const ClientDetailsPage = () => {
         partyUuid: selectedClient.client.id,
         partyTypeName: PartyType.Organization,
         partyId: Number(selectedClient.client.partyId ?? 0),
+        isDeleted: selectedClient.client.isDeleted ?? undefined,
+        variant: selectedClient.client.variant,
       }
     : undefined;
 

--- a/src/features/amUI/systemUser/SystemUserAgentDelegationPage/CustomerList.tsx
+++ b/src/features/amUI/systemUser/SystemUserAgentDelegationPage/CustomerList.tsx
@@ -16,7 +16,7 @@ import { AmPagination } from '@/components/Paginering';
 import type { AgentDelegation, AgentDelegationCustomer } from '../types';
 
 import classes from './CustomerList.module.css';
-import { formatOrgNr } from '@/resources/utils/reporteeUtils';
+import { formatOrgNr, isSubUnitByType } from '@/resources/utils/reporteeUtils';
 import { addAllSystemuserCustomers } from '@/resources/utils/featureFlagUtils';
 import { useIsMobileOrSmaller } from '@/resources/utils/screensizeUtils';
 
@@ -129,7 +129,11 @@ export const CustomerList = ({
           <ListItem
             key={customer.id}
             id={customer.id}
-            icon={{ type: 'company', name: customer.name }}
+            icon={{
+              type: 'company',
+              name: customer.name,
+              isParent: !isSubUnitByType(customer.unitType),
+            }}
             title={{ children: customer.name, as: 'div' }}
             description={`${t('common.org_nr')} ${formatOrgNr(customer.orgNo)}`}
             interactive={false}

--- a/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPageContent.tsx
+++ b/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPageContent.tsx
@@ -261,6 +261,7 @@ export const SystemUserAgentDelegationPageContent = ({
             id: reporteeData.partyUuid,
             name: reporteeData.name,
             orgNo: reporteeData.organizationNumber || '',
+            unitType: reporteeData.unitType,
             access: [],
             isSelfOrg: true,
           },

--- a/src/features/amUI/systemUser/types.ts
+++ b/src/features/amUI/systemUser/types.ts
@@ -66,6 +66,7 @@ export interface AgentDelegationCustomer {
   id: string;
   name: string;
   orgNo: string;
+  unitType?: string;
   access: {
     role: string;
     packages: string[];


### PR DESCRIPTION
## Description
Add mapping of unitType to display subunit avatars in:
- Client delegation client heading
- Systemuser clients 

<img width="569" height="230" alt="image" src="https://github.com/user-attachments/assets/02633c62-43b4-472f-ab9a-45a4fccbd194" />

___

<img width="630" height="264" alt="image" src="https://github.com/user-attachments/assets/afc84c52-1bc0-4153-9e2b-f4c5ea995dd5" />

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Customer and party details now include unit type information for organizations.
  * Assigned customer lists and customer cards can better distinguish parent units from sub-units.
  * Client details now carry additional party status information for improved display and handling.

* **Bug Fixes**
  * Improved consistency in how organization-related customer data is shown across delegation views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->