### PR TITLE
fix: change size of poaDetails header + hide icon on small screens

### DIFF
--- a/src/features/amUI/packagePoaDetailsPage/PackagePoaDetailsHeader.module.css
+++ b/src/features/amUI/packagePoaDetailsPage/PackagePoaDetailsHeader.module.css
@@ -1,37 +1,36 @@
 .headingContainer {
-  display: grid;
-  grid-template-areas:
-    'icon heading'
-    'status status'
-    'description description';
-  grid-template-columns: auto 1fr;
-  gap: 1rem;
-  margin-bottom: 1.5rem;
-  align-items: center;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--ds-size-4);
+  margin-bottom: var(--ds-size-8);
 }
 
-@media screen and (max-width: 768px) {
+.headingContainerText {
+  display: flex;
+  flex-direction: row;
+  gap: var(--ds-size-4);
 }
 
 .packageIcon {
-  grid-area: icon;
-  height: 2.6rem;
-  width: 2.6rem;
+  height: var(--ds-size-8);
+  width: var(--ds-size-8);
   margin: auto;
+  flex: 0 0 var(--ds-size-8);
 }
 
 .pageHeading {
-  grid-area: heading;
   max-width: 100%;
   word-break: break-word;
-}
-
-.statusSection {
-  grid-area: status;
 }
 
 .pageDescription {
-  grid-area: description;
   max-width: 100%;
   word-break: break-word;
+}
+
+@media screen and (max-width: 768px) {
+  .packageIcon {
+    display: none;
+  }
 }

--- a/src/features/amUI/packagePoaDetailsPage/PackagePoaDetailsHeader.tsx
+++ b/src/features/amUI/packagePoaDetailsPage/PackagePoaDetailsHeader.tsx
@@ -3,6 +3,7 @@ import classes from './PackagePoaDetailsHeader.module.css';
 import { DsHeading, DsParagraph } from '@altinn/altinn-components';
 import { PackageIcon } from '@navikt/aksel-icons';
 import { PackagePoaDetailsHeaderSkeleton } from './PackagePoaDetailsHeaderSkeleton';
+import { useIsMobileOrSmaller } from '@/resources/utils/screensizeUtils';
 
 interface PackagePoaDetailsHeaderProps {
   packageName?: string;
@@ -17,22 +18,26 @@ export const PackagePoaDetailsHeader: React.FC<PackagePoaDetailsHeaderProps> = (
   isLoading = false,
   statusSection,
 }) => {
+  const isSmall = useIsMobileOrSmaller();
+
   return isLoading ? (
     <PackagePoaDetailsHeaderSkeleton />
   ) : (
     <>
-      <PackageIcon
-        className={classes.packageIcon}
-        aria-hidden='true'
-      />
-      <DsHeading
-        level={1}
-        data-size='lg'
-        className={classes.pageHeading}
-      >
-        {packageName}
-      </DsHeading>
-      {statusSection && <div className={classes.statusSection}>{statusSection}</div>}
+      <div className={classes.headingContainerText}>
+        <PackageIcon
+          className={classes.packageIcon}
+          aria-hidden='true'
+        />
+        <DsHeading
+          level={1}
+          data-size={isSmall ? '2xs' : 'sm'}
+          className={classes.pageHeading}
+        >
+          {packageName}
+        </DsHeading>
+      </div>
+      {statusSection}
       <DsParagraph
         variant='long'
         className={classes.pageDescription}

--- a/src/features/amUI/packagePoaDetailsPage/PackagePoaDetailsHeaderSkeleton.tsx
+++ b/src/features/amUI/packagePoaDetailsPage/PackagePoaDetailsHeaderSkeleton.tsx
@@ -4,17 +4,19 @@ import { DsSkeleton } from '@altinn/altinn-components';
 
 export const PackagePoaDetailsHeaderSkeleton: React.FC = () => (
   <>
-    <DsSkeleton
-      variant='rectangle'
-      width={50}
-      height={50}
-      className={classes.packageIcon}
-    />
-    <DsSkeleton
-      className={`${classes.pageHeading}`}
-      variant='rectangle'
-      height={50}
-    />
+    <div className={classes.headingContainerText}>
+      <DsSkeleton
+        variant='rectangle'
+        width={50}
+        height={32}
+        className={classes.packageIcon}
+      />
+      <DsSkeleton
+        className={`${classes.pageHeading}`}
+        height={32}
+        width={200}
+      />
+    </div>
     <DsSkeleton
       className={`${classes.pageDescription}`}
       variant='text'


### PR DESCRIPTION
## Description
- Changes in header on poaDetails page: 
  - Default header size is "sm", and "2xs" on mobile screens (same as other h1 headings)
  - Reduce size of icon from 2.6rem to 2rem
  - Hide icon on mobile screens
  - Remove extra spacing if statusSection is `null`
<img width="1046" height="331" alt="image" src="https://github.com/user-attachments/assets/fc01717a-255c-47b3-b03d-8743dca56bc5" />
<img width="418" height="488" alt="image" src="https://github.com/user-attachments/assets/70f6fe11-3d75-4d53-98ac-b5070b649d11" />
<img width="1047" height="233" alt="image" src="https://github.com/user-attachments/assets/a7d9ff2b-232f-4a2d-acfe-0b9031857ac0" />

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/3716

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated the package details header layout for a cleaner, more responsive presentation.
  * Adjusted heading sizes for smaller screens to improve readability.
  * Hid the package icon on mobile devices to optimize available space.
  * Improved alignment and spacing between the package icon, heading, description, and status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->