### PR TITLE
Fixed test that failed due to wrong selectors

### DIFF
--- a/playwright/pages/profile/accessPackageDelegationPage.ts
+++ b/playwright/pages/profile/accessPackageDelegationPage.ts
@@ -97,7 +97,9 @@ export class DelegationPage {
     await searchBox.click();
     await searchBox.fill(packageName);
 
-    const packageButton = this.page.getByRole('button', { name: packageName, exact: true });
+    const packageButton = this.page
+      .getByRole('button')
+      .filter({ has: this.page.getByText(packageName, { exact: true }) });
 
     await expect(packageButton).toBeVisible({ timeout: 10000 });
     await packageButton.click();
@@ -196,13 +198,15 @@ export class DelegationPage {
     await expect(confirmBtn).toBeVisible({ timeout: 10000 });
     await confirmBtn.click();
   }
-  async verifyDelegatedPackage(areaName: string, pacakageName: string) {
+  async verifyDelegatedPackage(areaName: string, packageName: string) {
     const areaBtn = this.page.getByRole('list').getByRole('button', { name: areaName }).first();
     await expect(areaBtn).toBeVisible();
     await areaBtn.click();
 
-    const packageBtn = this.page.getByRole('button', { name: pacakageName, exact: true });
-    await expect(packageBtn).toBeVisible();
+    const packageButton = this.page
+      .getByRole('button')
+      .filter({ has: this.page.getByText(packageName, { exact: true }) });
+    await expect(packageButton).toBeVisible();
   }
 
   async verifyDelegatedPackages(expectations: { areaName: string; packageName: string }[]) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

One playwright test failed due to too specific selectors that might have been changed at some point in altinn components. This change makes that test run green

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package selection on the access delegation page so the correct item is matched more reliably.
  * Fixed a parameter naming issue in delegation verification to improve consistency and reduce errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->