### PR TITLE
use partyUuid instead of partyId to look up systemuser reportee

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Helpers/SystemRegisterUtils.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Helpers/SystemRegisterUtils.cs
@@ -18,10 +18,11 @@ namespace Altinn.AccessManagement.UI.Core.Helpers
         /// <returns>Frontend system object <see cref="RegisteredSystemFE"/></returns>
         public static RegisteredSystemFE MapToRegisteredSystemFE(string languageCode, RegisteredSystem system, List<PartyName> orgNames)
         {
+            string lang = string.IsNullOrWhiteSpace(languageCode) ? "nb" : languageCode;
             return new RegisteredSystemFE() 
             {
                 SystemId = system.SystemId,
-                Name = system.Name.TryGetValue(languageCode, out string name) ? name : "N/A",
+                Name = system.Name.TryGetValue(lang, out string name) ? name : "N/A",
                 SystemVendorOrgNumber = system.SystemVendorOrgNumber,
                 SystemVendorOrgName = orgNames.Find(x => x.OrgNo == system.SystemVendorOrgNumber)?.Name ?? "N/A"
             };

--- a/src/features/amUI/systemUser/CreateSystemUserPage/RightsIncluded.tsx
+++ b/src/features/amUI/systemUser/CreateSystemUserPage/RightsIncluded.tsx
@@ -29,7 +29,8 @@ export const RightsIncluded = ({ selectedSystem, onNavigateBack }: RightsInclude
   const { t } = useTranslation();
   const navigate = useNavigate();
   const partyId = getCookie('AltinnPartyId');
-  const { data: reporteeData } = useGetSystemUserReporteeQuery(partyId);
+  const partyUuid = getCookie('AltinnPartyUuid');
+  const { data: reporteeData } = useGetSystemUserReporteeQuery(partyUuid);
 
   const {
     data: rights,

--- a/src/features/amUI/systemUser/CreateSystemUserPage/SelectRegisteredSystem.tsx
+++ b/src/features/amUI/systemUser/CreateSystemUserPage/SelectRegisteredSystem.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link, useNavigate } from 'react-router';
+import { Link } from 'react-router';
 import {
   DsHeading,
   DsParagraph,
@@ -41,10 +41,9 @@ export const SelectRegisteredSystem = ({
   handleConfirm,
 }: SelectRegisteredSystemProps) => {
   const { t } = useTranslation();
-  const navigate = useNavigate();
-  const partyId = getCookie('AltinnPartyId');
+  const partyUuid = getCookie('AltinnPartyUuid');
   const { data: reporteeData, isLoading: isLoadingReportee } =
-    useGetSystemUserReporteeQuery(partyId);
+    useGetSystemUserReporteeQuery(partyUuid);
 
   const {
     data: registeredSystems,

--- a/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPage.tsx
@@ -36,7 +36,7 @@ export const SystemUserAgentDelegationPage = (): React.ReactNode => {
 
   useDocumentTitle(t('systemuser_agent_delegation.page_title'));
 
-  const { data: reporteeData } = useGetSystemUserReporteeQuery(partyId);
+  const { data: reporteeData } = useGetSystemUserReporteeQuery(partyUuid);
   const { data: isAdmin } = useGetIsAdminQuery();
   const { data: isClientAdmin } = useGetIsClientAdminQuery();
 

--- a/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPageContent.tsx
+++ b/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPageContent.tsx
@@ -73,7 +73,7 @@ export const SystemUserAgentDelegationPageContent = ({
 
   const { data: isClientAdmin } = useGetIsClientAdminQuery();
   const { data: isAdmin } = useGetIsAdminQuery();
-  const { data: reporteeData } = useGetSystemUserReporteeQuery(partyId);
+  const { data: reporteeData } = useGetSystemUserReporteeQuery(partyUuid);
 
   const [assignCustomer] = useAssignCustomerMutation();
   const [removeCustomer] = useRemoveCustomerMutation();

--- a/src/features/amUI/systemUser/SystemUserAgentRequestPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserAgentRequestPage.tsx
@@ -46,8 +46,8 @@ export const SystemUserAgentRequestPage = () => {
     data: reporteeData,
     isLoading: isLoadingReportee,
     error: loadReporteeError,
-  } = useGetSystemUserReporteeQuery(request?.partyId ?? '', {
-    skip: !request?.partyId,
+  } = useGetSystemUserReporteeQuery(request?.partyUuid ?? '', {
+    skip: !request?.partyUuid,
   });
   const { data: isAdmin } = useGetSystemuserIsAdminQuery(request?.partyUuid ?? '', {
     skip: !request?.partyUuid,

--- a/src/features/amUI/systemUser/SystemUserChangeRequestPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserChangeRequestPage.tsx
@@ -41,8 +41,8 @@ export const SystemUserChangeRequestPage = () => {
     data: reporteeData,
     isLoading: isLoadingReportee,
     error: loadReporteeError,
-  } = useGetSystemUserReporteeQuery(changeRequest?.partyId ?? '', {
-    skip: !changeRequest?.partyId,
+  } = useGetSystemUserReporteeQuery(changeRequest?.partyUuid ?? '', {
+    skip: !changeRequest?.partyUuid,
   });
   const { data: isAdmin } = useGetSystemuserIsAdminQuery(changeRequest?.partyUuid ?? '', {
     skip: !changeRequest?.partyUuid,

--- a/src/features/amUI/systemUser/SystemUserDetailPage/SystemUserDetailsPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserDetailPage/SystemUserDetailsPage.tsx
@@ -30,9 +30,10 @@ export const SystemUserDetailsPage = (): React.ReactNode => {
   const navigate = useNavigate();
   useDocumentTitle(t('systemuser_detailpage.page_title'));
   const partyId = getCookie('AltinnPartyId');
+  const partyUuid = getCookie('AltinnPartyUuid');
   const backUrl = `/${SystemUserPath.SystemUser}/${SystemUserPath.Overview}`;
 
-  const { data: reporteeData } = useGetSystemUserReporteeQuery(partyId);
+  const { data: reporteeData } = useGetSystemUserReporteeQuery(partyUuid);
   const { data: isAdmin } = useGetIsAdminQuery();
 
   const {

--- a/src/features/amUI/systemUser/SystemUserRequestPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserRequestPage.tsx
@@ -44,8 +44,8 @@ export const SystemUserRequestPage = () => {
     data: reporteeData,
     isLoading: isLoadingReportee,
     error: loadReporteeError,
-  } = useGetSystemUserReporteeQuery(request?.partyId ?? '', {
-    skip: !request?.partyId,
+  } = useGetSystemUserReporteeQuery(request?.partyUuid ?? '', {
+    skip: !request?.partyUuid,
   });
   const { data: isAdmin } = useGetSystemuserIsAdminQuery(request?.partyUuid ?? '', {
     skip: !request?.partyUuid,

--- a/src/features/amUI/systemUser/SystemUsersOverviewPage/SystemUserOverviewPage.tsx
+++ b/src/features/amUI/systemUser/SystemUsersOverviewPage/SystemUserOverviewPage.tsx
@@ -41,7 +41,7 @@ export const SystemUserOverviewPage = () => {
   const { data: isAdmin, isLoading: isLoadingIsAdmin } = useGetIsAdminQuery();
   const { data: isClientAdmin, isLoading: isLoadingClientAdmin } = useGetIsClientAdminQuery();
   const { data: reporteeData, isLoading: isLoadingReportee } =
-    useGetSystemUserReporteeQuery(partyId);
+    useGetSystemUserReporteeQuery(partyUuid);
 
   // load only for isAdmin
   const {

--- a/src/rtk/features/systemUserApi.ts
+++ b/src/rtk/features/systemUserApi.ts
@@ -52,7 +52,7 @@ export const systemUserApi = createApi({
     // system user reportee
     getSystemUserReportee: builder.query<ReporteeInfo, string>({
       keepUnusedDataFor: 300,
-      query: (partyId) => `user/reportee/${partyId}`,
+      query: (partyUuid) => `user/reportee/${partyUuid}`,
       transformResponse: (response: ReporteeInfo) => {
         return {
           ...response,


### PR DESCRIPTION
## Description
- Change `getSystemUserReportee` to accept partyUuid instead of partyId.
- Show system name in bokmål (instead of string "N/A") if language cookie is somehow not set

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved localized system-name display by falling back to Norwegian when no language is provided.
  * Fixed several system user pages so reportee details load using the correct organization identifier, helping pages display the right information and load more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->