### PR TITLE
Minimize text and save more space on mobile

### DIFF
--- a/src/features/amUI/InstanceDetailPage/InstanceDetailPageContent.tsx
+++ b/src/features/amUI/InstanceDetailPage/InstanceDetailPageContent.tsx
@@ -36,6 +36,7 @@ import {
 
 import classes from './InstanceDetailPageContent.module.css';
 import { RequestInstanceAdminPackage } from './RequestInstanceAdminPackage';
+import { useIsMobileOrSmaller } from '@/resources/utils/screensizeUtils';
 
 // Focus-restore fallback for this zone: when a revoked row is gone, focus lands on the search field
 // above the list instead of the page heading. Unique within this provider zone.
@@ -45,6 +46,7 @@ export const InstanceDetailPageContent = () => {
   const { t, i18n } = useTranslation();
   const [searchParams] = useSearchParams();
   const { actingParty, fromParty } = usePartyRepresentation();
+  const isSmall = useIsMobileOrSmaller();
 
   const actingPartyIsOrg = actingParty?.partyTypeName === PartyType.Organization;
 
@@ -218,7 +220,7 @@ export const InstanceDetailPageContent = () => {
         </DsAlert>
       ) : (
         <div className={classes.contentSection}>
-          <DsParagraph data-size='sm'>
+          <DsParagraph data-size={isSmall ? 'xs' : 'sm'}>
             {isInstanceAdmin ? (
               t('instance_detail_page.description')
             ) : (

--- a/src/features/amUI/common/AmTabs/AmTabs.module.css
+++ b/src/features/amUI/common/AmTabs/AmTabs.module.css
@@ -17,7 +17,7 @@
 
 @media (max-width: 768px) {
   .tabList > * {
-    padding-inline: 0.375rem !important;
+    padding-inline: 0.1rem !important;
   }
 
   .tabLabel {

--- a/src/features/amUI/common/InstanceDescription/InstanceDescription.module.css
+++ b/src/features/amUI/common/InstanceDescription/InstanceDescription.module.css
@@ -1,9 +1,14 @@
 .container {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
-  gap: var(--ds-spacing-3);
+  gap: var(--ds-spacing-2);
   padding-bottom: var(--ds-spacing-4);
+}
+
+.metadataRows {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-spacing-1);
 }
 
 .resourceOwner {

--- a/src/features/amUI/common/InstanceDescription/InstanceDescription.tsx
+++ b/src/features/amUI/common/InstanceDescription/InstanceDescription.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 import { Avatar, DsHeading, DsParagraph, Icon, formatDisplayName } from '@altinn/altinn-components';
+import { useIsMobileOrSmaller } from '@/resources/utils/screensizeUtils';
 import { useTranslation } from 'react-i18next';
 
 import { useProviderLogoUrl } from '@/resources/hooks';
@@ -35,6 +36,7 @@ export const InstanceDescription = ({
   const { t, i18n } = useTranslation();
   const shortId = getInstanceShortId(instanceData?.instance.refId);
   const title = resolveInstanceTitle(instanceData, resource, t, i18n.language);
+  const isSmall = useIsMobileOrSmaller();
   const providerLogoUrl = resource.resourceOwnerOrgcode
     ? getProviderLogoUrl(resource.resourceOwnerOrgcode)
     : undefined;
@@ -47,51 +49,53 @@ export const InstanceDescription = ({
     <div className={classes.container}>
       <DsHeading
         level={titleLevel}
-        data-size='sm'
+        data-size={isSmall ? 'xs' : 'sm'}
       >
         {title}
       </DsHeading>
-      <div className={classes.resourceOwner}>
-        {providerLogoUrl || resource.resourceOwnerLogoUrl ? (
-          <Icon
-            iconUrl={providerLogoUrl ?? resource.resourceOwnerLogoUrl}
-            size='sm'
-          />
-        ) : (
-          <Avatar
-            type='company'
-            name={resource.resourceOwnerName}
-            size='sm'
-          />
+      <div className={classes.metadataRows}>
+        <div className={classes.resourceOwner}>
+          {providerLogoUrl || resource.resourceOwnerLogoUrl ? (
+            <Icon
+              iconUrl={providerLogoUrl ?? resource.resourceOwnerLogoUrl}
+              size='sm'
+            />
+          ) : (
+            <Avatar
+              type='company'
+              name={resource.resourceOwnerName}
+              size='sm'
+            />
+          )}
+          <DsParagraph
+            data-size={isSmall ? 'xs' : 'sm'}
+            className={classes.ownerTag}
+          >
+            {resource.resourceOwnerName}{' '}
+            <span className={classes.ownerName}>
+              {t('instance_detail_page.provider_name', {
+                name: fromName,
+              })}
+            </span>
+          </DsParagraph>
+        </div>
+        {statusSection}
+        {(resource.title || instanceData?.instance.refId) && (
+          <>
+            {resource.title && (
+              <div className={classes.metadataRow}>
+                {t('instance.service_title_label')} {': '} {resource.title}
+              </div>
+            )}
+            {instanceData?.instance.refId && (
+              <div className={classes.metadataRow}>
+                {t('instance.instance_id_label')} {': '}
+                {shortId}
+              </div>
+            )}
+          </>
         )}
-        <DsParagraph
-          data-size='sm'
-          className={classes.ownerTag}
-        >
-          {resource.resourceOwnerName}{' '}
-          <span className={classes.ownerName}>
-            {t('instance_detail_page.provider_name', {
-              name: fromName,
-            })}
-          </span>
-        </DsParagraph>
       </div>
-      {statusSection}
-      {(resource.title || instanceData?.instance.refId) && (
-        <>
-          {resource.title && (
-            <div className={classes.metadataRow}>
-              {t('instance.service_title_label')} {': '} {resource.title}
-            </div>
-          )}
-          {instanceData?.instance.refId && (
-            <div className={classes.metadataRow}>
-              {t('instance.instance_id_label')} {': '}
-              {shortId}
-            </div>
-          )}
-        </>
-      )}
     </div>
   );
 };

--- a/src/features/amUI/packagePoaDetailsPage/PackagePoaDetailsHeader.tsx
+++ b/src/features/amUI/packagePoaDetailsPage/PackagePoaDetailsHeader.tsx
@@ -41,6 +41,7 @@ export const PackagePoaDetailsHeader: React.FC<PackagePoaDetailsHeaderProps> = (
       <DsParagraph
         variant='long'
         className={classes.pageDescription}
+        data-size={isSmall ? 'xs' : 'sm'}
       >
         {packageDescription}
       </DsParagraph>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<div align="center">
  <img src="https://github.com/user-attachments/assets/edf92ef2-bf3c-4c59-9e80-9734653b38d8" width="30%" />
  <img src="https://github.com/user-attachments/assets/f1b99ae1-7c34-45e0-941d-65debf73b04b" width="30%" />
  <img src="https://github.com/user-attachments/assets/b9be38d4-d925-484c-b1ba-8be05fa46b05" width="30%" />
</div>

## Description
<!--- Describe your changes in detail -->

After testing our page on a real mobile, I realized that we still have some space that can be saved and texts that can be minimized.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive text sizing across instance details and package descriptions for smaller screens.
  * Reduced spacing between metadata items for a more compact layout.
  * Tightened mobile tab padding to improve navigation and fit.
  * Refined instance description alignment and spacing for a cleaner presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->