### PR TITLE
Only display reportee page when isAdmin on org or user represents themselves

### DIFF
--- a/src/features/amUI/common/PageLayoutWrapper/useSidebarItems.tsx
+++ b/src/features/amUI/common/PageLayoutWrapper/useSidebarItems.tsx
@@ -6,6 +6,7 @@ import {
 import {
   hasConsentPermission,
   hasCreateSystemUserPermission,
+  hasReporteesPermission,
   hasSystemUserClientAdminPermission,
 } from '@/resources/utils/permissionUtils';
 import {
@@ -107,7 +108,7 @@ export const useSidebarItems = ({ isSmall }: { isSmall?: boolean }) => {
 
   if (displayConfettiPackage) {
     items.push(getUsersMenuItem(pathname, isLoading, isSmall));
-    if (isAdmin) {
+    if (hasReporteesPermission(reportee, isAdmin, isCurrentUserReportee)) {
       items.push(getReporteesMenuItem(pathname, isLoading, isSmall));
     }
   }

--- a/src/features/amUI/landingPage/LandingPage.tsx
+++ b/src/features/amUI/landingPage/LandingPage.tsx
@@ -22,6 +22,7 @@ import { useTranslation } from 'react-i18next';
 import { useSearchParams } from 'react-router';
 import {
   hasConsentPermission,
+  hasReporteesPermission,
   hasSystemUserClientAdminPermission,
   hasCreateSystemUserPermission,
 } from '@/resources/utils/permissionUtils';
@@ -161,7 +162,10 @@ export const LandingPage = () => {
       });
     }
 
-    if (displayConfettiPackage && isAdmin) {
+    if (
+      displayConfettiPackage &&
+      hasReporteesPermission(reportee, isAdmin, isCurrentUserReportee)
+    ) {
       items.push({
         ...getReporteesMenuItem(),
         description: isCurrentUserReportee

--- a/src/features/amUI/reportees/ReporteesPage.tsx
+++ b/src/features/amUI/reportees/ReporteesPage.tsx
@@ -6,6 +6,8 @@ import { useDocumentTitle } from '@/resources/hooks/useDocumentTitle';
 import { PageWrapper } from '@/components';
 import { getCookie } from '@/resources/Cookie/CookieMethods';
 import { useGetIsAdminQuery, useGetReporteeQuery } from '@/rtk/features/userInfoApi';
+import { useGetPartyFromLoggedInUserQuery } from '@/rtk/features/lookupApi';
+import { hasReporteesPermission } from '@/resources/utils/permissionUtils';
 
 import { PageLayoutWrapper } from '../common/PageLayoutWrapper';
 import { PartyRepresentationProvider } from '../common/PartyRepresentationContext/PartyRepresentationContext';
@@ -18,6 +20,8 @@ export const ReporteesPage = () => {
   const { t } = useTranslation();
   const { data: isAdmin, isLoading } = useGetIsAdminQuery();
   const { data: reportee, isLoading: reporteeLoading } = useGetReporteeQuery();
+  const { data: currentUser } = useGetPartyFromLoggedInUserQuery();
+  const isCurrentUserReportee = reportee?.partyUuid === currentUser?.partyUuid;
   const name = formatDisplayName({
     fullName: reportee?.name || '',
     type: reportee?.type === 'Person' ? 'person' : 'company',
@@ -28,7 +32,9 @@ export const ReporteesPage = () => {
   return (
     <PageWrapper>
       <PageLayoutWrapper>
-        {!isLoading && !isAdmin ? (
+        {!isLoading &&
+        !reporteeLoading &&
+        !hasReporteesPermission(reportee, isAdmin, isCurrentUserReportee) ? (
           <DsAlert data-color='warning'>
             {t('reportees_page.not_admin_alert', { name: name || '' })}
           </DsAlert>

--- a/src/features/amUI/reportees/ReporteesPage.tsx
+++ b/src/features/amUI/reportees/ReporteesPage.tsx
@@ -20,7 +20,7 @@ export const ReporteesPage = () => {
   const { t } = useTranslation();
   const { data: isAdmin, isLoading } = useGetIsAdminQuery();
   const { data: reportee, isLoading: reporteeLoading } = useGetReporteeQuery();
-  const { data: currentUser } = useGetPartyFromLoggedInUserQuery();
+  const { data: currentUser, isLoading: currentUserIsLoading } = useGetPartyFromLoggedInUserQuery();
   const isCurrentUserReportee = reportee?.partyUuid === currentUser?.partyUuid;
   const name = formatDisplayName({
     fullName: reportee?.name || '',
@@ -34,6 +34,7 @@ export const ReporteesPage = () => {
       <PageLayoutWrapper>
         {!isLoading &&
         !reporteeLoading &&
+        !currentUserIsLoading &&
         !hasReporteesPermission(reportee, isAdmin, isCurrentUserReportee) ? (
           <DsAlert data-color='warning'>
             {t('reportees_page.not_admin_alert', { name: name || '' })}

--- a/src/resources/utils/permissionUtils.ts
+++ b/src/resources/utils/permissionUtils.ts
@@ -26,3 +26,18 @@ export const hasSystemUserClientAdminPermission = (
   const isOrganization = reporteeInfo.type === 'Organization';
   return isOrganization && isClientAdmin;
 };
+
+export const hasReporteesPermission = (
+  reporteeInfo?: ReporteeInfo,
+  isAdmin: boolean = false,
+  isCurrentUserReportee: boolean = false,
+): boolean => {
+  if (!reporteeInfo) {
+    return false;
+  }
+  const isOrg = reporteeInfo.type === 'Organization';
+  if (isOrg) {
+    return isAdmin;
+  }
+  return isCurrentUserReportee;
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<img width="1487" height="788" alt="image" src="https://github.com/user-attachments/assets/e24cdf45-6094-4669-8c54-6cda9ee2049f" />

## Description
<!--- Describe your changes in detail -->
This PR updates the landing page and side menu to hide the reportee page when the actor is a person, unless the user themselves is that very actor.
This means that admins on private individuals no longer have access to this page.

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/3686

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
