### PR TITLE
Hide sent requests from private person admins

### DIFF
--- a/src/features/amUI/common/PageLayoutWrapper/useSidebarItems.tsx
+++ b/src/features/amUI/common/PageLayoutWrapper/useSidebarItems.tsx
@@ -2,7 +2,7 @@ import { getCookie } from '@/resources/Cookie/CookieMethods';
 import {
   hasConsentPermission,
   hasCreateSystemUserPermission,
-  hasReporteesPermission,
+  hasReporteeListAdminAccess,
   hasSystemUserClientAdminPermission,
 } from '@/resources/utils/permissionUtils';
 import {
@@ -95,7 +95,7 @@ export const useSidebarItems = ({ isSmall }: { isSmall?: boolean }) => {
   }
 
   items.push(getUsersMenuItem(pathname, isLoading, isSmall));
-  if (hasReporteesPermission(reportee, isAdmin, isCurrentUserReportee)) {
+  if (hasReporteeListAdminAccess(reportee, isAdmin, isCurrentUserReportee)) {
     items.push(getReporteesMenuItem(pathname, isLoading, isSmall));
   }
 

--- a/src/features/amUI/landingPage/LandingPage.tsx
+++ b/src/features/amUI/landingPage/LandingPage.tsx
@@ -22,7 +22,7 @@ import { useTranslation } from 'react-i18next';
 import { useSearchParams } from 'react-router';
 import {
   hasConsentPermission,
-  hasReporteesPermission,
+  hasReporteeListAdminAccess,
   hasSystemUserClientAdminPermission,
   hasCreateSystemUserPermission,
 } from '@/resources/utils/permissionUtils';
@@ -146,7 +146,7 @@ export const LandingPage = () => {
       });
     }
 
-    if (hasReporteesPermission(reportee, isAdmin, isCurrentUserReportee)) {
+    if (hasReporteeListAdminAccess(reportee, isAdmin, isCurrentUserReportee)) {
       items.push({
         ...getReporteesMenuItem(),
         description: isCurrentUserReportee

--- a/src/features/amUI/reportees/ReporteesPage.tsx
+++ b/src/features/amUI/reportees/ReporteesPage.tsx
@@ -7,7 +7,7 @@ import { PageWrapper } from '@/components';
 import { getCookie } from '@/resources/Cookie/CookieMethods';
 import { useGetIsAdminQuery, useGetReporteeQuery } from '@/rtk/features/userInfoApi';
 import { useGetPartyFromLoggedInUserQuery } from '@/rtk/features/lookupApi';
-import { hasReporteesPermission } from '@/resources/utils/permissionUtils';
+import { hasReporteeListAdminAccess } from '@/resources/utils/permissionUtils';
 
 import { PageLayoutWrapper } from '../common/PageLayoutWrapper';
 import { PartyRepresentationProvider } from '../common/PartyRepresentationContext/PartyRepresentationContext';
@@ -35,7 +35,7 @@ export const ReporteesPage = () => {
         {!isLoading &&
         !reporteeLoading &&
         !currentUserIsLoading &&
-        !hasReporteesPermission(reportee, isAdmin, isCurrentUserReportee) ? (
+        !hasReporteeListAdminAccess(reportee, isAdmin, isCurrentUserReportee) ? (
           <DsAlert data-color='warning'>
             {t('reportees_page.not_admin_alert', { name: name || '' })}
           </DsAlert>

--- a/src/features/amUI/requestPage/RequestsPage.tsx
+++ b/src/features/amUI/requestPage/RequestsPage.tsx
@@ -30,10 +30,6 @@ const SENT_REQUESTS_TAB = 'sentRequests';
 export const RequestPage = () => {
   const { t } = useTranslation();
   const restoreFocus = useRestoreFocus();
-  const [selectedTab, setSelectedTab] = useTabState({
-    tabs: [INCOMING_REQUESTS_TAB, SENT_REQUESTS_TAB],
-    defaultTab: INCOMING_REQUESTS_TAB,
-  });
 
   useDocumentTitle(t('request_page.page_title'));
 
@@ -42,13 +38,20 @@ export const RequestPage = () => {
   const { data: currentUser } = useGetPartyFromLoggedInUserQuery();
   const isCurrentUserReportee = reportee?.partyUuid === currentUser?.partyUuid;
   const showSentRequestsTab = hasReporteeListAdminAccess(reportee, isAdmin, isCurrentUserReportee);
+
+  const [selectedTab, setSelectedTab] = useTabState({
+    tabs: showSentRequestsTab
+      ? [INCOMING_REQUESTS_TAB, SENT_REQUESTS_TAB]
+      : [INCOMING_REQUESTS_TAB],
+    defaultTab: INCOMING_REQUESTS_TAB,
+  });
   const {
     pendingRequests,
     isLoadingSentRequests,
     isLoadingReceivedRequests,
     isSentRequestsError,
     isReceivedRequestsError,
-  } = useRequests();
+  } = useRequests({ skipSentRequests: !showSentRequestsTab });
 
   const partyUuid = getCookie('AltinnPartyUuid');
   const { data: sentRequestCount } = useGetSentRequestsCountQuery(

--- a/src/features/amUI/requestPage/RequestsPage.tsx
+++ b/src/features/amUI/requestPage/RequestsPage.tsx
@@ -7,6 +7,8 @@ import { PageLayoutWrapper } from '../common/PageLayoutWrapper';
 import { Breadcrumbs } from '../common/Breadcrumbs/Breadcrumbs';
 import ReporteePageHeading from '../common/ReporteePageHeading';
 import { useGetIsAdminQuery, useGetReporteeQuery } from '@/rtk/features/userInfoApi';
+import { useGetPartyFromLoggedInUserQuery } from '@/rtk/features/lookupApi';
+import { hasReporteeListAdminAccess } from '@/resources/utils/permissionUtils';
 import { useDocumentTitle } from '@/resources/hooks/useDocumentTitle';
 import { useRequests } from '@/resources/hooks/useRequests';
 import { useGetSentRequestsCountQuery } from '@/rtk/features/requestApi';
@@ -37,6 +39,9 @@ export const RequestPage = () => {
 
   const { data: reportee, isLoading: isLoadingReportee } = useGetReporteeQuery();
   const { data: isAdmin, isLoading: isLoadingAdmin } = useGetIsAdminQuery();
+  const { data: currentUser } = useGetPartyFromLoggedInUserQuery();
+  const isCurrentUserReportee = reportee?.partyUuid === currentUser?.partyUuid;
+  const showSentRequestsTab = hasReporteeListAdminAccess(reportee, isAdmin, isCurrentUserReportee);
   const {
     pendingRequests,
     isLoadingSentRequests,
@@ -48,7 +53,7 @@ export const RequestPage = () => {
   const partyUuid = getCookie('AltinnPartyUuid');
   const { data: sentRequestCount } = useGetSentRequestsCountQuery(
     { party: partyUuid || '', status: ['Pending'] },
-    { skip: !partyUuid || !isAdmin },
+    { skip: !partyUuid || !isAdmin || !showSentRequestsTab },
   );
   const { requestsBadgeCount: receivedRequestCount } = useSidebarRequestCount({
     isAdmin,
@@ -95,11 +100,13 @@ export const RequestPage = () => {
                       label={t('request_page.incoming_requests')}
                       badge={receivedRequestsCount}
                     />
-                    <AmTabs.Tab
-                      value={SENT_REQUESTS_TAB}
-                      label={t('request_page.sent_requests')}
-                      badge={resolvedSentRequestCount}
-                    />
+                    {showSentRequestsTab && (
+                      <AmTabs.Tab
+                        value={SENT_REQUESTS_TAB}
+                        label={t('request_page.sent_requests')}
+                        badge={resolvedSentRequestCount}
+                      />
+                    )}
                   </AmTabs.List>
                   <AmTabs.Panel value={INCOMING_REQUESTS_TAB}>
                     <RequestsTabPanel
@@ -111,16 +118,18 @@ export const RequestPage = () => {
                       <PendingRequests pendingRequests={pendingRequests.received} />
                     </RequestsTabPanel>
                   </AmTabs.Panel>
-                  <AmTabs.Panel value={SENT_REQUESTS_TAB}>
-                    <RequestsTabPanel
-                      count={sentRequestCount ?? 0}
-                      isLoading={isLoadingSentRequests}
-                      isError={isSentRequestsError}
-                      emptyMessageKey='request_page.no_sent_requests'
-                    >
-                      <SentRequestsTabPanel pendingRequests={pendingRequests.sent} />
-                    </RequestsTabPanel>
-                  </AmTabs.Panel>
+                  {showSentRequestsTab && (
+                    <AmTabs.Panel value={SENT_REQUESTS_TAB}>
+                      <RequestsTabPanel
+                        count={sentRequestCount ?? 0}
+                        isLoading={isLoadingSentRequests}
+                        isError={isSentRequestsError}
+                        emptyMessageKey='request_page.no_sent_requests'
+                      >
+                        <SentRequestsTabPanel pendingRequests={pendingRequests.sent} />
+                      </RequestsTabPanel>
+                    </AmTabs.Panel>
+                  )}
                 </AmTabs>
               </RestoreFocusProvider>
             </PartyRepresentationProvider>

--- a/src/resources/hooks/useRequests.tsx
+++ b/src/resources/hooks/useRequests.tsx
@@ -15,7 +15,11 @@ import {
 import { formatDisplayName } from '@altinn/altinn-components';
 import { isSubUnitByType } from '@/resources/utils/reporteeUtils';
 
-export const useRequests = () => {
+interface UseRequestsOptions {
+  skipSentRequests?: boolean;
+}
+
+export const useRequests = ({ skipSentRequests = false }: UseRequestsOptions = {}) => {
   const partyUuid = getCookie('AltinnPartyUuid');
 
   const {
@@ -54,7 +58,7 @@ export const useRequests = () => {
     isError: isSentAccessRequestsError,
   } = useGetSentRequestsQuery(
     { party: partyUuid || '', status: ['Pending'], to: '' },
-    { skip: !partyUuid },
+    { skip: !partyUuid || skipSentRequests },
   );
   const {
     data: pendingReceivedAccessRequests,

--- a/src/resources/utils/permissionUtils.ts
+++ b/src/resources/utils/permissionUtils.ts
@@ -27,7 +27,7 @@ export const hasSystemUserClientAdminPermission = (
   return isOrganization && isClientAdmin;
 };
 
-export const hasReporteesPermission = (
+export const hasReporteeListAdminAccess = (
   reporteeInfo?: ReporteeInfo,
   isAdmin: boolean = false,
   isCurrentUserReportee: boolean = false,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<img width="1507" height="511" alt="image" src="https://github.com/user-attachments/assets/d7a420d1-0d68-4a70-b8a9-b1b62541c2aa" />

## Description
<!--- Describe your changes in detail -->
Hide the "sent" tab of the requests page unless the user is representing themselves, or they are access admin and is representing an organization.

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/3723

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Updated Access Controls**
  - Reportees navigation and related pages now use revised permission criteria to decide whether the “Reportees” shortcut and content are available.
  - Users without the required reportee-list admin access see the appropriate restricted-state experience.

- **Improved Requests Experience**
  - The “Sent Requests” tab is now shown only when eligible, and its content is not rendered otherwise.
  - Sent-request counts are retrieved only when the tab is available, avoiding unnecessary loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->