### PR TITLE
fix: add role='alert' to consent errors shown when user interacts with something

### DIFF
--- a/src/features/amUI/consent/ConsentRequestPage/ConsentRequestError.tsx
+++ b/src/features/amUI/consent/ConsentRequestPage/ConsentRequestError.tsx
@@ -36,5 +36,12 @@ export const ConsentRequestError = ({ defaultError, error }: ConsentRequestError
     }
   };
 
-  return <DsAlert data-color='danger'>{getErrorMessage()}</DsAlert>;
+  return (
+    <DsAlert
+      data-color='danger'
+      role='alert'
+    >
+      {getErrorMessage()}
+    </DsAlert>
+  );
 };

--- a/src/features/amUI/consent/components/ConsentDetails/ConsentDetails.tsx
+++ b/src/features/amUI/consent/components/ConsentDetails/ConsentDetails.tsx
@@ -78,7 +78,12 @@ export const ConsentDetails = ({ consentId }: ConsentDetailsProps) => {
   return (
     <>
       {loadConsentError && (
-        <DsAlert data-color='danger'>{t('active_consents.load_consent_error')}</DsAlert>
+        <DsAlert
+          data-color='danger'
+          role='alert'
+        >
+          {t('active_consents.load_consent_error')}
+        </DsAlert>
       )}
       {consent && (
         <div className={classes.consentContainer}>
@@ -135,7 +140,10 @@ export const ConsentDetails = ({ consentId }: ConsentDetailsProps) => {
               </DsPopover.TriggerContext>
             )}
             {revokeConsentError && (
-              <DsAlert data-color='danger'>
+              <DsAlert
+                data-color='danger'
+                role='alert'
+              >
                 {consent.isPoa
                   ? t('active_consents.revoke_poa_error')
                   : t('active_consents.revoke_consent_error')}


### PR DESCRIPTION
## Description
- add role='alert' to consent errors shown when user interacts with something:
    - Approve request fails
    - Reject request fails
    - Loading single consent fails
    - Revoke consent fails

## Related Issue(s)
- part of https://github.com/Altinn/altinn-authorization-tmp/issues/2968

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated alert markup in consent-related screens for clearer, more consistent structure.
  * Added alert roles to error states to improve accessibility and assistive technology behavior.
  * No visible behavior or content changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->