### PR TITLE
fix playwright tests after upgrading altinn-components

### DIFF
--- a/playwright/pages/profile/accessPackageDelegationPage.ts
+++ b/playwright/pages/profile/accessPackageDelegationPage.ts
@@ -106,7 +106,6 @@ export class DelegationPage {
 
     const packageButton = this.page.getByRole('button', {
       name: new RegExp(`^${this.escapeRegExp(packageName)} ${packageCountPattern}$`),
-      exact: true,
     });
 
     await expect(packageButton).toBeVisible({ timeout: 10000 });
@@ -216,7 +215,6 @@ export class DelegationPage {
 
     const packageBtn = this.page.getByRole('button', {
       name: new RegExp(`^${this.escapeRegExp(pacakageName)} ${packageCountPattern}$`),
-      exact: true,
     });
 
     await expect(packageBtn).toBeVisible();

--- a/playwright/pages/profile/accessPackageDelegationPage.ts
+++ b/playwright/pages/profile/accessPackageDelegationPage.ts
@@ -47,6 +47,10 @@ export class DelegationPage {
     this.clearSearchButton = page.getByRole('button', { name: /Tøm/ });
   }
 
+  escapeRegExp(text: string) {
+    return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+
   async addUser() {
     const addUserBtn = this.page.getByRole('button', {
       name: this.texts.new_user_modal.trigger_button,
@@ -97,7 +101,13 @@ export class DelegationPage {
     await searchBox.click();
     await searchBox.fill(packageName);
 
-    const packageButton = this.page.getByRole('button', { name: packageName, exact: true });
+    const packageCountPattern =
+      this.texts.access_packages.package_number_of_resources_other.replace('{{count}}', '\\d+');
+
+    const packageButton = this.page.getByRole('button', {
+      name: new RegExp(`^${this.escapeRegExp(packageName)} ${packageCountPattern}$`),
+      exact: true,
+    });
 
     await expect(packageButton).toBeVisible({ timeout: 10000 });
     await packageButton.click();
@@ -201,7 +211,14 @@ export class DelegationPage {
     await expect(areaBtn).toBeVisible();
     await areaBtn.click();
 
-    const packageBtn = this.page.getByRole('button', { name: pacakageName, exact: true });
+    const packageCountPattern =
+      this.texts.access_packages.package_number_of_resources_other.replace('{{count}}', '\\d+');
+
+    const packageBtn = this.page.getByRole('button', {
+      name: new RegExp(`^${this.escapeRegExp(pacakageName)} ${packageCountPattern}$`),
+      exact: true,
+    });
+
     await expect(packageBtn).toBeVisible();
   }
 


### PR DESCRIPTION
## Description
- `aria-label` for AccessPackageListItem was previously hardcoded to access package name. Fix button name locator in playwright after this was removed

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved matching for access package buttons so the correct package is selected even when the displayed text includes additional resource-count details.
  * Made delegated package verification more reliable when labels contain text that could otherwise be interpreted incorrectly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->