### PR TITLE
Add "Start" link globally in breadcrumb component

### DIFF
--- a/src/features/amUI/common/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/features/amUI/common/Breadcrumbs/Breadcrumbs.tsx
@@ -3,6 +3,7 @@ import { Breadcrumbs as AcBreadcrumbs, DsSkeleton } from '@altinn/altinn-compone
 import { Link } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { amUIPath, ConsentPath, SystemUserPath } from '@/routes/paths';
+import { getAltinnStartPageUrl } from '@/resources/utils/pathUtils';
 
 export type BreadcrumbItem = { label?: string; href?: string };
 
@@ -72,19 +73,32 @@ interface BreadcrumbsProps {
 }
 
 export const Breadcrumbs = ({ items, lastBreadcrumb }: BreadcrumbsProps) => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
 
+  const start = { label: 'common.start', href: getAltinnStartPageUrl(i18n.language) };
   const last = lastBreadcrumb ? [lastBreadcrumb] : [];
-  const breadcrumbs: BreadcrumbItem[] = [...items.map((item) => BreadcrumbConfig[item]), ...last];
+  const breadcrumbs: BreadcrumbItem[] = [
+    start,
+    ...items.map((item) => BreadcrumbConfig[item]),
+    ...last,
+  ];
   const breadcrumbItems = breadcrumbs.map((item) => {
+    const isExternal = item.href?.startsWith('http');
     return {
       label: item.label ? t(item.label) : <DsSkeleton variant='text'>xxxxxxxxxxxxxx</DsSkeleton>,
-      as: (props: ComponentPropsWithoutRef<typeof Link>) => (
-        <Link
-          {...props}
-          to={item.href ?? ''}
-        />
-      ),
+      as: isExternal
+        ? (props: ComponentPropsWithoutRef<'a'>) => (
+            <a
+              {...props}
+              href={item.href}
+            />
+          )
+        : (props: ComponentPropsWithoutRef<typeof Link>) => (
+            <Link
+              {...props}
+              to={item.href ?? ''}
+            />
+          ),
     };
   });
 

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -1,6 +1,7 @@
 {
   "common": {
     "beta": "Beta",
+    "start": "Start",
     "error": "Error",
     "restart": "Restart",
     "close": "Close",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -1,6 +1,7 @@
 {
   "common": {
     "beta": "Beta",
+    "start": "Start",
     "error": "Feil",
     "restart": "Start på nytt",
     "close": "Lukk",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -1,6 +1,7 @@
 {
   "common": {
     "beta": "Beta",
+    "start": "Start",
     "error": "Feil",
     "restart": "Start på nytt",
     "close": "Lukk",


### PR DESCRIPTION
Legger til «Start» som første element i brødsmulestien på alle sider, med lenke til Altinn-startsiden/Infoportal.

Ingen brødsmulesti på landingssiden.

[#3441](https://github.com/Altinn/altinn-authorization-tmp/issues/3441)
