### PR TITLE
call redirectToChangeReporteeAndRedirect if systemuser request is for a different party than selected party

### DIFF
--- a/src/features/amUI/common/RequestPageLayout/RequestPageLayout.tsx
+++ b/src/features/amUI/common/RequestPageLayout/RequestPageLayout.tsx
@@ -17,10 +17,16 @@ import { useGetUserProfileQuery } from '@/rtk/features/userInfoApi';
 
 import { getButtonIconSize } from '@/resources/utils/iconUtils';
 import { ArrowLeftIcon } from '@navikt/aksel-icons';
+import { useRedirectToRequestParty } from '@/resources/hooks/useRedirectToRequestParty';
 
 interface RequestPageLayoutProps {
   account: { name: string; type: 'person' | 'company' };
   isLoading: boolean;
+  /**
+   * The party the request belongs to. When it differs from the active reportee,
+   * the user is redirected to switch reportee before the page is shown.
+   */
+  requestPartyUuid?: string;
   error?: React.ReactNode;
   heading?: React.ReactNode;
   body?: React.ReactNode;
@@ -30,6 +36,7 @@ interface RequestPageLayoutProps {
 export const RequestPageLayout = ({
   account,
   isLoading,
+  requestPartyUuid,
   error,
   heading,
   body,
@@ -42,6 +49,12 @@ export const RequestPageLayout = ({
   const [updateSelectedLanguage] = useUpdateSelectedLanguageMutation();
 
   const { data: userData } = useGetUserProfileQuery();
+
+  const partyUuid = useRedirectToRequestParty(requestPartyUuid);
+  // While a reportee switch is pending, keep showing the loading state so the
+  // page content isn't shown for the wrong party before the redirect happens.
+  const isChangingParty = !!requestPartyUuid && requestPartyUuid !== partyUuid;
+  const showLoading = isLoading || isChangingParty;
 
   const onChangeLocale = (newLocale: string) => {
     i18n.changeLanguage(newLocale);
@@ -101,9 +114,9 @@ export const RequestPageLayout = ({
           },
         }}
       >
-        {isLoading && <LoadingState />}
-        {!isLoading && error && <div className={classes.centerBlock}>{error}</div>}
-        {heading && body && (
+        {showLoading && <LoadingState />}
+        {!showLoading && error && <div className={classes.centerBlock}>{error}</div>}
+        {!showLoading && heading && body && (
           <div className={classes.centerBlock}>
             {backToPage && (
               <DsButton

--- a/src/features/amUI/requestPage/DraftRequestPage/DraftRequestPage.tsx
+++ b/src/features/amUI/requestPage/DraftRequestPage/DraftRequestPage.tsx
@@ -83,9 +83,10 @@ export const DraftRequestPage = () => {
     }
   };
 
-  const isInitialLoad = isMultiMode
-    ? isLoadingMultiRequests || !!(multiRequests[0] && multiRequests[0].from.id !== partyUuid)
-    : isLoadingRequest || !!(request && request.from.id !== partyUuid);
+  // The pending reportee-switch ("changing party") state is handled centrally by
+  // RequestPageLayout via the requestPartyUuid prop, so it's intentionally not
+  // duplicated here.
+  const isInitialLoad = isMultiMode ? isLoadingMultiRequests : isLoadingRequest;
 
   const toName = formatDisplayName({
     fullName: representativeRequest?.to.name ?? '',

--- a/src/features/amUI/requestPage/DraftRequestPage/DraftRequestPage.tsx
+++ b/src/features/amUI/requestPage/DraftRequestPage/DraftRequestPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { DsAlert, DsParagraph, formatDisplayName } from '@altinn/altinn-components';
 import {
@@ -8,7 +8,6 @@ import {
   type EnrichedResourceRequest,
 } from '@/rtk/features/requestApi';
 import { useSearchParams } from 'react-router';
-import { redirectToChangeReporteeAndRedirect } from '@/resources/utils/changeReporteeUtils';
 import { getCookie } from '@/resources/Cookie/CookieMethods';
 import { RequestPageLayout } from '../../common/RequestPageLayout/RequestPageLayout';
 import { PartyRepresentationProvider } from '../../common/PartyRepresentationContext/PartyRepresentationContext';
@@ -83,13 +82,6 @@ export const DraftRequestPage = () => {
       withdrawRequest({ party: request.from.id, id: request.id });
     }
   };
-
-  useEffect(() => {
-    const fromId = representativeRequest?.from.id;
-    if (fromId && fromId !== partyUuid) {
-      redirectToChangeReporteeAndRedirect(fromId, window.location.href);
-    }
-  }, [representativeRequest, partyUuid]);
 
   const isInitialLoad = isMultiMode
     ? isLoadingMultiRequests || !!(multiRequests[0] && multiRequests[0].from.id !== partyUuid)
@@ -213,6 +205,7 @@ export const DraftRequestPage = () => {
       }}
       error={error}
       isLoading={isInitialLoad}
+      requestPartyUuid={representativeRequest?.from.id}
       heading={heading}
       body={body}
     />

--- a/src/features/amUI/systemUser/CreateSystemUserPage/RightsIncluded.tsx
+++ b/src/features/amUI/systemUser/CreateSystemUserPage/RightsIncluded.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useNavigate } from 'react-router';
-import { DsSpinner, DsAlert, DsButton } from '@altinn/altinn-components';
+import { DsSpinner, DsAlert, DsButton, formatDisplayName } from '@altinn/altinn-components';
 
 import {
   useCreateSystemUserMutation,
@@ -75,7 +75,10 @@ export const RightsIncluded = ({ selectedSystem, onNavigateBack }: RightsInclude
                 : 'systemuser_includedrightspage.header',
               {
                 integrationTitle: selectedSystem.name,
-                companyName: reporteeData?.name,
+                companyName: formatDisplayName({
+                  fullName: reporteeData?.name || '',
+                  type: 'company',
+                }),
               },
             )}
             avatarTitle={selectedSystem.name}

--- a/src/features/amUI/systemUser/CreateSystemUserPage/RightsIncluded.tsx
+++ b/src/features/amUI/systemUser/CreateSystemUserPage/RightsIncluded.tsx
@@ -6,7 +6,6 @@ import { DsSpinner, DsAlert, DsButton } from '@altinn/altinn-components';
 import {
   useCreateSystemUserMutation,
   useGetRegisteredSystemRightsQuery,
-  useGetSystemUserReporteeQuery,
 } from '@/rtk/features/systemUserApi';
 import { getCookie } from '@/resources/Cookie/CookieMethods';
 import { SystemUserPath } from '@/routes/paths';
@@ -19,6 +18,7 @@ import { ButtonRow } from '../components/ButtonRow/ButtonRow';
 import { SystemUserHeader } from '../components/SystemUserHeader/SystemUserHeader';
 
 import classes from './CreateSystemUser.module.css';
+import { useGetReporteeQuery } from '@/rtk/features/userInfoApi';
 
 interface RightsIncludedProps {
   selectedSystem: RegisteredSystem;
@@ -29,8 +29,7 @@ export const RightsIncluded = ({ selectedSystem, onNavigateBack }: RightsInclude
   const { t } = useTranslation();
   const navigate = useNavigate();
   const partyId = getCookie('AltinnPartyId');
-  const partyUuid = getCookie('AltinnPartyUuid');
-  const { data: reporteeData } = useGetSystemUserReporteeQuery(partyUuid);
+  const { data: reporteeData } = useGetReporteeQuery();
 
   const {
     data: rights,

--- a/src/features/amUI/systemUser/CreateSystemUserPage/SelectRegisteredSystem.tsx
+++ b/src/features/amUI/systemUser/CreateSystemUserPage/SelectRegisteredSystem.tsx
@@ -10,20 +10,16 @@ import {
   DsSpinner,
 } from '@altinn/altinn-components';
 
-import {
-  useGetRegisteredSystemsQuery,
-  useGetSystemUserReporteeQuery,
-} from '@/rtk/features/systemUserApi';
+import { useGetRegisteredSystemsQuery } from '@/rtk/features/systemUserApi';
 import { SystemUserPath } from '@/routes/paths';
 import { PageContainer } from '@/features/amUI/common/PageContainer/PageContainer';
-import { getCookie } from '@/resources/Cookie/CookieMethods';
 
 import { ButtonRow } from '../components/ButtonRow/ButtonRow';
 import type { RegisteredSystem } from '../types';
 import { CreateSystemUserCheck } from '../components/CreateSystemUserCheck/CreateSystemUserCheck';
 
 import classes from './CreateSystemUser.module.css';
-import { useGetIsAdminQuery } from '@/rtk/features/userInfoApi';
+import { useGetIsAdminQuery, useGetReporteeQuery } from '@/rtk/features/userInfoApi';
 
 const isStringMatch = (inputString: string, matchString = ''): boolean => {
   return matchString.toLowerCase().indexOf(inputString.toLowerCase()) >= 0;
@@ -41,9 +37,7 @@ export const SelectRegisteredSystem = ({
   handleConfirm,
 }: SelectRegisteredSystemProps) => {
   const { t } = useTranslation();
-  const partyUuid = getCookie('AltinnPartyUuid');
-  const { data: reporteeData, isLoading: isLoadingReportee } =
-    useGetSystemUserReporteeQuery(partyUuid);
+  const { data: reporteeData, isLoading: isLoadingReportee } = useGetReporteeQuery();
 
   const {
     data: registeredSystems,

--- a/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPage.tsx
@@ -8,7 +8,6 @@ import {
   useGetAgentSystemUserQuery,
   useGetCustomersQuery,
   useDeleteAgentSystemuserMutation,
-  useGetSystemUserReporteeQuery,
 } from '@/rtk/features/systemUserApi';
 import { getCookie } from '@/resources/Cookie/CookieMethods';
 import { PageWrapper } from '@/components';
@@ -24,7 +23,11 @@ import { PageContainer } from '../../common/PageContainer/PageContainer';
 import { SystemUserPath } from '@/routes/paths';
 import { hasCreateSystemUserPermission } from '@/resources/utils/permissionUtils';
 import { DeleteSystemUserPopover } from '../components/DeleteSystemUserPopover/DeleteSystemUserPopover';
-import { useGetIsAdminQuery, useGetIsClientAdminQuery } from '@/rtk/features/userInfoApi';
+import {
+  useGetIsAdminQuery,
+  useGetIsClientAdminQuery,
+  useGetReporteeQuery,
+} from '@/rtk/features/userInfoApi';
 
 export const SystemUserAgentDelegationPage = (): React.ReactNode => {
   const { id } = useParams();
@@ -36,7 +39,7 @@ export const SystemUserAgentDelegationPage = (): React.ReactNode => {
 
   useDocumentTitle(t('systemuser_agent_delegation.page_title'));
 
-  const { data: reporteeData } = useGetSystemUserReporteeQuery(partyUuid);
+  const { data: reporteeData } = useGetReporteeQuery();
   const { data: isAdmin } = useGetIsAdminQuery();
   const { data: isClientAdmin } = useGetIsClientAdminQuery();
 

--- a/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPageContent.tsx
+++ b/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPageContent.tsx
@@ -8,6 +8,7 @@ import {
   DsDialog,
   DsHeading,
   DsParagraph,
+  formatDisplayName,
   useSnackbar,
 } from '@altinn/altinn-components';
 
@@ -99,6 +100,7 @@ export const SystemUserAgentDelegationPageContent = ({
   );
 
   const isAddingAllCustomers = addAllState.maxCount > -1;
+  const reporteeName = formatDisplayName({ fullName: reporteeData?.name || '', type: 'company' });
 
   const resetLoadingId = (customerId: string): void => {
     setLoadingIds((oldLoadingIds) => oldLoadingIds.filter((id) => id !== customerId));
@@ -261,7 +263,7 @@ export const SystemUserAgentDelegationPageContent = ({
       ? [
           {
             id: reporteeData.partyUuid,
-            name: reporteeData.name,
+            name: reporteeName,
             orgNo: reporteeData.organizationNumber || '',
             unitType: reporteeData.unitType,
             access: [],
@@ -306,10 +308,10 @@ export const SystemUserAgentDelegationPageContent = ({
                 onRemoveCustomer={onRemoveCustomer}
                 onAddAllCustomers={onAddAllCustomers}
               />
-              {customers.length === 0 && reporteeData?.name && (
+              {customers.length === 0 && reporteeName && (
                 <DsAlert data-color='warning'>
                   {t('systemuser_agent_delegation.no_customers_warning', {
-                    companyName: reporteeData?.name,
+                    companyName: reporteeName,
                   })}
                 </DsAlert>
               )}
@@ -327,7 +329,7 @@ export const SystemUserAgentDelegationPageContent = ({
       <div className={classes.flexContainer}>
         <SystemUserHeader
           title={systemUser.integrationTitle}
-          subTitle={reporteeData?.name}
+          subTitle={reporteeName}
         />
         <DsHeading
           level={2}

--- a/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPageContent.tsx
+++ b/src/features/amUI/systemUser/SystemUserAgentDelegationPage/SystemUserAgentDelegationPageContent.tsx
@@ -8,14 +8,12 @@ import {
   DsDialog,
   DsHeading,
   DsParagraph,
-  Snackbar,
   useSnackbar,
 } from '@altinn/altinn-components';
 
 import {
   useAssignCustomerMutation,
   useAssignSelfCustomerMutation,
-  useGetSystemUserReporteeQuery,
   useIsSelfAddedQuery,
   useRemoveCustomerMutation,
   useRemoveSelfCustomerMutation,
@@ -26,7 +24,11 @@ import type { AgentDelegation, AgentDelegationCustomer, ProblemDetail, SystemUse
 import { RightsList } from '../components/RightsList/RightsList';
 import classes from './SystemUserAgentDelegationPage.module.css';
 import { CustomerList } from './CustomerList';
-import { useGetIsAdminQuery, useGetIsClientAdminQuery } from '@/rtk/features/userInfoApi';
+import {
+  useGetIsAdminQuery,
+  useGetIsClientAdminQuery,
+  useGetReporteeQuery,
+} from '@/rtk/features/userInfoApi';
 import { AddAllCustomers } from './AddAllCustomers';
 import { DelegationCheckError } from '../components/DelegationCheckError/DelegationCheckError';
 import { enableAddSelfToSystemuser } from '@/resources/utils/featureFlagUtils';
@@ -73,7 +75,7 @@ export const SystemUserAgentDelegationPageContent = ({
 
   const { data: isClientAdmin } = useGetIsClientAdminQuery();
   const { data: isAdmin } = useGetIsAdminQuery();
-  const { data: reporteeData } = useGetSystemUserReporteeQuery(partyUuid);
+  const { data: reporteeData } = useGetReporteeQuery();
 
   const [assignCustomer] = useAssignCustomerMutation();
   const [removeCustomer] = useRemoveCustomerMutation();

--- a/src/features/amUI/systemUser/SystemUserAgentRequestPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserAgentRequestPage.tsx
@@ -27,7 +27,6 @@ import { RightsList } from './components/RightsList/RightsList';
 import { getLogoutUrl } from '@/resources/utils/pathUtils';
 import { SystemUserRequestLoadError } from './components/SystemUserRequestLoadError/SystemUserRequestLoadError';
 import { enableAddSelfToSystemuser } from '@/resources/utils/featureFlagUtils';
-import { useRedirectToRequestParty } from '@/resources/hooks/useRedirectToRequestParty';
 import { useGetIsAdminQuery, useGetReporteeQuery } from '@/rtk/features/userInfoApi';
 
 export const SystemUserAgentRequestPage = () => {
@@ -54,8 +53,6 @@ export const SystemUserAgentRequestPage = () => {
     error: loadReporteeError,
   } = useGetReporteeQuery();
   const { data: isAdmin } = useGetIsAdminQuery();
-
-  const partyUuid = useRedirectToRequestParty(request?.partyUuid);
 
   const [
     postAcceptCreationRequest,
@@ -120,7 +117,8 @@ export const SystemUserAgentRequestPage = () => {
     <RequestPageBase
       system={request?.system}
       reportee={reporteeData}
-      isLoading={isLoadingRequest || isLoadingReportee || request?.partyUuid !== partyUuid}
+      isLoading={isLoadingRequest || isLoadingReportee}
+      requestPartyUuid={request?.partyUuid}
       error={error}
       heading={t('systemuser_agent_request.banner_title')}
     >

--- a/src/features/amUI/systemUser/SystemUserAgentRequestPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserAgentRequestPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useTranslation, Trans } from 'react-i18next';
 import { useNavigate, useSearchParams } from 'react-router';
 import { DsAlert, DsHeading, DsParagraph, DsButton } from '@altinn/altinn-components';
@@ -7,8 +7,6 @@ import {
   useGetAgentSystemUserRequestQuery,
   useApproveAgentSystemUserRequestMutation,
   useRejectAgentSystemUserRequestMutation,
-  useGetSystemUserReporteeQuery,
-  useGetSystemuserIsAdminQuery,
 } from '@/rtk/features/systemUserApi';
 import { useDocumentTitle } from '@/resources/hooks/useDocumentTitle';
 import { RequestPageBase } from './components/RequestPageBase/RequestPageBase';
@@ -23,11 +21,15 @@ import { RightsList } from './components/RightsList/RightsList';
 import { getLogoutUrl } from '@/resources/utils/pathUtils';
 import { SystemUserRequestLoadError } from './components/SystemUserRequestLoadError/SystemUserRequestLoadError';
 import { enableAddSelfToSystemuser } from '@/resources/utils/featureFlagUtils';
+import { redirectToChangeReporteeAndRedirect } from '@/resources/utils/changeReporteeUtils';
+import { useGetIsAdminQuery, useGetReporteeQuery } from '@/rtk/features/userInfoApi';
+import { getCookie } from '@/resources/Cookie/CookieMethods';
 
 export const SystemUserAgentRequestPage = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   useDocumentTitle(t('systemuser_agent_request.page_title'));
+  const partyUuid = getCookie('AltinnPartyUuid');
   const [searchParams] = useSearchParams();
   const skipLogout = searchParams.get('skiplogout');
   const requestId = searchParams.get('id') ?? '';
@@ -46,12 +48,14 @@ export const SystemUserAgentRequestPage = () => {
     data: reporteeData,
     isLoading: isLoadingReportee,
     error: loadReporteeError,
-  } = useGetSystemUserReporteeQuery(request?.partyUuid ?? '', {
-    skip: !request?.partyUuid,
-  });
-  const { data: isAdmin } = useGetSystemuserIsAdminQuery(request?.partyUuid ?? '', {
-    skip: !request?.partyUuid,
-  });
+  } = useGetReporteeQuery();
+  const { data: isAdmin } = useGetIsAdminQuery();
+
+  useEffect(() => {
+    if (request?.partyUuid && request?.partyUuid !== partyUuid) {
+      redirectToChangeReporteeAndRedirect(request.partyUuid, window.location.href);
+    }
+  }, [request?.partyUuid, partyUuid]);
 
   const [
     postAcceptCreationRequest,
@@ -116,7 +120,7 @@ export const SystemUserAgentRequestPage = () => {
     <RequestPageBase
       system={request?.system}
       reportee={reporteeData}
-      isLoading={isLoadingRequest || isLoadingReportee}
+      isLoading={isLoadingRequest || isLoadingReportee || request?.partyUuid !== partyUuid}
       error={error}
       heading={t('systemuser_agent_request.banner_title')}
     >

--- a/src/features/amUI/systemUser/SystemUserAgentRequestPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserAgentRequestPage.tsx
@@ -1,7 +1,13 @@
 import React, { useEffect } from 'react';
 import { useTranslation, Trans } from 'react-i18next';
 import { useNavigate, useSearchParams } from 'react-router';
-import { DsAlert, DsHeading, DsParagraph, DsButton } from '@altinn/altinn-components';
+import {
+  DsAlert,
+  DsHeading,
+  DsParagraph,
+  DsButton,
+  formatDisplayName,
+} from '@altinn/altinn-components';
 
 import {
   useGetAgentSystemUserRequestQuery,
@@ -148,7 +154,7 @@ export const SystemUserAgentRequestPage = () => {
               i18nKey={'systemuser_agent_request.system_description'}
               values={{
                 vendorName: request.system.name,
-                companyName: reporteeData?.name,
+                companyName: formatDisplayName({ fullName: reporteeData?.name, type: 'company' }),
                 addSelfInfo:
                   request.accessPackages.every((p) => p.isAssignable) && enableAddSelfToSystemuser()
                     ? t('systemuser_agent_request.add_self_possible')

--- a/src/features/amUI/systemUser/SystemUserAgentRequestPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserAgentRequestPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useTranslation, Trans } from 'react-i18next';
 import { useNavigate, useSearchParams } from 'react-router';
 import {
@@ -27,15 +27,13 @@ import { RightsList } from './components/RightsList/RightsList';
 import { getLogoutUrl } from '@/resources/utils/pathUtils';
 import { SystemUserRequestLoadError } from './components/SystemUserRequestLoadError/SystemUserRequestLoadError';
 import { enableAddSelfToSystemuser } from '@/resources/utils/featureFlagUtils';
-import { redirectToChangeReporteeAndRedirect } from '@/resources/utils/changeReporteeUtils';
+import { useRedirectToRequestParty } from '@/resources/hooks/useRedirectToRequestParty';
 import { useGetIsAdminQuery, useGetReporteeQuery } from '@/rtk/features/userInfoApi';
-import { getCookie } from '@/resources/Cookie/CookieMethods';
 
 export const SystemUserAgentRequestPage = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   useDocumentTitle(t('systemuser_agent_request.page_title'));
-  const partyUuid = getCookie('AltinnPartyUuid');
   const [searchParams] = useSearchParams();
   const skipLogout = searchParams.get('skiplogout');
   const requestId = searchParams.get('id') ?? '';
@@ -57,11 +55,7 @@ export const SystemUserAgentRequestPage = () => {
   } = useGetReporteeQuery();
   const { data: isAdmin } = useGetIsAdminQuery();
 
-  useEffect(() => {
-    if (request?.partyUuid && request?.partyUuid !== partyUuid) {
-      redirectToChangeReporteeAndRedirect(request.partyUuid, window.location.href);
-    }
-  }, [request?.partyUuid, partyUuid]);
+  const partyUuid = useRedirectToRequestParty(request?.partyUuid);
 
   const [
     postAcceptCreationRequest,

--- a/src/features/amUI/systemUser/SystemUserChangeRequestPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserChangeRequestPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useTranslation, Trans } from 'react-i18next';
 import { useSearchParams } from 'react-router';
 import {
@@ -24,14 +24,12 @@ import { CreateSystemUserCheck } from './components/CreateSystemUserCheck/Create
 import type { ServiceResource } from '@/rtk/features/singleRights/singleRightsApi';
 import { getLogoutUrl } from '@/resources/utils/pathUtils';
 import { SystemUserRequestLoadError } from './components/SystemUserRequestLoadError/SystemUserRequestLoadError';
-import { redirectToChangeReporteeAndRedirect } from '@/resources/utils/changeReporteeUtils';
+import { useRedirectToRequestParty } from '@/resources/hooks/useRedirectToRequestParty';
 import { useGetIsAdminQuery, useGetReporteeQuery } from '@/rtk/features/userInfoApi';
-import { getCookie } from '@/resources/Cookie/CookieMethods';
 
 export const SystemUserChangeRequestPage = () => {
   const { t } = useTranslation();
   useDocumentTitle(t('systemuser_change_request.page_title'));
-  const partyUuid = getCookie('AltinnPartyUuid');
   const [searchParams] = useSearchParams();
   const changeRequestId = searchParams.get('id') ?? '';
 
@@ -52,11 +50,7 @@ export const SystemUserChangeRequestPage = () => {
   } = useGetReporteeQuery();
   const { data: isAdmin } = useGetIsAdminQuery();
 
-  useEffect(() => {
-    if (changeRequest?.partyUuid && changeRequest?.partyUuid !== partyUuid) {
-      redirectToChangeReporteeAndRedirect(changeRequest.partyUuid, window.location.href);
-    }
-  }, [changeRequest?.partyUuid, partyUuid]);
+  const partyUuid = useRedirectToRequestParty(changeRequest?.partyUuid);
 
   const [
     postAcceptChangeRequest,

--- a/src/features/amUI/systemUser/SystemUserChangeRequestPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserChangeRequestPage.tsx
@@ -1,7 +1,13 @@
 import React, { useEffect } from 'react';
 import { useTranslation, Trans } from 'react-i18next';
 import { useSearchParams } from 'react-router';
-import { DsAlert, DsHeading, DsParagraph, DsButton } from '@altinn/altinn-components';
+import {
+  DsAlert,
+  DsHeading,
+  DsParagraph,
+  DsButton,
+  formatDisplayName,
+} from '@altinn/altinn-components';
 import { useDocumentTitle } from '@/resources/hooks/useDocumentTitle';
 import {
   useApproveChangeRequestMutation,
@@ -139,7 +145,7 @@ export const SystemUserChangeRequestPage = () => {
               i18nKey={'systemuser_request.system_description'}
               values={{
                 systemName: changeRequest.system.name,
-                partyName: reporteeData?.name,
+                partyName: formatDisplayName({ fullName: reporteeData?.name, type: 'company' }),
               }}
             ></Trans>
           </DsParagraph>

--- a/src/features/amUI/systemUser/SystemUserChangeRequestPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserChangeRequestPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useTranslation, Trans } from 'react-i18next';
 import { useSearchParams } from 'react-router';
 import { DsAlert, DsHeading, DsParagraph, DsButton } from '@altinn/altinn-components';
@@ -6,8 +6,6 @@ import { useDocumentTitle } from '@/resources/hooks/useDocumentTitle';
 import {
   useApproveChangeRequestMutation,
   useGetChangeRequestQuery,
-  useGetSystemuserIsAdminQuery,
-  useGetSystemUserReporteeQuery,
   useRejectChangeRequestMutation,
 } from '@/rtk/features/systemUserApi';
 import { RequestPageBase } from './components/RequestPageBase/RequestPageBase';
@@ -20,10 +18,14 @@ import { CreateSystemUserCheck } from './components/CreateSystemUserCheck/Create
 import type { ServiceResource } from '@/rtk/features/singleRights/singleRightsApi';
 import { getLogoutUrl } from '@/resources/utils/pathUtils';
 import { SystemUserRequestLoadError } from './components/SystemUserRequestLoadError/SystemUserRequestLoadError';
+import { redirectToChangeReporteeAndRedirect } from '@/resources/utils/changeReporteeUtils';
+import { useGetIsAdminQuery, useGetReporteeQuery } from '@/rtk/features/userInfoApi';
+import { getCookie } from '@/resources/Cookie/CookieMethods';
 
 export const SystemUserChangeRequestPage = () => {
   const { t } = useTranslation();
   useDocumentTitle(t('systemuser_change_request.page_title'));
+  const partyUuid = getCookie('AltinnPartyUuid');
   const [searchParams] = useSearchParams();
   const changeRequestId = searchParams.get('id') ?? '';
 
@@ -41,12 +43,14 @@ export const SystemUserChangeRequestPage = () => {
     data: reporteeData,
     isLoading: isLoadingReportee,
     error: loadReporteeError,
-  } = useGetSystemUserReporteeQuery(changeRequest?.partyUuid ?? '', {
-    skip: !changeRequest?.partyUuid,
-  });
-  const { data: isAdmin } = useGetSystemuserIsAdminQuery(changeRequest?.partyUuid ?? '', {
-    skip: !changeRequest?.partyUuid,
-  });
+  } = useGetReporteeQuery();
+  const { data: isAdmin } = useGetIsAdminQuery();
+
+  useEffect(() => {
+    if (changeRequest?.partyUuid && changeRequest?.partyUuid !== partyUuid) {
+      redirectToChangeReporteeAndRedirect(changeRequest.partyUuid, window.location.href);
+    }
+  }, [changeRequest?.partyUuid, partyUuid]);
 
   const [
     postAcceptChangeRequest,
@@ -105,7 +109,9 @@ export const SystemUserChangeRequestPage = () => {
     <RequestPageBase
       system={changeRequest?.system}
       reportee={reporteeData}
-      isLoading={isLoadingChangeRequest || isLoadingReportee}
+      isLoading={
+        isLoadingChangeRequest || isLoadingReportee || changeRequest?.partyUuid !== partyUuid
+      }
       error={error}
       heading={t('systemuser_change_request.banner_title')}
     >

--- a/src/features/amUI/systemUser/SystemUserChangeRequestPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserChangeRequestPage.tsx
@@ -24,7 +24,6 @@ import { CreateSystemUserCheck } from './components/CreateSystemUserCheck/Create
 import type { ServiceResource } from '@/rtk/features/singleRights/singleRightsApi';
 import { getLogoutUrl } from '@/resources/utils/pathUtils';
 import { SystemUserRequestLoadError } from './components/SystemUserRequestLoadError/SystemUserRequestLoadError';
-import { useRedirectToRequestParty } from '@/resources/hooks/useRedirectToRequestParty';
 import { useGetIsAdminQuery, useGetReporteeQuery } from '@/rtk/features/userInfoApi';
 
 export const SystemUserChangeRequestPage = () => {
@@ -49,8 +48,6 @@ export const SystemUserChangeRequestPage = () => {
     error: loadReporteeError,
   } = useGetReporteeQuery();
   const { data: isAdmin } = useGetIsAdminQuery();
-
-  const partyUuid = useRedirectToRequestParty(changeRequest?.partyUuid);
 
   const [
     postAcceptChangeRequest,
@@ -109,9 +106,8 @@ export const SystemUserChangeRequestPage = () => {
     <RequestPageBase
       system={changeRequest?.system}
       reportee={reporteeData}
-      isLoading={
-        isLoadingChangeRequest || isLoadingReportee || changeRequest?.partyUuid !== partyUuid
-      }
+      isLoading={isLoadingChangeRequest || isLoadingReportee}
+      requestPartyUuid={changeRequest?.partyUuid}
       error={error}
       heading={t('systemuser_change_request.banner_title')}
     >

--- a/src/features/amUI/systemUser/SystemUserDetailPage/SystemUserDetailsPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserDetailPage/SystemUserDetailsPage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router';
-import { DsAlert, DsParagraph } from '@altinn/altinn-components';
+import { DsAlert, DsParagraph, formatDisplayName } from '@altinn/altinn-components';
 
 import { useDeleteSystemuserMutation, useGetSystemUserQuery } from '@/rtk/features/systemUserApi';
 import { getCookie } from '@/resources/Cookie/CookieMethods';
@@ -78,7 +78,10 @@ export const SystemUserDetailsPage = (): React.ReactNode => {
             <div className={classes.systemUserDetails}>
               <SystemUserHeader
                 title={systemUser?.integrationTitle ?? ''}
-                subTitle={reporteeData?.name}
+                subTitle={formatDisplayName({
+                  fullName: reporteeData?.name || '',
+                  type: 'company',
+                })}
                 isLoading={isLoadingSystemUser}
               />
               <RightsList

--- a/src/features/amUI/systemUser/SystemUserDetailPage/SystemUserDetailsPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserDetailPage/SystemUserDetailsPage.tsx
@@ -3,11 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router';
 import { DsAlert, DsParagraph } from '@altinn/altinn-components';
 
-import {
-  useDeleteSystemuserMutation,
-  useGetSystemUserQuery,
-  useGetSystemUserReporteeQuery,
-} from '@/rtk/features/systemUserApi';
+import { useDeleteSystemuserMutation, useGetSystemUserQuery } from '@/rtk/features/systemUserApi';
 import { getCookie } from '@/resources/Cookie/CookieMethods';
 import { PageLayoutWrapper } from '@/features/amUI/common/PageLayoutWrapper';
 import { PageWrapper } from '@/components';
@@ -22,7 +18,7 @@ import { RightsList } from '../components/RightsList/RightsList';
 import classes from './SystemUserDetailsPage.module.css';
 import { hasCreateSystemUserPermission } from '@/resources/utils/permissionUtils';
 import { Breadcrumbs } from '../../common/Breadcrumbs/Breadcrumbs';
-import { useGetIsAdminQuery } from '@/rtk/features/userInfoApi';
+import { useGetIsAdminQuery, useGetReporteeQuery } from '@/rtk/features/userInfoApi';
 
 export const SystemUserDetailsPage = (): React.ReactNode => {
   const { t } = useTranslation();
@@ -30,10 +26,9 @@ export const SystemUserDetailsPage = (): React.ReactNode => {
   const navigate = useNavigate();
   useDocumentTitle(t('systemuser_detailpage.page_title'));
   const partyId = getCookie('AltinnPartyId');
-  const partyUuid = getCookie('AltinnPartyUuid');
   const backUrl = `/${SystemUserPath.SystemUser}/${SystemUserPath.Overview}`;
 
-  const { data: reporteeData } = useGetSystemUserReporteeQuery(partyUuid);
+  const { data: reporteeData } = useGetReporteeQuery();
   const { data: isAdmin } = useGetIsAdminQuery();
 
   const {

--- a/src/features/amUI/systemUser/SystemUserRequestPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserRequestPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useTranslation, Trans } from 'react-i18next';
 import { useNavigate, useSearchParams } from 'react-router';
 import {
@@ -26,14 +26,12 @@ import { getApiBaseUrl } from './requestUtils';
 import { getLogoutUrl } from '@/resources/utils/pathUtils';
 import { SystemUserRequestLoadError } from './components/SystemUserRequestLoadError/SystemUserRequestLoadError';
 import { useGetIsAdminQuery, useGetReporteeQuery } from '@/rtk/features/userInfoApi';
-import { getCookie } from '@/resources/Cookie/CookieMethods';
-import { redirectToChangeReporteeAndRedirect } from '@/resources/utils/changeReporteeUtils';
+import { useRedirectToRequestParty } from '@/resources/hooks/useRedirectToRequestParty';
 
 export const SystemUserRequestPage = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   useDocumentTitle(t('systemuser_request.page_title'));
-  const partyUuid = getCookie('AltinnPartyUuid');
   const [searchParams] = useSearchParams();
   const skipLogout = searchParams.get('skiplogout');
   const requestId = searchParams.get('id') ?? '';
@@ -55,11 +53,7 @@ export const SystemUserRequestPage = () => {
   } = useGetReporteeQuery();
   const { data: isAdmin } = useGetIsAdminQuery();
 
-  useEffect(() => {
-    if (request?.partyUuid && request?.partyUuid !== partyUuid) {
-      redirectToChangeReporteeAndRedirect(request.partyUuid, window.location.href);
-    }
-  }, [request?.partyUuid, partyUuid]);
+  const partyUuid = useRedirectToRequestParty(request?.partyUuid);
 
   const [
     postAcceptCreationRequest,

--- a/src/features/amUI/systemUser/SystemUserRequestPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserRequestPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useTranslation, Trans } from 'react-i18next';
 import { useNavigate, useSearchParams } from 'react-router';
 import { DsAlert, DsHeading, DsParagraph, DsButton } from '@altinn/altinn-components';
@@ -7,8 +7,6 @@ import {
   useGetSystemUserRequestQuery,
   useApproveSystemUserRequestMutation,
   useRejectSystemUserRequestMutation,
-  useGetSystemUserReporteeQuery,
-  useGetSystemuserIsAdminQuery,
 } from '@/rtk/features/systemUserApi';
 import { RequestPageBase } from './components/RequestPageBase/RequestPageBase';
 import type { ProblemDetail } from './types';
@@ -21,11 +19,15 @@ import { SystemUserPath } from '@/routes/paths';
 import { getApiBaseUrl } from './requestUtils';
 import { getLogoutUrl } from '@/resources/utils/pathUtils';
 import { SystemUserRequestLoadError } from './components/SystemUserRequestLoadError/SystemUserRequestLoadError';
+import { useGetIsAdminQuery, useGetReporteeQuery } from '@/rtk/features/userInfoApi';
+import { getCookie } from '@/resources/Cookie/CookieMethods';
+import { redirectToChangeReporteeAndRedirect } from '@/resources/utils/changeReporteeUtils';
 
 export const SystemUserRequestPage = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   useDocumentTitle(t('systemuser_request.page_title'));
+  const partyUuid = getCookie('AltinnPartyUuid');
   const [searchParams] = useSearchParams();
   const skipLogout = searchParams.get('skiplogout');
   const requestId = searchParams.get('id') ?? '';
@@ -44,12 +46,14 @@ export const SystemUserRequestPage = () => {
     data: reporteeData,
     isLoading: isLoadingReportee,
     error: loadReporteeError,
-  } = useGetSystemUserReporteeQuery(request?.partyUuid ?? '', {
-    skip: !request?.partyUuid,
-  });
-  const { data: isAdmin } = useGetSystemuserIsAdminQuery(request?.partyUuid ?? '', {
-    skip: !request?.partyUuid,
-  });
+  } = useGetReporteeQuery();
+  const { data: isAdmin } = useGetIsAdminQuery();
+
+  useEffect(() => {
+    if (request?.partyUuid && request?.partyUuid !== partyUuid) {
+      redirectToChangeReporteeAndRedirect(request.partyUuid, window.location.href);
+    }
+  }, [request?.partyUuid, partyUuid]);
 
   const [
     postAcceptCreationRequest,
@@ -114,7 +118,7 @@ export const SystemUserRequestPage = () => {
     <RequestPageBase
       system={request?.system}
       reportee={reporteeData}
-      isLoading={isLoadingRequest || isLoadingReportee}
+      isLoading={isLoadingRequest || isLoadingReportee || request?.partyUuid !== partyUuid}
       error={error}
       heading={t('systemuser_request.banner_title')}
     >

--- a/src/features/amUI/systemUser/SystemUserRequestPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserRequestPage.tsx
@@ -26,7 +26,6 @@ import { getApiBaseUrl } from './requestUtils';
 import { getLogoutUrl } from '@/resources/utils/pathUtils';
 import { SystemUserRequestLoadError } from './components/SystemUserRequestLoadError/SystemUserRequestLoadError';
 import { useGetIsAdminQuery, useGetReporteeQuery } from '@/rtk/features/userInfoApi';
-import { useRedirectToRequestParty } from '@/resources/hooks/useRedirectToRequestParty';
 
 export const SystemUserRequestPage = () => {
   const { t } = useTranslation();
@@ -52,8 +51,6 @@ export const SystemUserRequestPage = () => {
     error: loadReporteeError,
   } = useGetReporteeQuery();
   const { data: isAdmin } = useGetIsAdminQuery();
-
-  const partyUuid = useRedirectToRequestParty(request?.partyUuid);
 
   const [
     postAcceptCreationRequest,
@@ -118,7 +115,8 @@ export const SystemUserRequestPage = () => {
     <RequestPageBase
       system={request?.system}
       reportee={reporteeData}
-      isLoading={isLoadingRequest || isLoadingReportee || request?.partyUuid !== partyUuid}
+      isLoading={isLoadingRequest || isLoadingReportee}
+      requestPartyUuid={request?.partyUuid}
       error={error}
       heading={t('systemuser_request.banner_title')}
     >

--- a/src/features/amUI/systemUser/SystemUserRequestPage.tsx
+++ b/src/features/amUI/systemUser/SystemUserRequestPage.tsx
@@ -1,7 +1,13 @@
 import React, { useEffect } from 'react';
 import { useTranslation, Trans } from 'react-i18next';
 import { useNavigate, useSearchParams } from 'react-router';
-import { DsAlert, DsHeading, DsParagraph, DsButton } from '@altinn/altinn-components';
+import {
+  DsAlert,
+  DsHeading,
+  DsParagraph,
+  DsButton,
+  formatDisplayName,
+} from '@altinn/altinn-components';
 import { useDocumentTitle } from '@/resources/hooks/useDocumentTitle';
 import {
   useGetSystemUserRequestQuery,
@@ -146,7 +152,7 @@ export const SystemUserRequestPage = () => {
               i18nKey={'systemuser_request.system_description'}
               values={{
                 systemName: request.system.name,
-                partyName: reporteeData?.name,
+                partyName: formatDisplayName({ fullName: reporteeData?.name, type: 'company' }),
               }}
             ></Trans>
           </DsParagraph>

--- a/src/features/amUI/systemUser/SystemUsersOverviewPage/SystemUserOverviewPage.tsx
+++ b/src/features/amUI/systemUser/SystemUsersOverviewPage/SystemUserOverviewPage.tsx
@@ -17,7 +17,6 @@ import { PageWrapper } from '@/components';
 import {
   useGetAgentSystemUsersQuery,
   useGetPendingSystemUserRequestsQuery,
-  useGetSystemUserReporteeQuery,
   useGetSystemUsersQuery,
 } from '@/rtk/features/systemUserApi';
 import { getCookie } from '@/resources/Cookie/CookieMethods';
@@ -25,7 +24,11 @@ import { SystemUserPath } from '@/routes/paths';
 import { PageLayoutWrapper } from '@/features/amUI/common/PageLayoutWrapper';
 
 import classes from './SystemUserOverviewPage.module.css';
-import { useGetIsAdminQuery, useGetIsClientAdminQuery } from '@/rtk/features/userInfoApi';
+import {
+  useGetIsAdminQuery,
+  useGetIsClientAdminQuery,
+  useGetReporteeQuery,
+} from '@/rtk/features/userInfoApi';
 import { hasCreateSystemUserPermission } from '@/resources/utils/permissionUtils';
 import { SystemUserList } from './SystemUserList';
 import { Breadcrumbs } from '../../common/Breadcrumbs/Breadcrumbs';
@@ -40,8 +43,7 @@ export const SystemUserOverviewPage = () => {
 
   const { data: isAdmin, isLoading: isLoadingIsAdmin } = useGetIsAdminQuery();
   const { data: isClientAdmin, isLoading: isLoadingClientAdmin } = useGetIsClientAdminQuery();
-  const { data: reporteeData, isLoading: isLoadingReportee } =
-    useGetSystemUserReporteeQuery(partyUuid);
+  const { data: reporteeData, isLoading: isLoadingReportee } = useGetReporteeQuery();
 
   // load only for isAdmin
   const {

--- a/src/features/amUI/systemUser/components/RequestPageBase/RequestPageBase.tsx
+++ b/src/features/amUI/systemUser/components/RequestPageBase/RequestPageBase.tsx
@@ -12,6 +12,7 @@ interface RequestPageBaseProps {
   heading: string;
   reportee?: ReporteeInfo;
   isLoading?: boolean;
+  requestPartyUuid?: string;
   error?: React.ReactNode;
   children: React.ReactNode | React.ReactNode[];
 }
@@ -21,6 +22,7 @@ export const RequestPageBase = ({
   heading,
   reportee,
   isLoading,
+  requestPartyUuid,
   error,
   children,
 }: RequestPageBaseProps): React.ReactNode => {
@@ -35,6 +37,7 @@ export const RequestPageBase = ({
     <RequestPageLayout
       account={account}
       isLoading={isLoading ?? false}
+      requestPartyUuid={requestPartyUuid}
       error={error}
       heading={
         <DsHeading

--- a/src/resources/hooks/useRedirectToRequestParty.ts
+++ b/src/resources/hooks/useRedirectToRequestParty.ts
@@ -4,9 +4,9 @@ import { getCookie } from '@/resources/Cookie/CookieMethods';
 import { redirectToChangeReporteeAndRedirect } from '@/resources/utils/changeReporteeUtils';
 
 /**
- * Redirects the user to change their active reportee when a system user request
- * belongs to a different party than the one currently selected, then returns to
- * the current page once the reportee has been switched.
+ * Redirects the user to change their active reportee when a request belongs to a
+ * different party than the one currently selected, then returns to the current
+ * page once the reportee has been switched.
  *
  * @param requestPartyUuid the party the request belongs to (from the loaded request)
  * @returns the currently selected party uuid (from the `AltinnPartyUuid` cookie)

--- a/src/resources/hooks/useRedirectToRequestParty.ts
+++ b/src/resources/hooks/useRedirectToRequestParty.ts
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+
+import { getCookie } from '@/resources/Cookie/CookieMethods';
+import { redirectToChangeReporteeAndRedirect } from '@/resources/utils/changeReporteeUtils';
+
+/**
+ * Redirects the user to change their active reportee when a system user request
+ * belongs to a different party than the one currently selected, then returns to
+ * the current page once the reportee has been switched.
+ *
+ * @param requestPartyUuid the party the request belongs to (from the loaded request)
+ * @returns the currently selected party uuid (from the `AltinnPartyUuid` cookie)
+ */
+export const useRedirectToRequestParty = (requestPartyUuid: string | undefined): string | null => {
+  const partyUuid = getCookie('AltinnPartyUuid');
+
+  useEffect(() => {
+    if (requestPartyUuid && requestPartyUuid !== partyUuid) {
+      redirectToChangeReporteeAndRedirect(requestPartyUuid, window.location.href);
+    }
+  }, [requestPartyUuid, partyUuid]);
+
+  return partyUuid;
+};

--- a/src/rtk/features/systemUserApi.ts
+++ b/src/rtk/features/systemUserApi.ts
@@ -11,7 +11,6 @@ import type {
   SystemUserChangeRequest,
 } from '@/features/amUI/systemUser/types';
 
-import type { ReporteeInfo } from './userInfoApi';
 import { formatDisplayName } from '@altinn/altinn-components';
 
 const baseUrl = `${import.meta.env.BASE_URL}accessmanagement/api/v1/`;
@@ -49,21 +48,6 @@ export const systemUserApi = createApi({
   }),
   tagTypes: [Tags.SystemUsers, Tags.PendingSystemUsers],
   endpoints: (builder) => ({
-    // system user reportee
-    getSystemUserReportee: builder.query<ReporteeInfo, string>({
-      keepUnusedDataFor: 300,
-      query: (partyUuid) => `user/reportee/${partyUuid}`,
-      transformResponse: (response: ReporteeInfo) => {
-        return {
-          ...response,
-          name: formatDisplayName({ fullName: response.name, type: 'company' }),
-        };
-      },
-    }),
-    getSystemuserIsAdmin: builder.query<boolean, string>({
-      query: (partyUuid) => `user/isAdmin?party=${partyUuid}`,
-    }),
-
     // systemregister
     getRegisteredSystems: builder.query<RegisteredSystem[], void>({
       query: () => `/systemregister`,
@@ -354,8 +338,6 @@ const apiWithTag = systemUserApi.enhanceEndpoints({
 });
 
 export const {
-  useGetSystemUserReporteeQuery,
-  useGetSystemuserIsAdminQuery,
   useCreateSystemUserMutation,
   useDeleteSystemuserMutation,
   useGetSystemUserQuery,


### PR DESCRIPTION
## Description
- Instead of using partyUuid from request to get reportee and check if this party is admin, call `redirectToChangeReporteeAndRedirect` to change party if request party is different from current selected party.
- Remove systemuser overrides for getReportee and isAdmin

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/3635

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system user pages to consistently display the correct organization name in headers, alerts, and permission dialogs.
  * Updated page routing/loading so content waits during organization switch redirects, and draft pages avoid unnecessary redirects.
* **New Features**
  * Added automatic redirect support when opening system user pages for a different organization selection.
* **Refactor**
  * Consolidated reportee and admin data fetching across the system user experience and standardized company name formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->