### PR TITLE
Add approve all and reject all buttons to request review modal

### DIFF
--- a/src/features/amUI/requestPage/RequestReviewModal/RequestReviewModal.module.css
+++ b/src/features/amUI/requestPage/RequestReviewModal/RequestReviewModal.module.css
@@ -16,8 +16,10 @@
   gap: var(--ds-spacing-3);
 }
 
-.closeButton {
-  width: fit-content;
+.bulkActionButtons {
+  display: flex;
+  gap: var(--ds-spacing-4);
+  flex-wrap: wrap;
 }
 
 .userLink {

--- a/src/features/amUI/requestPage/RequestReviewModal/RequestReviewModal.module.css
+++ b/src/features/amUI/requestPage/RequestReviewModal/RequestReviewModal.module.css
@@ -36,7 +36,6 @@
   display: flex;
   align-items: center;
   gap: var(--ds-spacing-2);
-  padding-right: var(--ds-spacing-2);
   color: var(--ds-color-text-subtle);
 }
 

--- a/src/features/amUI/requestPage/RequestReviewModal/RequestReviewModalContent.tsx
+++ b/src/features/amUI/requestPage/RequestReviewModal/RequestReviewModalContent.tsx
@@ -50,10 +50,15 @@ export const RequestReviewModalContent = ({ request, onClose }: RequestReviewMod
     resetSelection,
     processedRequests,
     actionLoading,
+    bulkActionLoading,
     cannotApprove,
+    hasPendingRequests,
+    hasApprovableRequests,
     handleClose,
     handleApprove,
     handleReject,
+    handleApproveAll,
+    handleRejectAll,
     handleSelection,
   } = useRequestReview(request, onClose);
 
@@ -237,13 +242,36 @@ export const RequestReviewModalContent = ({ request, onClose }: RequestReviewMod
             </>
           )}
           <DsParagraph data-size='md'>{t('request_page.review_close_info')}</DsParagraph>
-          <DsButton
-            variant='secondary'
-            onClick={handleClose}
-            className={classes.closeButton}
-          >
-            {t('common.close')}
-          </DsButton>
+          <div className={classes.bulkActionButtons}>
+            <DsButton
+              aria-disabled={
+                !hasApprovableRequests || !hasPendingRequests || !!bulkActionLoading || undefined
+              }
+              onClick={
+                !hasApprovableRequests || !hasPendingRequests || !!bulkActionLoading
+                  ? undefined
+                  : handleApproveAll
+              }
+              loading={bulkActionLoading === 'approveAll'}
+            >
+              {t('request_page.approve_all')}
+            </DsButton>
+            <DsButton
+              variant='secondary'
+              data-color='danger'
+              aria-disabled={!hasPendingRequests || !!bulkActionLoading || undefined}
+              onClick={!hasPendingRequests || !!bulkActionLoading ? undefined : handleRejectAll}
+              loading={bulkActionLoading === 'rejectAll'}
+            >
+              {t('request_page.reject_all')}
+            </DsButton>
+            <DsButton
+              variant='secondary'
+              onClick={handleClose}
+            >
+              {t('common.close')}
+            </DsButton>
+          </div>
         </div>
       </RestoreFocusFallback>
     </RestoreFocusProvider>

--- a/src/features/amUI/requestPage/RequestReviewModal/RequestReviewModalContent.tsx
+++ b/src/features/amUI/requestPage/RequestReviewModal/RequestReviewModalContent.tsx
@@ -111,6 +111,12 @@ export const RequestReviewModalContent = ({ request, onClose }: RequestReviewMod
   const itemControls = ({ resourceId, packageId }: { resourceId?: string; packageId?: string }) => {
     const id = resourceId ?? packageId ?? '';
     const status = processedRequests[id]?.status;
+    const chevron = () => (
+      <ChevronRightIcon
+        className={classes.chevronIcon}
+        aria-hidden='true'
+      />
+    );
     if (status === 'approved') {
       return (
         <span className={classes.processedStatus}>
@@ -119,6 +125,7 @@ export const RequestReviewModalContent = ({ request, onClose }: RequestReviewMod
             className={classes.approvedIcon}
             aria-hidden='true'
           />
+          {chevron()}
         </span>
       );
     }
@@ -130,6 +137,7 @@ export const RequestReviewModalContent = ({ request, onClose }: RequestReviewMod
             className={classes.rejectedIcon}
             aria-hidden='true'
           />
+          {chevron()}
         </span>
       );
     }
@@ -141,15 +149,11 @@ export const RequestReviewModalContent = ({ request, onClose }: RequestReviewMod
             className={classes.warningIcon}
             aria-hidden='true'
           />
+          {chevron()}
         </span>
       );
     }
-    return (
-      <ChevronRightIcon
-        className={classes.chevronIcon}
-        aria-hidden='true'
-      />
-    );
+    return chevron();
   };
 
   return (

--- a/src/features/amUI/requestPage/RequestReviewModal/RequestReviewModalContent.tsx
+++ b/src/features/amUI/requestPage/RequestReviewModal/RequestReviewModalContent.tsx
@@ -267,7 +267,8 @@ export const RequestReviewModalContent = ({ request, onClose }: RequestReviewMod
             </DsButton>
             <DsButton
               variant='secondary'
-              onClick={handleClose}
+              aria-disabled={!!bulkActionLoading || !!actionLoading || undefined}
+              onClick={!!bulkActionLoading || !!actionLoading ? undefined : handleClose}
             >
               {t('common.close')}
             </DsButton>

--- a/src/features/amUI/requestPage/RequestReviewModal/useRequestReview.test.ts
+++ b/src/features/amUI/requestPage/RequestReviewModal/useRequestReview.test.ts
@@ -1,0 +1,586 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+
+import * as requestApiModule from '@/rtk/features/requestApi';
+import * as singleRightsModule from '@/rtk/features/singleRights/singleRightsApi';
+import * as partyRepModule from '../../common/PartyRepresentationContext/PartyRepresentationContext';
+import * as delegationCheckModule from '../../common/DelegationCheck/AccessPackageDelegationCheckContext';
+import * as altinnComponents from '@altinn/altinn-components';
+import * as i18nModule from 'react-i18next';
+
+import { useRequestReview } from './useRequestReview';
+import type { Request } from '../types';
+import type { EnrichedResourceRequest, EnrichedPackageRequest } from '@/rtk/features/requestApi';
+import type { AccessPackage } from '@/rtk/features/accessPackageApi';
+import type { ServiceResource } from '@/rtk/features/singleRights/singleRightsApi';
+
+vi.mock('@altinn/altinn-components', () => ({ useSnackbar: vi.fn() }));
+vi.mock('react-i18next', () => ({ useTranslation: vi.fn() }));
+vi.mock('../../common/PartyRepresentationContext/PartyRepresentationContext', () => ({
+  usePartyRepresentation: vi.fn(),
+}));
+vi.mock('../../common/DelegationCheck/AccessPackageDelegationCheckContext', () => ({
+  useAccessPackageDelegationCheck: vi.fn(),
+}));
+vi.mock('@/rtk/features/requestApi', () => ({
+  useApproveRequestMutation: vi.fn(),
+  useRejectRequestMutation: vi.fn(),
+  useGetEnrichedReceivedResourceRequestsQuery: vi.fn(),
+  useGetEnrichedReceivedPackageRequestsQuery: vi.fn(),
+}));
+vi.mock('@/rtk/features/singleRights/singleRightsApi', () => ({
+  useLazyDelegationCheckQuery: vi.fn(),
+}));
+
+// --- Constants ---
+
+const PARTY_UUID = 'acting-party-uuid';
+const FROM_PARTY_UUID = 'from-party-uuid';
+const LAST_UPDATED = '2024-01-15T12:00:00Z';
+
+const mockRequest: Request = {
+  id: 'mock-request',
+  type: 'accessrequest',
+  createdDate: '2024-01-01',
+  displayPartyName: 'Test Person',
+  displayPartyType: 'person',
+  partyUuid: FROM_PARTY_UUID,
+};
+
+// --- Test data factories ---
+
+const makeResourceReq = (requestId: string, identifier: string): EnrichedResourceRequest =>
+  ({
+    id: requestId,
+    lastUpdated: LAST_UPDATED,
+    resource: { identifier },
+  }) as EnrichedResourceRequest;
+
+const makePackageReq = (requestId: string, packageId: string): EnrichedPackageRequest =>
+  ({
+    id: requestId,
+    lastUpdated: LAST_UPDATED,
+    package: { id: packageId },
+  }) as EnrichedPackageRequest;
+
+// --- Tests ---
+
+describe('useRequestReview', () => {
+  const mockOpenSnackbar = vi.fn();
+  const mockCanDelegatePackage = vi.fn();
+  const mockApproveFn = vi.fn();
+  const mockRejectFn = vi.fn();
+  const mockLazyCheck = vi.fn();
+  const mockOnClose = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(altinnComponents.useSnackbar).mockReturnValue({
+      openSnackbar: mockOpenSnackbar,
+    } as any);
+    vi.mocked(i18nModule.useTranslation).mockReturnValue({ t: (k: string) => k } as any);
+    vi.mocked(partyRepModule.usePartyRepresentation).mockReturnValue({
+      actingParty: { partyUuid: PARTY_UUID },
+    } as any);
+    vi.mocked(delegationCheckModule.useAccessPackageDelegationCheck).mockReturnValue({
+      canDelegatePackage: mockCanDelegatePackage,
+    } as any);
+
+    mockApproveFn.mockReturnValue({
+      unwrap: vi.fn().mockResolvedValue({ lastUpdated: LAST_UPDATED }),
+    });
+    mockRejectFn.mockReturnValue({
+      unwrap: vi.fn().mockResolvedValue({ lastUpdated: LAST_UPDATED }),
+    });
+    mockLazyCheck.mockReturnValue({ unwrap: vi.fn().mockResolvedValue([]) });
+    mockCanDelegatePackage.mockReturnValue(undefined);
+
+    vi.mocked(requestApiModule.useApproveRequestMutation).mockReturnValue([mockApproveFn] as any);
+    vi.mocked(requestApiModule.useRejectRequestMutation).mockReturnValue([mockRejectFn] as any);
+    vi.mocked(singleRightsModule.useLazyDelegationCheckQuery).mockReturnValue([
+      mockLazyCheck,
+    ] as any);
+    vi.mocked(requestApiModule.useGetEnrichedReceivedResourceRequestsQuery).mockReturnValue({
+      data: [],
+      isLoading: false,
+      isFetching: false,
+    } as any);
+    vi.mocked(requestApiModule.useGetEnrichedReceivedPackageRequestsQuery).mockReturnValue({
+      data: [],
+      isLoading: false,
+      isFetching: false,
+    } as any);
+  });
+
+  /** Renders the hook with the given snapshot data already available from the API. */
+  const renderWithData = (
+    resources: EnrichedResourceRequest[] = [],
+    packages: EnrichedPackageRequest[] = [],
+  ) => {
+    vi.mocked(requestApiModule.useGetEnrichedReceivedResourceRequestsQuery).mockReturnValue({
+      data: resources,
+      isLoading: false,
+      isFetching: false,
+    } as any);
+    vi.mocked(requestApiModule.useGetEnrichedReceivedPackageRequestsQuery).mockReturnValue({
+      data: packages,
+      isLoading: false,
+      isFetching: false,
+    } as any);
+    return renderHook(() => useRequestReview(mockRequest, mockOnClose));
+  };
+
+  // ---------------------------------------------------------------------------
+
+  describe('snapshot capture', () => {
+    it('starts with an empty snapshot when there is no data', () => {
+      const { result } = renderHook(() => useRequestReview(mockRequest, mockOnClose));
+      expect(result.current.snapshotResources).toHaveLength(0);
+      expect(result.current.snapshotPackages).toHaveLength(0);
+    });
+
+    it('captures resource requests into the snapshot when data arrives', async () => {
+      const { result } = renderWithData([makeResourceReq('req-r1', 'resource-1')]);
+      await act(async () => {});
+      expect(result.current.snapshotResources).toHaveLength(1);
+      expect(result.current.snapshotResources[0].identifier).toBe('resource-1');
+    });
+
+    it('captures package requests into the snapshot when data arrives', async () => {
+      const { result } = renderWithData([], [makePackageReq('req-p1', 'package-1')]);
+      await act(async () => {});
+      expect(result.current.snapshotPackages).toHaveLength(1);
+      expect(result.current.snapshotPackages[0].id).toBe('package-1');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+
+  describe('cannotApprove', () => {
+    it('returns false for a package when canDelegatePackage returns undefined (no data yet)', () => {
+      mockCanDelegatePackage.mockReturnValue(undefined);
+      const { result } = renderHook(() => useRequestReview(mockRequest, mockOnClose));
+      expect(result.current.cannotApprove({ packageId: 'pkg-1' })).toBe(false);
+    });
+
+    it('returns false for a package when canDelegatePackage result is true', () => {
+      mockCanDelegatePackage.mockReturnValue({ result: true, reasons: [] });
+      const { result } = renderHook(() => useRequestReview(mockRequest, mockOnClose));
+      expect(result.current.cannotApprove({ packageId: 'pkg-1' })).toBe(false);
+    });
+
+    it('returns true for a package when canDelegatePackage result is false', () => {
+      mockCanDelegatePackage.mockReturnValue({ result: false, reasons: [] });
+      const { result } = renderHook(() => useRequestReview(mockRequest, mockOnClose));
+      expect(result.current.cannotApprove({ packageId: 'pkg-1' })).toBe(true);
+    });
+
+    it('returns false for a resource when no delegation checks have loaded', () => {
+      const { result } = renderHook(() => useRequestReview(mockRequest, mockOnClose));
+      expect(result.current.cannotApprove({ resourceId: 'resource-1' })).toBe(false);
+    });
+
+    it('returns false for a resource when all delegation checks pass', async () => {
+      mockLazyCheck.mockReturnValue({
+        unwrap: vi.fn().mockResolvedValue([{ result: true }, { result: true }]),
+      });
+      const { result } = renderWithData([makeResourceReq('req-r1', 'resource-1')]);
+      await act(async () => {});
+      expect(result.current.cannotApprove({ resourceId: 'resource-1' })).toBe(false);
+    });
+
+    it('returns true for a resource when any delegation check fails', async () => {
+      mockLazyCheck.mockReturnValue({
+        unwrap: vi.fn().mockResolvedValue([{ result: true }, { result: false }]),
+      });
+      const { result } = renderWithData([makeResourceReq('req-r1', 'resource-1')]);
+      await act(async () => {});
+      expect(result.current.cannotApprove({ resourceId: 'resource-1' })).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+
+  describe('derived values: hasPendingRequests / hasApprovableRequests', () => {
+    it('hasPendingRequests is false with no snapshot data', () => {
+      const { result } = renderHook(() => useRequestReview(mockRequest, mockOnClose));
+      expect(result.current.hasPendingRequests).toBe(false);
+    });
+
+    it('hasPendingRequests is true when there are unprocessed items', async () => {
+      const { result } = renderWithData([makeResourceReq('req-r1', 'resource-1')]);
+      await act(async () => {});
+      expect(result.current.hasPendingRequests).toBe(true);
+    });
+
+    it('hasPendingRequests is false once all items have been processed', async () => {
+      const { result } = renderWithData([makeResourceReq('req-r1', 'resource-1')]);
+      await act(async () => {});
+      await act(async () => {
+        await result.current.handleApprove({ resourceId: 'resource-1' });
+      });
+      expect(result.current.hasPendingRequests).toBe(false);
+    });
+
+    it('hasApprovableRequests is false with no snapshot data', () => {
+      const { result } = renderHook(() => useRequestReview(mockRequest, mockOnClose));
+      expect(result.current.hasApprovableRequests).toBe(false);
+    });
+
+    it('hasApprovableRequests is false when all items cannotApprove', async () => {
+      mockCanDelegatePackage.mockReturnValue({ result: false, reasons: [] });
+      const { result } = renderWithData([], [makePackageReq('req-p1', 'package-1')]);
+      await act(async () => {});
+      expect(result.current.hasApprovableRequests).toBe(false);
+    });
+
+    it('hasApprovableRequests is true when at least one item is approvable', async () => {
+      mockCanDelegatePackage.mockReturnValue({ result: true, reasons: [] });
+      const { result } = renderWithData([], [makePackageReq('req-p1', 'package-1')]);
+      await act(async () => {});
+      expect(result.current.hasApprovableRequests).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+
+  describe('handleApprove', () => {
+    it('calls approveRequest with the correct party and request ID', async () => {
+      const { result } = renderWithData([makeResourceReq('req-r1', 'resource-1')]);
+      await act(async () => {});
+      await act(async () => {
+        await result.current.handleApprove({ resourceId: 'resource-1' });
+      });
+      expect(mockApproveFn).toHaveBeenCalledWith({ party: PARTY_UUID, id: 'req-r1' });
+    });
+
+    it('marks the item as approved in processedRequests', async () => {
+      const { result } = renderWithData([makeResourceReq('req-r1', 'resource-1')]);
+      await act(async () => {});
+      await act(async () => {
+        await result.current.handleApprove({ resourceId: 'resource-1' });
+      });
+      expect(result.current.processedRequests['resource-1']).toEqual({
+        status: 'approved',
+        handledAt: LAST_UPDATED,
+      });
+    });
+
+    it('works for packages as well as resources', async () => {
+      const { result } = renderWithData([], [makePackageReq('req-p1', 'package-1')]);
+      await act(async () => {});
+      await act(async () => {
+        await result.current.handleApprove({ packageId: 'package-1' });
+      });
+      expect(mockApproveFn).toHaveBeenCalledWith({ party: PARTY_UUID, id: 'req-p1' });
+      expect(result.current.processedRequests['package-1']?.status).toBe('approved');
+    });
+
+    it('shows a success snackbar on approval', async () => {
+      const { result } = renderWithData([makeResourceReq('req-r1', 'resource-1')]);
+      await act(async () => {});
+      await act(async () => {
+        await result.current.handleApprove({ resourceId: 'resource-1' });
+      });
+      expect(mockOpenSnackbar).toHaveBeenCalledWith(expect.objectContaining({ color: 'success' }));
+    });
+
+    it('shows an error snackbar when approval fails', async () => {
+      mockApproveFn.mockReturnValue({ unwrap: vi.fn().mockRejectedValue(new Error('API error')) });
+      const { result } = renderWithData([makeResourceReq('req-r1', 'resource-1')]);
+      await act(async () => {});
+      await act(async () => {
+        await result.current.handleApprove({ resourceId: 'resource-1' });
+      });
+      expect(mockOpenSnackbar).toHaveBeenCalledWith(expect.objectContaining({ color: 'danger' }));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+
+  describe('handleReject', () => {
+    it('calls rejectRequest with the correct party and request ID', async () => {
+      const { result } = renderWithData([makeResourceReq('req-r1', 'resource-1')]);
+      await act(async () => {});
+      await act(async () => {
+        await result.current.handleReject({ resourceId: 'resource-1' });
+      });
+      expect(mockRejectFn).toHaveBeenCalledWith({ party: PARTY_UUID, id: 'req-r1' });
+    });
+
+    it('marks the item as rejected in processedRequests', async () => {
+      const { result } = renderWithData([makeResourceReq('req-r1', 'resource-1')]);
+      await act(async () => {});
+      await act(async () => {
+        await result.current.handleReject({ resourceId: 'resource-1' });
+      });
+      expect(result.current.processedRequests['resource-1']).toEqual({
+        status: 'rejected',
+        handledAt: LAST_UPDATED,
+      });
+    });
+
+    it('works for packages as well as resources', async () => {
+      const { result } = renderWithData([], [makePackageReq('req-p1', 'package-1')]);
+      await act(async () => {});
+      await act(async () => {
+        await result.current.handleReject({ packageId: 'package-1' });
+      });
+      expect(mockRejectFn).toHaveBeenCalledWith({ party: PARTY_UUID, id: 'req-p1' });
+      expect(result.current.processedRequests['package-1']?.status).toBe('rejected');
+    });
+
+    it('shows an error snackbar when rejection fails', async () => {
+      mockRejectFn.mockReturnValue({ unwrap: vi.fn().mockRejectedValue(new Error('API error')) });
+      const { result } = renderWithData([makeResourceReq('req-r1', 'resource-1')]);
+      await act(async () => {});
+      await act(async () => {
+        await result.current.handleReject({ resourceId: 'resource-1' });
+      });
+      expect(mockOpenSnackbar).toHaveBeenCalledWith(expect.objectContaining({ color: 'danger' }));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+
+  describe('handleApproveAll', () => {
+    it('approves all pending approvable resources and packages', async () => {
+      mockCanDelegatePackage.mockReturnValue({ result: true, reasons: [] });
+      const { result } = renderWithData(
+        [makeResourceReq('req-r1', 'resource-1')],
+        [makePackageReq('req-p1', 'package-1')],
+      );
+      await act(async () => {});
+      await act(async () => {
+        await result.current.handleApproveAll();
+      });
+      expect(result.current.processedRequests['resource-1']?.status).toBe('approved');
+      expect(result.current.processedRequests['package-1']?.status).toBe('approved');
+    });
+
+    it('skips items where cannotApprove is true', async () => {
+      mockCanDelegatePackage.mockImplementation((id: string) =>
+        id === 'can-approve' ? { result: true, reasons: [] } : { result: false, reasons: [] },
+      );
+      const { result } = renderWithData(
+        [],
+        [makePackageReq('req-p1', 'can-approve'), makePackageReq('req-p2', 'cannot-approve')],
+      );
+      await act(async () => {});
+      await act(async () => {
+        await result.current.handleApproveAll();
+      });
+      expect(result.current.processedRequests['can-approve']?.status).toBe('approved');
+      expect(result.current.processedRequests['cannot-approve']).toBeUndefined();
+    });
+
+    it('skips items that are already processed', async () => {
+      const { result } = renderWithData([], [makePackageReq('req-p1', 'package-1')]);
+      await act(async () => {});
+      await act(async () => {
+        await result.current.handleReject({ packageId: 'package-1' });
+      });
+      mockApproveFn.mockClear();
+      await act(async () => {
+        await result.current.handleApproveAll();
+      });
+      expect(mockApproveFn).not.toHaveBeenCalled();
+    });
+
+    it('shows a success snackbar when all approvals succeed', async () => {
+      const { result } = renderWithData([], [makePackageReq('req-p1', 'package-1')]);
+      await act(async () => {});
+      await act(async () => {
+        await result.current.handleApproveAll();
+      });
+      expect(mockOpenSnackbar).toHaveBeenCalledWith(
+        expect.objectContaining({ color: 'success', message: 'request_page.approve_all_success' }),
+      );
+    });
+
+    it('shows a partial failure snackbar when some approvals fail', async () => {
+      let callCount = 0;
+      mockApproveFn.mockImplementation(() => ({
+        unwrap: vi.fn().mockImplementation(() => {
+          callCount++;
+          return callCount === 1
+            ? Promise.resolve({ lastUpdated: LAST_UPDATED })
+            : Promise.reject(new Error('API error'));
+        }),
+      }));
+      const { result } = renderWithData(
+        [],
+        [makePackageReq('req-p1', 'package-1'), makePackageReq('req-p2', 'package-2')],
+      );
+      await act(async () => {});
+      await act(async () => {
+        await result.current.handleApproveAll();
+      });
+      expect(mockOpenSnackbar).toHaveBeenCalledWith(
+        expect.objectContaining({
+          color: 'danger',
+          message: 'request_page.approve_all_partial_failed',
+        }),
+      );
+    });
+
+    it('bulkActionLoading is null after the operation completes', async () => {
+      const { result } = renderWithData([], [makePackageReq('req-p1', 'package-1')]);
+      await act(async () => {});
+      await act(async () => {
+        await result.current.handleApproveAll();
+      });
+      expect(result.current.bulkActionLoading).toBeNull();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+
+  describe('handleRejectAll', () => {
+    it('rejects all pending items, including those that cannotApprove', async () => {
+      mockCanDelegatePackage.mockImplementation((id: string) =>
+        id === 'package-2' ? { result: false, reasons: [] } : { result: true, reasons: [] },
+      );
+      const { result } = renderWithData(
+        [],
+        [makePackageReq('req-p1', 'package-1'), makePackageReq('req-p2', 'package-2')],
+      );
+      await act(async () => {});
+      await act(async () => {
+        await result.current.handleRejectAll();
+      });
+      expect(result.current.processedRequests['package-1']?.status).toBe('rejected');
+      expect(result.current.processedRequests['package-2']?.status).toBe('rejected');
+    });
+
+    it('skips items that are already processed', async () => {
+      const { result } = renderWithData([], [makePackageReq('req-p1', 'package-1')]);
+      await act(async () => {});
+      await act(async () => {
+        await result.current.handleApprove({ packageId: 'package-1' });
+      });
+      mockRejectFn.mockClear();
+      await act(async () => {
+        await result.current.handleRejectAll();
+      });
+      expect(mockRejectFn).not.toHaveBeenCalled();
+    });
+
+    it('shows a success snackbar when all rejections succeed', async () => {
+      const { result } = renderWithData([], [makePackageReq('req-p1', 'package-1')]);
+      await act(async () => {});
+      await act(async () => {
+        await result.current.handleRejectAll();
+      });
+      expect(mockOpenSnackbar).toHaveBeenCalledWith(
+        expect.objectContaining({ color: 'success', message: 'request_page.reject_all_success' }),
+      );
+    });
+
+    it('shows a partial failure snackbar when some rejections fail', async () => {
+      let callCount = 0;
+      mockRejectFn.mockImplementation(() => ({
+        unwrap: vi.fn().mockImplementation(() => {
+          callCount++;
+          return callCount === 1
+            ? Promise.resolve({ lastUpdated: LAST_UPDATED })
+            : Promise.reject(new Error('API error'));
+        }),
+      }));
+      const { result } = renderWithData(
+        [],
+        [makePackageReq('req-p1', 'package-1'), makePackageReq('req-p2', 'package-2')],
+      );
+      await act(async () => {});
+      await act(async () => {
+        await result.current.handleRejectAll();
+      });
+      expect(mockOpenSnackbar).toHaveBeenCalledWith(
+        expect.objectContaining({
+          color: 'danger',
+          message: 'request_page.reject_all_partial_failed',
+        }),
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+
+  describe('handleClose', () => {
+    it('calls the onClose callback', () => {
+      const { result } = renderHook(() => useRequestReview(mockRequest, mockOnClose));
+      act(() => {
+        result.current.handleClose();
+      });
+      expect(mockOnClose).toHaveBeenCalledOnce();
+    });
+
+    it('clears the snapshot and processedRequests', async () => {
+      const { result } = renderWithData([makeResourceReq('req-r1', 'resource-1')]);
+      await act(async () => {});
+      await act(async () => {
+        await result.current.handleApprove({ resourceId: 'resource-1' });
+      });
+
+      // Simulate the modal closing: queries return no data (request prop would become null)
+      vi.mocked(requestApiModule.useGetEnrichedReceivedResourceRequestsQuery).mockReturnValue({
+        data: [],
+        isLoading: false,
+        isFetching: false,
+      } as any);
+      vi.mocked(requestApiModule.useGetEnrichedReceivedPackageRequestsQuery).mockReturnValue({
+        data: [],
+        isLoading: false,
+        isFetching: false,
+      } as any);
+
+      await act(async () => {
+        result.current.handleClose();
+      });
+      expect(result.current.snapshotResources).toHaveLength(0);
+      expect(result.current.processedRequests).toEqual({});
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+
+  describe('handleSelection / resetSelection', () => {
+    it('sets selectedResource and clears selectedPackage', () => {
+      const resource = { identifier: 'resource-1' } as ServiceResource;
+      const { result } = renderHook(() => useRequestReview(mockRequest, mockOnClose));
+      act(() => {
+        result.current.handleSelection({ resource });
+      });
+      expect(result.current.selectedResource).toBe(resource);
+      expect(result.current.selectedPackage).toBeNull();
+    });
+
+    it('sets selectedPackage and clears selectedResource', () => {
+      const resource = { identifier: 'resource-1' } as ServiceResource;
+      const pkg = { id: 'package-1' } as AccessPackage;
+      const { result } = renderHook(() => useRequestReview(mockRequest, mockOnClose));
+      act(() => {
+        result.current.handleSelection({ resource });
+      });
+      act(() => {
+        result.current.handleSelection({ package: pkg });
+      });
+      expect(result.current.selectedPackage).toBe(pkg);
+      expect(result.current.selectedResource).toBeNull();
+    });
+
+    it('resetSelection clears both selected items', () => {
+      const resource = { identifier: 'resource-1' } as ServiceResource;
+      const { result } = renderHook(() => useRequestReview(mockRequest, mockOnClose));
+      act(() => {
+        result.current.handleSelection({ resource });
+      });
+      act(() => {
+        result.current.resetSelection();
+      });
+      expect(result.current.selectedResource).toBeNull();
+      expect(result.current.selectedPackage).toBeNull();
+    });
+  });
+});

--- a/src/features/amUI/requestPage/RequestReviewModal/useRequestReview.ts
+++ b/src/features/amUI/requestPage/RequestReviewModal/useRequestReview.ts
@@ -66,6 +66,9 @@ export const useRequestReview = (request: Request | null, onClose: () => void) =
     Record<string, DelegationCheckedRight[]>
   >({});
   const [actionLoading, setActionLoading] = useState<'approve' | 'reject' | null>(null);
+  const [bulkActionLoading, setBulkActionLoading] = useState<'approveAll' | 'rejectAll' | null>(
+    null,
+  );
   const { canDelegatePackage } = useAccessPackageDelegationCheck();
 
   // Reset state only when switching to a different party (not on every object reference change)
@@ -77,6 +80,7 @@ export const useRequestReview = (request: Request | null, onClose: () => void) =
     setProcessedRequests({});
     setDelegationChecks({});
     setActionLoading(null);
+    setBulkActionLoading(null);
   }, [requestPartyUuid]);
 
   useEffect(() => {
@@ -136,6 +140,7 @@ export const useRequestReview = (request: Request | null, onClose: () => void) =
     setProcessedRequests({});
     setDelegationChecks({});
     setActionLoading(null);
+    setBulkActionLoading(null);
     onClose();
   };
 
@@ -226,6 +231,63 @@ export const useRequestReview = (request: Request | null, onClose: () => void) =
     }
   };
 
+  const executeBulkAction = async (
+    type: 'approve_all' | 'reject_all',
+    items: { id: string; key: string }[],
+  ) => {
+    if (!actingParty?.partyUuid) return;
+    const partyUuid = actingParty.partyUuid;
+    const mutate = type === 'approve_all' ? approveRequest : rejectRequest;
+    const status: ProcessedStatus = type === 'approve_all' ? 'approved' : 'rejected';
+    setBulkActionLoading(type === 'approve_all' ? 'approveAll' : 'rejectAll');
+    try {
+      const results = await Promise.allSettled(
+        items.map(async ({ id, key }) => {
+          const result = await mutate({ party: partyUuid, id }).unwrap();
+          setProcessedRequests((prev) => ({
+            ...prev,
+            [key]: { status, handledAt: result.lastUpdated },
+          }));
+        }),
+      );
+      const anyFailed = results.some((r) => r.status === 'rejected');
+      openSnackbar({
+        message: t(
+          anyFailed ? `request_page.${type}_partial_failed` : `request_page.${type}_success`,
+        ),
+        color: anyFailed ? 'danger' : 'success',
+      });
+    } finally {
+      setBulkActionLoading(null);
+    }
+  };
+
+  const handleApproveAll = () =>
+    executeBulkAction('approve_all', [
+      ...snapshotRequests.resourceRequests
+        .filter(
+          (r) =>
+            !processedRequests[r.resource.identifier] &&
+            !cannotApprove({ resourceId: r.resource.identifier }),
+        )
+        .map((r) => ({ id: r.id, key: r.resource.identifier })),
+      ...snapshotRequests.packageRequests
+        .filter(
+          (p) => !processedRequests[p.package.id] && !cannotApprove({ packageId: p.package.id }),
+        )
+        .map((p) => ({ id: p.id, key: p.package.id })),
+    ]);
+
+  const handleRejectAll = () =>
+    executeBulkAction('reject_all', [
+      ...snapshotRequests.resourceRequests
+        .filter((r) => !processedRequests[r.resource.identifier])
+        .map((r) => ({ id: r.id, key: r.resource.identifier })),
+      ...snapshotRequests.packageRequests
+        .filter((p) => !processedRequests[p.package.id])
+        .map((p) => ({ id: p.id, key: p.package.id })),
+    ]);
+
   const handleSelection = ({
     resource,
     package: pkg,
@@ -253,6 +315,17 @@ export const useRequestReview = (request: Request | null, onClose: () => void) =
   const isLoadingRequests = isLoadingResourceRequests || isLoadingPackageRequests;
   const isFetchingRequests = isFetchingResourceRequests || isFetchingPackageRequests;
 
+  const pendingResourceIds = snapshotResources
+    .map((r) => r.identifier)
+    .filter((id) => !processedRequests[id]);
+  const pendingPackageIds = snapshotPackages
+    .map((p) => p.id)
+    .filter((id) => !processedRequests[id]);
+  const hasPendingRequests = pendingResourceIds.length > 0 || pendingPackageIds.length > 0;
+  const hasApprovableRequests =
+    pendingResourceIds.some((id) => !cannotApprove({ resourceId: id })) ||
+    pendingPackageIds.some((id) => !cannotApprove({ packageId: id }));
+
   return {
     isLoadingRequests,
     isFetchingRequests,
@@ -263,10 +336,15 @@ export const useRequestReview = (request: Request | null, onClose: () => void) =
     resetSelection,
     processedRequests,
     actionLoading,
+    bulkActionLoading,
     cannotApprove,
+    hasPendingRequests,
+    hasApprovableRequests,
     handleClose,
     handleApprove,
     handleReject,
+    handleApproveAll,
+    handleRejectAll,
     handleSelection,
   };
 };

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -1079,7 +1079,13 @@
     "error_partial_loading_requests": "Could not load all requests",
     "package_list_title": "Access packages:",
     "resource_list_title": "Services:",
-    "cannot_approve_package": "You lack this access package yourself and therefore cannot approve the request."
+    "cannot_approve_package": "You lack this access package yourself and therefore cannot approve the request.",
+    "approve_all": "Approve all",
+    "reject_all": "Reject all",
+    "approve_all_success": "All requests approved",
+    "approve_all_partial_failed": "Some approvals failed",
+    "reject_all_success": "All requests rejected",
+    "reject_all_partial_failed": "Some rejections failed"
   },
   "draft_request_page": {
     "page_title": "Power of Attorney Request - Altinn",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -1076,7 +1076,13 @@
     "error_partial_loading_requests": "Kunne ikke laste alle forespørsler",
     "package_list_title": "Tilgangspakker:",
     "resource_list_title": "Tjenester:",
-    "cannot_approve_package": "Du mangler denne tilgangspakken selv og kan derfor ikke godkjenne forespørselen."
+    "cannot_approve_package": "Du mangler denne tilgangspakken selv og kan derfor ikke godkjenne forespørselen.",
+    "approve_all": "Godkjenn alle",
+    "reject_all": "Avvis alle",
+    "approve_all_success": "Alle forespørsler godkjent",
+    "approve_all_partial_failed": "Noen godkjenninger feilet",
+    "reject_all_success": "Alle forespørsler avvist",
+    "reject_all_partial_failed": "Noen avvisninger feilet"
   },
   "draft_request_page": {
     "page_title": "Forespørsel om fullmakt - Altinn",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -1075,7 +1075,13 @@
     "error_partial_loading_requests": "Kunne ikkje laste alle førespurnader",
     "package_list_title": "Tilgangspakkar",
     "resource_list_title": "Tenester",
-    "cannot_approve_package": "Du manglar denne tilgangspakken sjølv og kan derfor ikkje godkjenne førespurnaden."
+    "cannot_approve_package": "Du manglar denne tilgangspakken sjølv og kan derfor ikkje godkjenne førespurnaden.",
+    "approve_all": "Godkjenn alle",
+    "reject_all": "Avvis alle",
+    "approve_all_success": "Alle førespurnader godkjende",
+    "approve_all_partial_failed": "Nokre godkjenningar feila",
+    "reject_all_success": "Alle førespurnader avviste",
+    "reject_all_partial_failed": "Nokre avvisingar feila"
   },
   "draft_request_page": {
     "page_title": "Førespurnad om fullmakt - Altinn",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<img width="1208" height="673" alt="image" src="https://github.com/user-attachments/assets/b298110f-95cc-41ec-a17d-53d3cc7b69e0" />

## Description
<!--- Describe your changes in detail -->

This PR introduces two new buttons to the request review modal: "Approve all" and "Reject all"

These buttons trigger bulk updates for all non-processed requests:
- Approve all: Approves all requests that the end-user can approve (excluding those that fail the canDelegate check)
- Reject all: Rejects all requests (including those that fails the canDelegate check)

Both buttons are disabled when they have no requests to approve/reject. However, we use aria-disabled instead of regular disabled to avoid needing custom focus handling when using keyboard navigation.

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/3633

<img width="1148" height="862" alt="image" src="https://github.com/user-attachments/assets/9266faca-06b7-4452-bfa4-a734f6eab2f7" />

<img width="1207" height="660" alt="image" src="https://github.com/user-attachments/assets/70a01396-1f5e-49e7-99c3-73163ce67aed" />
👆Added chevron on _all_ items, even with an active status, since they are now always clickable

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added bulk actions (“Approve all” and “Reject all”) to the request review modal, replacing the single footer action.
  - Bulk approve skips ineligible items; bulk reject targets all pending items.
  - Added bulk loading state and success vs partial-failure notifications; buttons are disabled when actions aren’t applicable or are in progress.
- **Localization**
  - Added English and Norwegian strings for bulk action labels and notifications.
- **Tests**
  - Added extensive hook tests covering bulk flows, eligibility rules, notifications, selection/reset, and close behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->