### PR TITLE
fix: add role='alert' to systemuser errors shown when user interacts with something

### DIFF
--- a/src/features/amUI/systemUser/components/DelegationCheckError/DelegationCheckError.tsx
+++ b/src/features/amUI/systemUser/components/DelegationCheckError/DelegationCheckError.tsx
@@ -26,7 +26,12 @@ export const DelegationCheckError = ({
 
   return (
     <div className={classes.delegationCheckError}>
-      <DsAlert data-color='danger'>{getErrorMessage()}</DsAlert>
+      <DsAlert
+        data-color='danger'
+        role='alert'
+      >
+        {getErrorMessage()}
+      </DsAlert>
     </div>
   );
 };

--- a/src/features/amUI/systemUser/components/EscalateRequest/EscalateRequest.tsx
+++ b/src/features/amUI/systemUser/components/EscalateRequest/EscalateRequest.tsx
@@ -106,9 +106,11 @@ const StepOne = ({ isLoading, isError, onEscalate, onCancel }: StepOneProps) => 
           >
             {t('systemuser_request.escalate_cancel_button')}
           </DsButton>
-          {isError && (
-            <DsValidationMessage>{t('systemuser_request.escalate_error')}</DsValidationMessage>
-          )}
+          <div aria-live='polite'>
+            {isError && (
+              <DsValidationMessage>{t('systemuser_request.escalate_error')}</DsValidationMessage>
+            )}
+          </div>
         </ButtonRow>
       </div>
     </>


### PR DESCRIPTION
## Description
add role='alert' to systemuser errors shown when user interacts with something:
- Create system user fails
- Add own organization fails
- Remove own organization fails
- Delete systemuser fails
- Add client fails
- Remove client fails
- Approve standard/agent/change request fails
- Reject standard/agent/change request fails
- Escalate standard/agent request fails (change request cannot be escalated)

## Related Issue(s)
- part of https://github.com/Altinn/altinn-authorization-tmp/issues/2968

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the error display for delegation checks with a cleaner, more consistent alert layout.
  * Updated escalation request validation errors to appear in a live region, helping assistive technologies announce changes more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->