### PR TITLE
Add support for package draft requests

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/Interfaces/IRequestService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/Interfaces/IRequestService.cs
@@ -89,8 +89,8 @@ namespace Altinn.AccessManagement.UI.Core.Services.Interfaces
         /// <param name="id">The request id</param>
         /// <param name="languageCode">The language code for the response</param>
         /// <param name="cancellationToken">Cancellation token</param>
-        /// <returns>The request</returns>
-        Task<EnrichedResourceRequest> GetDraftRequest(Guid id, string languageCode, CancellationToken cancellationToken);
+        /// <returns>The request, enriched as either an <see cref="EnrichedResourceRequest"/> or an <see cref="EnrichedPackageRequest"/> depending on the request type</returns>
+        Task<RequestFE> GetDraftRequest(Guid id, string languageCode, CancellationToken cancellationToken);
 
         /// <summary>
         /// Creates a new resource request

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/RequestService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/RequestService.cs
@@ -81,9 +81,14 @@ namespace Altinn.AccessManagement.UI.Core.Services
         }
 
         /// <inheritdoc />
-        public async Task<EnrichedResourceRequest> GetDraftRequest(Guid id, string languageCode, CancellationToken cancellationToken)
+        public async Task<RequestFE> GetDraftRequest(Guid id, string languageCode, CancellationToken cancellationToken)
         {
             Request response = await _requestClient.GetDraftRequest(id, cancellationToken);
+            if (response.Type == "package")
+            {
+                return (await MapToEnrichedPackageRequestList(new[] { response }, languageCode)).First();
+            }
+
             return (await MapToEnrichedResourceRequestList(new[] { response }, languageCode)).First();
         }
 

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/Request/draftPackageRequest.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/Request/draftPackageRequest.json
@@ -1,0 +1,20 @@
+{
+  "id": "44444444-4444-4444-4444-444444444444",
+  "type": "package",
+  "status": "Draft",
+  "to": {
+    "id": "feb51634-0042-4ab0-a9db-8705300141a6",
+    "name": "EKSTRA SUNN KATT DAGSMARSJ",
+    "type": "organization"
+  },
+  "from": {
+    "id": "167536b5-f8ed-4c5a-8f48-0279507e53ae",
+    "name": "SITRONGUL MEDALJONG",
+    "type": "person"
+  },
+  "package": {
+    "id": "bacc9294-56fd-457f-930e-59ee4a7a3894",
+    "referenceId": "bacc9294-56fd-457f-930e-59ee4a7a3894"
+  },
+  "lastUpdated": "2025-06-01T12:00:00+00:00"
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/Request/draftPackageRequestByggesoknad.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/Request/draftPackageRequestByggesoknad.json
@@ -1,0 +1,20 @@
+{
+  "id": "44444444-4444-4444-4444-444444444442",
+  "type": "package",
+  "status": "Draft",
+  "to": {
+    "id": "feb51634-0042-4ab0-a9db-8705300141a6",
+    "name": "EKSTRA SUNN KATT DAGSMARSJ",
+    "type": "organization"
+  },
+  "from": {
+    "id": "167536b5-f8ed-4c5a-8f48-0279507e53ae",
+    "name": "SITRONGUL MEDALJONG",
+    "type": "person"
+  },
+  "package": {
+    "id": "1e40697b-e178-4920-8fbd-af5164b4d147",
+    "referenceId": "1e40697b-e178-4920-8fbd-af5164b4d147"
+  },
+  "lastUpdated": "2025-06-01T12:00:00+00:00"
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/Request/draftPackageRequestConfirmError.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Data/Request/draftPackageRequestConfirmError.json
@@ -1,0 +1,20 @@
+{
+  "id": "44444444-4444-4444-4444-444444444440",
+  "type": "package",
+  "status": "Draft",
+  "to": {
+    "id": "feb51634-0042-4ab0-a9db-8705300141a6",
+    "name": "EKSTRA SUNN KATT DAGSMARSJ",
+    "type": "organization"
+  },
+  "from": {
+    "id": "167536b5-f8ed-4c5a-8f48-0279507e53ae",
+    "name": "SITRONGUL MEDALJONG",
+    "type": "person"
+  },
+  "package": {
+    "id": "4c859601-9b2b-4662-af39-846f4117ad7a",
+    "referenceId": "4c859601-9b2b-4662-af39-846f4117ad7a"
+  },
+  "lastUpdated": "2025-06-01T12:00:00+00:00"
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/RequestClientMock.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/RequestClientMock.cs
@@ -120,6 +120,7 @@ namespace Altinn.AccessManagement.UI.Mocks.Mocks
         {
             ThrowExceptionIfTriggerParty(party.ToString());
             ThrowHttpStatusExceptionIfTriggerParty(party.ToString());
+            ThrowHttpStatusExceptionIfTriggerRequest(id);
 
             string dataPath = Path.Combine(dataFolder, "Request", "singleRequest.json");
             return await Task.FromResult(Util.GetMockData<Request>(dataPath));
@@ -130,6 +131,7 @@ namespace Altinn.AccessManagement.UI.Mocks.Mocks
         {
             ThrowExceptionIfTriggerParty(party.ToString());
             ThrowHttpStatusExceptionIfTriggerParty(party.ToString());
+            ThrowHttpStatusExceptionIfTriggerRequest(id);
 
             string dataPath = Path.Combine(dataFolder, "Request", "singleRequest.json");
             return await Task.FromResult(Util.GetMockData<Request>(dataPath));
@@ -173,6 +175,10 @@ namespace Altinn.AccessManagement.UI.Mocks.Mocks
             {
                 dataPath = Path.Combine(dataFolder, "Request", "draftPackageRequestByggesoknad.json");
             }
+            else if (id == Guid.Parse("44444444-4444-4444-4444-444444444440"))
+            {
+                dataPath = Path.Combine(dataFolder, "Request", "draftPackageRequestConfirmError.json");
+            }
 
             return await Task.FromResult(Util.GetMockData<Request>(dataPath));
         }
@@ -208,6 +214,14 @@ namespace Altinn.AccessManagement.UI.Mocks.Mocks
             if (id == "11111111-1111-1111-1111-111111111111")
             {
                 throw new HttpStatusException("StatusError", "Simulated backend error", HttpStatusCode.BadRequest, "");
+            }
+        }
+
+        private static void ThrowHttpStatusExceptionIfTriggerRequest(Guid id)
+        {
+            if (id == Guid.Parse("44444444-4444-4444-4444-444444444440"))
+            {
+                throw new HttpStatusException("StatusError", "Simulated confirm/withdraw error", HttpStatusCode.BadRequest, "");
             }
         }
     }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/RequestClientMock.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/RequestClientMock.cs
@@ -165,6 +165,10 @@ namespace Altinn.AccessManagement.UI.Mocks.Mocks
             {
                 dataPath = Path.Combine(dataFolder, "Request", "draftRequestInvalidResource.json");
             }
+            else if (id == Guid.Parse("44444444-4444-4444-4444-444444444444"))
+            {
+                dataPath = Path.Combine(dataFolder, "Request", "draftPackageRequest.json");
+            }
 
             return await Task.FromResult(Util.GetMockData<Request>(dataPath));
         }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/RequestClientMock.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/RequestClientMock.cs
@@ -169,6 +169,10 @@ namespace Altinn.AccessManagement.UI.Mocks.Mocks
             {
                 dataPath = Path.Combine(dataFolder, "Request", "draftPackageRequest.json");
             }
+            else if (id == Guid.Parse("44444444-4444-4444-4444-444444444442"))
+            {
+                dataPath = Path.Combine(dataFolder, "Request", "draftPackageRequestByggesoknad.json");
+            }
 
             return await Task.FromResult(Util.GetMockData<Request>(dataPath));
         }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/RequestControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/RequestControllerTest.cs
@@ -311,6 +311,27 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         }
 
         /// <summary>
+        ///     Test case: GetDraftRequest returns a single draft request for an access package by id
+        ///     Expected: GetDraftRequest returns the draft request enriched with the access package
+        /// </summary>
+        [Fact]
+        public async Task GetDraftRequest_ReturnsSingleDraftPackageRequest()
+        {
+            // Arrange
+            string requestId = "44444444-4444-4444-4444-444444444444";
+            string path = Path.Combine(_expectedDataPath, "Request", "getEnrichedDraftPackageRequest.json");
+            EnrichedPackageRequest expectedResponse = Util.GetMockData<EnrichedPackageRequest>(path);
+
+            // Act
+            HttpResponseMessage httpResponse = await _client.GetAsync($"accessmanagement/api/v1/request/draft/{requestId}");
+            EnrichedPackageRequest actualResponse = await httpResponse.Content.ReadFromJsonAsync<EnrichedPackageRequest>();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, httpResponse.StatusCode);
+            AssertionUtil.AssertEqual(expectedResponse, actualResponse);
+        }
+
+        /// <summary>
         ///     Test case: GetDraftRequest encounters an unexpected internal error
         ///     Expected: Returns 500 Internal Server Error
         /// </summary>

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/Request/getEnrichedDraftPackageRequest.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Data/ExpectedResults/Request/getEnrichedDraftPackageRequest.json
@@ -1,0 +1,161 @@
+{
+  "id": "44444444-4444-4444-4444-444444444444",
+  "type": "package",
+  "status": "Draft",
+  "to": {
+    "id": "feb51634-0042-4ab0-a9db-8705300141a6",
+    "name": "EKSTRA SUNN KATT DAGSMARSJ",
+    "type": "organization"
+  },
+  "from": {
+    "id": "167536b5-f8ed-4c5a-8f48-0279507e53ae",
+    "name": "SITRONGUL MEDALJONG",
+    "type": "person"
+  },
+  "packageId": "bacc9294-56fd-457f-930e-59ee4a7a3894",
+  "lastUpdated": "2025-06-01T12:00:00+00:00",
+  "package": {
+    "id": "bacc9294-56fd-457f-930e-59ee4a7a3894",
+    "name": "Bærekraft",
+    "urn": "urn:altinn:accesspackage:baerekraft",
+    "description": "Denne tilgangspakken gir fullmakter til tjenester knyttet til tiltak og rapportering på bærekraft. Ved regelverksendringer eller innføring av nye digitale tjenester kan det bli endringer i tilganger som fullmakten gir.",
+    "isDelegable": true,
+    "isAssignable": false,
+    "area": {
+      "group": {
+        "id": "7e2a3af8-08cb-43a9-bdd7-7d5c7e377145",
+        "name": "Allment",
+        "description": "Standard gruppe",
+        "entityTypeId": "8c216e2f-afdd-4234-9ba2-691c727bb33d",
+        "urn": null
+      },
+      "id": "a8834a7c-ed89-4c73-b5d5-19a2347f3b13",
+      "name": "Miljø, ulykke og sikkerhet",
+      "description": "Dette fullmaktsområdet omfatter tilgangspakker knyttet til miljø, ulykke og sikkerhet.",
+      "iconUrl": "People_HandHeart",
+      "groupId": "7e2a3af8-08cb-43a9-bdd7-7d5c7e377145",
+      "urn": "accesspackage:area:miljo_ulykke_og_sikkerhet"
+    },
+    "resources": [
+      {
+        "id": "b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1",
+        "providerId": "c4c4c4c4-c4c4-c4c4-c4c4-c4c4c4c4c4c4",
+        "typeId": "d5d5d5d5-d5d5-d5d5-d5d5-d5d5d5d5d5d5",
+        "name": "HMS-dokumentasjon",
+        "description": "Dokumentasjon relatert til helse, miljø og sikkerhet.",
+        "refId": "HMS-DOC-001",
+        "provider": {
+          "id": "c4c4c4c4-c4c4-c4c4-c4c4-c4c4c4c4c4c4",
+          "code": "digdir",
+          "name": "Digitaliseringsdirektoratet",
+          "logoUrl": "https://profilveileder.digdir.no/sites/leikanger/files/styles/xxxs/public/2022-04/Ikon_Emblem-blaasvart.png?itok=QU5K_ApH"
+        },
+        "type": {
+          "name": "GenericAccessResource"
+        }
+      },
+      {
+        "id": "b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2",
+        "providerId": "c5c5c5c5-c5c5-c5c5-c5c5-c5c5c5c5c5c5",
+        "typeId": "d6d6d6d6-d6d6-d6d6-d6d6-d6d6d6d6d6d6",
+        "name": "Risikovurdering",
+        "description": "Verktøy for gjennomføring og dokumentasjon av risikovurderinger.",
+        "refId": "RISK-TOOL-001",
+        "provider": {
+          "id": "c5c5c5c5-c5c5-c5c5-c5c5-c5c5c5c5c5c5",
+          "code": "dsb",
+          "name": "Direktoratet for samfunnssikkerhet og beredskap",
+          "logoUrl": "https://elvirksomhetsregisteret.dsb.no/assets/dsb_logo.png"
+        },
+        "type": {
+          "name": "GenericAccessResource"
+        }
+      },
+      {
+        "id": "b3b3b3b3-b3b3-b3b3-b3b3-b3b3b3b3b3b3",
+        "providerId": "c4c4c4c4-c4c4-c4c4-c4c4-c4c4c4c4c4c4",
+        "typeId": "d7d7d7d7-d7d7-d7d7-d7d7-d7d7d7d7d7d7",
+        "name": "Internkontroll-system",
+        "description": "System for dokumentasjon og gjennomføring av internkontroll.",
+        "refId": "INT-SYS-002",
+        "provider": {
+          "id": "c4c4c4c4-c4c4-c4c4-c4c4-c4c4c4c4c4c4",
+          "code": "dat",
+          "name": "Arbeidstilsynet",
+          "logoUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/03/Emblem_of_the_Norwegian_Labour_Inspection_Authority.svg/1200px-Emblem_of_the_Norwegian_Labour_Inspection_Authority.svg.png"
+        },
+        "type": {
+          "name": "GenericAccessResource"
+        }
+      },
+      {
+        "id": "b4b4b4b4-b4b4-b4b4-b4b4-b4b4b4b4b4b4",
+        "providerId": "c6c6c6c6-c6c6-c6c6-c6c6-c6c6c6c6c6c6",
+        "typeId": "d5d5d5d5-d5d5-d5d5-d5d5-d5d5d5d5d5d5",
+        "name": "Beredskapsplan",
+        "description": "Dokumentasjon av beredskapsplan for krisesituasjoner.",
+        "refId": "EMG-PLAN-003",
+        "provider": {
+          "id": "c6c6c6c6-c6c6-c6c6-c6c6-c6c6c6c6c6c6",
+          "code": "digdir",
+          "name": "Næringslivets sikkerhetsråd",
+          "logoUrl": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRN0P4ygJ_NZXANCOzMyKonqsKRP4zCPDSp866h4tyh7-9kLWOs09wEeKygX2WsaMVpLQI&usqp=CAU"
+        },
+        "type": {
+          "name": "GenericAccessResource"
+        }
+      },
+      {
+        "id": "b5b5b5b5-b5b5-b5b5-b5b5-b5b5b5b5b5b5",
+        "providerId": "c5c5c5c5-c5c5-c5c5-c5c5-c5c5c5c5c5c5",
+        "typeId": "d6d6d6d6-d6d6-d6d6-d6d6-d6d6d6d6d6d6",
+        "name": "Avviksrapportering",
+        "description": "System for rapportering og håndtering av avvik.",
+        "refId": "DEV-REP-001",
+        "provider": {
+          "id": "c5c5c5c5-c5c5-c5c5-c5c5-c5c5c5c5c5c5",
+          "code": "dsb",
+          "name": "Direktoratet for samfunnssikkerhet og beredskap",
+          "logoUrl": "https://elvirksomhetsregisteret.dsb.no/assets/dsb_logo.png"
+        },
+        "type": {
+          "name": "GenericAccessResource"
+        }
+      },
+      {
+        "id": "b6b6b6b6-b6b6-b6b6-b6b6-b6b6b6b6b6b6",
+        "providerId": "c7c7c7c7-c7c7-c7c7-c7c7-c7c7c7c7c7c7",
+        "typeId": "d8d8d8d8-d8d8-d8d8-d8d8-d8d8d8d8d8d8",
+        "name": "GDPR-samsvar",
+        "description": "Verktøy for å sikre etterlevelse av personvernforordningen.",
+        "refId": "GDPR-COMP-001",
+        "provider": {
+          "id": "c7c7c7c7-c7c7-c7c7-c7c7-c7c7c7c7c7c7",
+          "code": "dat",
+          "name": "Datatilsynet",
+          "logoUrl": "https://www.datatilsynet.no/globalassets/global/bilder/logoer/pvo_logo?width=756&height=710&quality=80&h=4c22bcfb2f8f388c55db321994144cb6d8fcba42"
+        },
+        "type": {
+          "name": "GenericAccessResource"
+        }
+      },
+      {
+        "id": "b7b7b7b7-b7b7-b7b7-b7b7-b7b7b7b7b7b7",
+        "providerId": "c6c6c6c6-c6c6-c6c6-c6c6-c6c6c6c6c6c6",
+        "typeId": "d7d7d7d7-d7d7-d7d7-d7d7-d7d7d7d7d7d7",
+        "name": "Sikkerhetsstyring",
+        "description": "System for håndtering av sikkerhetstiltak og sikkerhetsrevisjon.",
+        "refId": "SEC-MGT-002",
+        "provider": {
+          "id": "c6c6c6c6-c6c6-c6c6-c6c6-c6c6c6c6c6c6",
+          "code": "digdir",
+          "name": "Næringslivets sikkerhetsråd",
+          "logoUrl": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRN0P4ygJ_NZXANCOzMyKonqsKRP4zCPDSp866h4tyh7-9kLWOs09wEeKygX2WsaMVpLQI&usqp=CAU"
+        },
+        "type": {
+          "name": "GenericAccessResource"
+        }
+      }
+    ]
+  }
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/RequestController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/RequestController.cs
@@ -354,7 +354,7 @@ namespace Altinn.AccessManagement.UI.Controllers
             }
             catch (ResourceNotFoundException ex)
             {
-                return NotFound(ProblemDetailsFactory.CreateProblemDetails(HttpContext, (int?)StatusCodes.Status404NotFound, "Service Resource not found", detail: ex.Message));
+                return NotFound(ProblemDetailsFactory.CreateProblemDetails(HttpContext, (int?)StatusCodes.Status404NotFound, "Service resource or access package not found", detail: ex.Message));
             }
             catch (HttpStatusException statusEx)
             {

--- a/src/features/amUI/common/DelegationModal/AccessPackages/PackageHeader.tsx
+++ b/src/features/amUI/common/DelegationModal/AccessPackages/PackageHeader.tsx
@@ -7,9 +7,10 @@ import classes from './AccessPackageInfo.module.css';
 
 interface PackageHeaderProps {
   name: string;
+  level?: 1 | 2 | 3;
 }
 
-export const PackageHeader = ({ name }: PackageHeaderProps) => {
+export const PackageHeader = ({ name, level = 1 }: PackageHeaderProps) => {
   const isSmall = useIsMobileOrSmaller();
 
   return (
@@ -22,7 +23,7 @@ export const PackageHeader = ({ name }: PackageHeaderProps) => {
         />
       )}
       <DsHeading
-        level={1}
+        level={level}
         data-size={isSmall ? 'xs' : 'md'}
       >
         {name}

--- a/src/features/amUI/requestPage/DraftRequestPage/DraftRequestBody.tsx
+++ b/src/features/amUI/requestPage/DraftRequestPage/DraftRequestBody.tsx
@@ -1,4 +1,9 @@
-import { EnrichedResourceRequest } from '@/rtk/features/requestApi';
+import {
+  EnrichedPackageRequest,
+  EnrichedRequest,
+  EnrichedResourceRequest,
+  isEnrichedPackageRequest,
+} from '@/rtk/features/requestApi';
 import { useTranslation } from 'react-i18next';
 import { DsParagraph } from '@altinn/altinn-components';
 import { usePartyRepresentation } from '../../common/PartyRepresentationContext/PartyRepresentationContext';
@@ -6,14 +11,47 @@ import { useSingleRightsDelegationRightsData } from '../../common/DelegationModa
 import { ResourceHeading } from '../../common/DelegationModal/SingleRights/ResourceHeading';
 import { RightsSection } from '../../common/DelegationModal/SingleRights/RightsSection';
 import { DelegationAction } from '../../common/DelegationModal/EditModal';
+import { PackageHeader } from '../../common/DelegationModal/AccessPackages/PackageHeader';
+import { PackageMeta } from '../../common/DelegationModal/AccessPackages/PackageMeta';
 import classes from './DraftRequestPage.module.css';
 
 interface DraftRequestBodyProps {
-  request: EnrichedResourceRequest;
+  request: EnrichedRequest;
   fromName: string;
 }
 
-export const DraftRequestBody = ({ request, fromName }: DraftRequestBodyProps) => {
+export const DraftRequestBody = ({ request, fromName }: DraftRequestBodyProps) =>
+  isEnrichedPackageRequest(request) ? (
+    <PackageRequestBody request={request} />
+  ) : (
+    <ResourceRequestBody
+      request={request}
+      fromName={fromName}
+    />
+  );
+
+const PackageRequestBody = ({ request }: { request: EnrichedPackageRequest }) => (
+  <div>
+    <div
+      className={classes.resourceInfo}
+      data-size='sm'
+    >
+      <PackageHeader
+        name={request.package.name}
+        level={2}
+      />
+    </div>
+    <PackageMeta accessPackage={request.package} />
+  </div>
+);
+
+const ResourceRequestBody = ({
+  request,
+  fromName,
+}: {
+  request: EnrichedResourceRequest;
+  fromName: string;
+}) => {
   const { t } = useTranslation();
   const { selfParty } = usePartyRepresentation();
 

--- a/src/features/amUI/requestPage/DraftRequestPage/DraftRequestPage.tsx
+++ b/src/features/amUI/requestPage/DraftRequestPage/DraftRequestPage.tsx
@@ -5,7 +5,7 @@ import {
   useConfirmRequestMutation,
   useGetEnrichedDraftRequestQuery,
   useWithdrawRequestMutation,
-  type EnrichedResourceRequest,
+  type EnrichedRequest,
 } from '@/rtk/features/requestApi';
 import { useSearchParams } from 'react-router';
 import { getCookie } from '@/resources/Cookie/CookieMethods';
@@ -53,7 +53,7 @@ export const DraftRequestPage = () => {
     loadError: multiLoadError,
   } = useMultipleDraftRequests(stableMultiIds);
 
-  const representativeRequest: EnrichedResourceRequest | undefined = isMultiMode
+  const representativeRequest: EnrichedRequest | undefined = isMultiMode
     ? multiRequests[0]
     : request;
 

--- a/src/features/amUI/requestPage/DraftRequestPage/MultipleDraftRequestsView.tsx
+++ b/src/features/amUI/requestPage/DraftRequestPage/MultipleDraftRequestsView.tsx
@@ -1,9 +1,20 @@
 import React, { useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-import { DsAlert, DsButton, DsHeading } from '@altinn/altinn-components';
+import {
+  AccessPackageListItem,
+  DsAlert,
+  DsButton,
+  DsHeading,
+  List,
+} from '@altinn/altinn-components';
 import { ArrowLeftIcon, ChevronRightIcon } from '@navikt/aksel-icons';
 
-import type { EnrichedResourceRequest } from '@/rtk/features/requestApi';
+import {
+  isEnrichedPackageRequest,
+  type EnrichedPackageRequest,
+  type EnrichedRequest,
+  type EnrichedResourceRequest,
+} from '@/rtk/features/requestApi';
 import { useAutoFocusRef } from '@/resources/hooks/useAutoFocusRef';
 import { ResourceList } from '../../common/ResourceList/ResourceList';
 import { DraftRequestBody } from './DraftRequestBody';
@@ -15,7 +26,7 @@ import { usePartyRepresentation } from '../../common/PartyRepresentationContext/
 export type BatchActionType = 'confirm' | 'withdraw' | null;
 
 interface MultipleDraftRequestsViewProps {
-  requests: EnrichedResourceRequest[];
+  requests: EnrichedRequest[];
   fromName: string;
   onBatchComplete: (actionType: BatchActionType) => void;
 }
@@ -26,7 +37,7 @@ export const MultipleDraftRequestsView = ({
   onBatchComplete,
 }: MultipleDraftRequestsViewProps) => {
   const { t } = useTranslation();
-  const [selectedRequest, setSelectedRequest] = useState<EnrichedResourceRequest | null>(null);
+  const [selectedRequest, setSelectedRequest] = useState<EnrichedRequest | null>(null);
   const { selfParty } = usePartyRepresentation();
 
   const {
@@ -39,10 +50,18 @@ export const MultipleDraftRequestsView = ({
 
   const backButtonRef = useAutoFocusRef<HTMLButtonElement>();
 
-  const resources = requests.map((r) => r.resource);
+  // While there are failures, only the failed requests are shown so the user can retry them
+  const failedRequestIds = new Set(failedRequests.map((f) => f.request.id));
+  const visibleRequests =
+    failedRequests.length > 0 ? requests.filter((r) => failedRequestIds.has(r.id)) : requests;
 
-  const handleSelect = (resource: (typeof resources)[number]) => {
-    const match = requests.find((r) => r.resource.identifier === resource.identifier);
+  const packageRequests = visibleRequests.filter(isEnrichedPackageRequest);
+  const resourceRequests = visibleRequests.filter(
+    (r): r is EnrichedResourceRequest => !isEnrichedPackageRequest(r),
+  );
+
+  const handleSelectResource = (resource: EnrichedResourceRequest['resource']) => {
+    const match = resourceRequests.find((r) => r.resource.identifier === resource.identifier);
     if (match) {
       setSelectedRequest(match);
     }
@@ -59,6 +78,9 @@ export const MultipleDraftRequestsView = ({
     const succeeded = await rawWithdrawAll();
     if (succeeded) onBatchComplete('withdraw');
   };
+
+  const displayFromName =
+    requests[0].from.id === selfParty?.partyUuid ? t('common.you_uppercase') : fromName;
 
   if (selectedRequest) {
     return (
@@ -80,55 +102,77 @@ export const MultipleDraftRequestsView = ({
     );
   }
 
+  const seeDetailsControls = (
+    <div className={classes.seeDetails}>
+      {t('common.see_details')}{' '}
+      <ChevronRightIcon
+        fontSize={'1.2rem'}
+        aria-hidden='true'
+      />
+    </div>
+  );
+
   return (
     <div className={classes.multipleDraftRequests}>
       <div aria-live='polite'>
         {failedRequests.length > 0 && (
           <DsAlert data-color='danger'>
             {t('draft_request_page.batch_partial_error', {
-              resources: failedRequests.map((f) => f.resourceName).join(', '),
+              resources: failedRequests.map((f) => f.name).join(', '),
             })}
           </DsAlert>
         )}
       </div>
-      <DsHeading
-        data-size='sm'
-        level={2}
-        id='multiple-services-title'
-      >
-        <Trans
-          i18nKey={'draft_request_page.multiple_services_title'}
-          components={{ b: <strong /> }}
-          values={{
-            name:
-              requests[0].from.id === selfParty?.partyUuid ? t('common.you_uppercase') : fromName,
-          }}
-        />
-      </DsHeading>
-      <ResourceList
-        size='xs'
-        border='dotted'
-        enableSearch={false}
-        showDetails={false}
-        resources={
-          failedRequests.length > 0
-            ? resources.filter((r) =>
-                failedRequests.some((f) => f.request.resourceId === r.identifier),
-              )
-            : resources
-        }
-        onSelect={handleSelect}
-        ariaLabelledBy='multiple-services-title'
-        renderControls={(resource) => (
-          <div className={classes.seeDetails}>
-            {t('common.see_details')}{' '}
-            <ChevronRightIcon
-              fontSize={'1.2rem'}
-              aria-hidden='true'
+      {packageRequests.length > 0 && (
+        <>
+          <DsHeading
+            data-size='sm'
+            level={2}
+            id='multiple-packages-title'
+          >
+            <Trans
+              i18nKey={'draft_request_page.multiple_packages_title'}
+              components={{ b: <strong /> }}
+              values={{ name: displayFromName }}
             />
-          </div>
-        )}
-      />
+          </DsHeading>
+          <List aria-labelledby='multiple-packages-title'>
+            {packageRequests.map((packageRequest) => (
+              <DraftPackageRow
+                key={packageRequest.id}
+                request={packageRequest}
+                controls={seeDetailsControls}
+                onClick={() => setSelectedRequest(packageRequest)}
+              />
+            ))}
+          </List>
+        </>
+      )}
+      {resourceRequests.length > 0 && (
+        <>
+          <DsHeading
+            data-size='sm'
+            level={2}
+            id='multiple-services-title'
+          >
+            <Trans
+              i18nKey={'draft_request_page.multiple_services_title'}
+              components={{ b: <strong /> }}
+              values={{ name: displayFromName }}
+            />
+          </DsHeading>
+          <ResourceList
+            size='xs'
+            border='dotted'
+            enableSearch={false}
+            showDetails={false}
+            resources={resourceRequests.map((r) => r.resource)}
+            onSelect={handleSelectResource}
+            ariaLabelledBy='multiple-services-title'
+            renderControls={() => seeDetailsControls}
+          />
+        </>
+      )}
       <div className={classes.buttonRow}>
         <DsButton
           variant='primary'
@@ -148,5 +192,29 @@ export const MultipleDraftRequestsView = ({
         </DsButton>
       </div>
     </div>
+  );
+};
+
+interface DraftPackageRowProps {
+  request: EnrichedPackageRequest;
+  controls: React.ReactNode;
+  onClick: () => void;
+}
+
+const DraftPackageRow = ({ request, controls, onClick }: DraftPackageRowProps) => {
+  const { t } = useTranslation();
+  return (
+    <AccessPackageListItem
+      id={request.package.id}
+      name={request.package.name}
+      description={t('access_packages.package_number_of_resources', {
+        count: request.package.resources.length,
+      })}
+      interactive
+      size='xs'
+      border='dotted'
+      controls={controls}
+      onClick={onClick}
+    />
   );
 };

--- a/src/features/amUI/requestPage/DraftRequestPage/SingleDraftRequestView.tsx
+++ b/src/features/amUI/requestPage/DraftRequestPage/SingleDraftRequestView.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { DsAlert, DsButton } from '@altinn/altinn-components';
-import type { EnrichedResourceRequest } from '@/rtk/features/requestApi';
+import type { EnrichedRequest } from '@/rtk/features/requestApi';
 import { PartyRepresentationProvider } from '../../common/PartyRepresentationContext/PartyRepresentationContext';
 import { DraftRequestBody } from './DraftRequestBody';
 import classes from './DraftRequestPage.module.css';
 
 interface SingleDraftRequestViewProps {
-  request: EnrichedResourceRequest;
+  request: EnrichedRequest;
   fromName: string;
   partyUuid: string;
   onConfirmRequest: () => void;

--- a/src/features/amUI/requestPage/DraftRequestPage/useBatchRequestAction.ts
+++ b/src/features/amUI/requestPage/DraftRequestPage/useBatchRequestAction.ts
@@ -2,14 +2,15 @@ import { useState, useCallback, useRef } from 'react';
 import {
   useConfirmRequestMutation,
   useWithdrawRequestMutation,
-  type EnrichedResourceRequest,
+  type EnrichedRequest,
+  isEnrichedPackageRequest,
   requestApi,
 } from '@/rtk/features/requestApi';
 import { useAppDispatch } from '@/rtk/app/hooks';
 
 export interface FailedRequest {
-  request: EnrichedResourceRequest;
-  resourceName: string;
+  request: EnrichedRequest;
+  name: string;
 }
 
 interface UseBatchRequestActionResult {
@@ -21,9 +22,7 @@ interface UseBatchRequestActionResult {
   failedRequests: FailedRequest[];
 }
 
-export const useBatchRequestAction = (
-  requests: EnrichedResourceRequest[],
-): UseBatchRequestActionResult => {
+export const useBatchRequestAction = (requests: EnrichedRequest[]): UseBatchRequestActionResult => {
   const [confirmRequest] = useConfirmRequestMutation();
   const [withdrawRequest] = useWithdrawRequestMutation();
   const dispatch = useAppDispatch();
@@ -36,10 +35,7 @@ export const useBatchRequestAction = (
   const lastActionRef = useRef<'confirm' | 'withdraw' | null>(null);
 
   const performAction = useCallback(
-    async (
-      targetRequests: EnrichedResourceRequest[],
-      action: 'confirm' | 'withdraw',
-    ): Promise<boolean> => {
+    async (targetRequests: EnrichedRequest[], action: 'confirm' | 'withdraw'): Promise<boolean> => {
       setIsProcessing(true);
       setFailedRequests([]);
       setAllSucceeded(false);
@@ -58,7 +54,7 @@ export const useBatchRequestAction = (
           const req = targetRequests[index];
           failed.push({
             request: req,
-            resourceName: req.resource.title,
+            name: isEnrichedPackageRequest(req) ? req.package.name : req.resource.title,
           });
         }
       });

--- a/src/features/amUI/requestPage/DraftRequestPage/useBatchRequestAction.ts
+++ b/src/features/amUI/requestPage/DraftRequestPage/useBatchRequestAction.ts
@@ -37,7 +37,6 @@ export const useBatchRequestAction = (requests: EnrichedRequest[]): UseBatchRequ
   const performAction = useCallback(
     async (targetRequests: EnrichedRequest[], action: 'confirm' | 'withdraw'): Promise<boolean> => {
       setIsProcessing(true);
-      setFailedRequests([]);
       setAllSucceeded(false);
       setActionType(action);
       lastActionRef.current = action;
@@ -92,6 +91,7 @@ export const useBatchRequestAction = (requests: EnrichedRequest[]): UseBatchRequ
         succeeded = stillFailedRequests.length === 0;
         setAllSucceeded(succeeded);
       } else {
+        setFailedRequests([]);
         succeeded = true;
         setAllSucceeded(true);
       }

--- a/src/features/amUI/requestPage/DraftRequestPage/useMultipleDraftRequests.ts
+++ b/src/features/amUI/requestPage/DraftRequestPage/useMultipleDraftRequests.ts
@@ -1,9 +1,9 @@
 import { useEffect, useMemo, useRef } from 'react';
 import { useAppDispatch, useAppSelector } from '@/rtk/app/hooks';
-import { requestApi, type EnrichedResourceRequest } from '@/rtk/features/requestApi';
+import { requestApi, type EnrichedRequest } from '@/rtk/features/requestApi';
 
 interface UseMultipleDraftRequestsResult {
-  requests: EnrichedResourceRequest[];
+  requests: EnrichedRequest[];
   isLoading: boolean;
   loadError: boolean;
 }
@@ -31,9 +31,7 @@ export const useMultipleDraftRequests = (ids: string[]): UseMultipleDraftRequest
 
   const results = useAppSelector((state) => selectors.map((sel) => sel(state)));
 
-  const requests = results
-    .map((r) => r.data)
-    .filter((d): d is EnrichedResourceRequest => d !== undefined);
+  const requests = results.map((r) => r.data).filter((d): d is EnrichedRequest => d !== undefined);
 
   const isLoading = results.some((r) => (r.isLoading || r.isUninitialized) && !r.data);
   const loadError = results.every((r) => r.isError && !r.data); // Drop invalid IDs silently, but show error if all are invalid or fail to load

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -1088,8 +1088,8 @@
   "draft_request_page": {
     "page_title": "Power of Attorney Request - Altinn",
     "heading": "Do you want to request access to <strong>{{to_name}}</strong>?",
-    "intro_person": "A proposal for access to a service on your behalf has been created, but you must approve it for it to take effect. The request will only be sent to <strong>{{to_name}}</strong> if you agree.",
-    "intro_company": "A proposal for access to a service on behalf of <strong>{{from_name}}</strong> has been created, but you must approve it for it to take effect. The request will only be sent to <strong>{{to_name}}</strong> if you agree.",
+    "intro_person": "A proposal for access on your behalf has been created, but you must approve it for it to take effect. The request will only be sent to <strong>{{to_name}}</strong> if you agree.",
+    "intro_company": "A proposal for access on behalf of <strong>{{from_name}}</strong> has been created, but you must approve it for it to take effect. The request will only be sent to <strong>{{to_name}}</strong> if you agree.",
     "confirm_request": "Yes, request access",
     "withdraw_request": "No, reject",
     "loading_request": "Loading request",
@@ -1102,8 +1102,9 @@
     "request_withdrawn_info": "You have rejected the request and will therefore not receive power of attorney for <strong>{{to_name}}</strong>.",
     "close_window_info": "You can now close this window.",
     "missing_request_id": "Cannot load request: requestId-parameter is not set in url",
-    "batch_partial_error": "Could not process the following resources: {{resources}}. Please try again.",
-    "multiple_services_title": "<strong>{{name}}</strong> request the following services:"
+    "batch_partial_error": "Could not process the following requests: {{resources}}. Please try again.",
+    "multiple_services_title": "<strong>{{name}}</strong> request the following services:",
+    "multiple_packages_title": "<strong>{{name}}</strong> request the following access packages:"
   },
   "add_altinn2_account_page": {
     "page_title": "Add account - Altinn",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -1085,8 +1085,8 @@
   "draft_request_page": {
     "page_title": "Forespørsel om fullmakt - Altinn",
     "heading": "Vil du be om tilgang til <strong>{{to_name}}</strong>?",
-    "intro_person": "Det er opprettet et forslag om tilgang til en tjeneste på dine vegne, men du må selv godkjenne den for at den skal tre i kraft. Forespørselen vil kun sendes til <strong>{{to_name}}</strong> dersom du sier deg enig.",
-    "intro_company": "Det er opprettet et forslag om tilgang til en tjeneste på vegne av <strong>{{from_name}}</strong>, men du må selv godkjenne den for at den skal tre i kraft. Forespørselen vil kun sendes til <strong>{{to_name}}</strong> dersom du sier deg enig.",
+    "intro_person": "Det er opprettet et forslag om tilgang på dine vegne, men du må selv godkjenne det for at det skal tre i kraft. Forespørselen vil kun sendes til <strong>{{to_name}}</strong> dersom du sier deg enig.",
+    "intro_company": "Det er opprettet et forslag om tilgang på vegne av <strong>{{from_name}}</strong>, men du må selv godkjenne det for at det skal tre i kraft. Forespørselen vil kun sendes til <strong>{{to_name}}</strong> dersom du sier deg enig.",
     "confirm_request": "Ja, be om tilgang",
     "withdraw_request": "Nei, avvis",
     "loading_request": "Laster forespørsel",
@@ -1099,8 +1099,9 @@
     "request_withdrawn_info": "Du har avvist forespørselen og vil dermed ikke få fullmakt til <strong>{{to_name}}</strong>.",
     "close_window_info": "Du kan nå lukke dette vinduet.",
     "missing_request_id": "Kan ikke laste forespørsel: requestId-parameter er ikke satt i url",
-    "batch_partial_error": "Kunne ikke behandle følgende ressurser: {{resources}}. Vennligst prøv igjen.",
-    "multiple_services_title": "<strong>{{name}}</strong> ber om følgende tjenester:"
+    "batch_partial_error": "Kunne ikke behandle følgende forespørsler: {{resources}}. Vennligst prøv igjen.",
+    "multiple_services_title": "<strong>{{name}}</strong> ber om følgende tjenester:",
+    "multiple_packages_title": "<strong>{{name}}</strong> ber om følgende tilgangspakker:"
   },
   "add_altinn2_account_page": {
     "page_title": "Legg til konto - Altinn",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -1084,8 +1084,8 @@
   "draft_request_page": {
     "page_title": "Førespurnad om fullmakt - Altinn",
     "heading": "Vil du be om tilgang til <strong>{{to_name}}</strong>?",
-    "intro_person": "Det er oppretta eit forslag om tilgang til ei teneste på dine vegner, men du må sjølv godkjenne det for at ho skal tre i kraft. Førespurnaden vil berre bli sendt til <strong>{{to_name}}</strong> dersom du seier deg einig.",
-    "intro_company": "Det er oppretta eit forslag om tilgang til ei teneste på vegner av <strong>{{from_name}}</strong>, men du må sjølv godkjenne det for at ho skal tre i kraft. Førespurnaden vil berre sendast til <strong>{{to_name}}</strong> dersom du seier deg einig.",
+    "intro_person": "Det er oppretta eit forslag om tilgang på dine vegner, men du må sjølv godkjenne det for at det skal tre i kraft. Førespurnaden vil berre bli sendt til <strong>{{to_name}}</strong> dersom du seier deg einig.",
+    "intro_company": "Det er oppretta eit forslag om tilgang på vegner av <strong>{{from_name}}</strong>, men du må sjølv godkjenne det for at det skal tre i kraft. Førespurnaden vil berre sendast til <strong>{{to_name}}</strong> dersom du seier deg einig.",
     "confirm_request": "Ja, be om tilgang",
     "withdraw_request": "Nei, avslå",
     "loading_request": "Lastar førespurnad",
@@ -1098,8 +1098,9 @@
     "request_withdrawn_info": "Du har avslått førespurnaden og vil dermed ikkje få fullmakt til <strong>{{to_name}}</strong>.",
     "close_window_info": "Du kan no lukke dette vinduet.",
     "missing_request_id": "Kan ikkje laste førespurnaden: requestId-parameter er ikkje sett i url",
-    "batch_partial_error": "Kunne ikkje behandle følgande ressursar: {{resources}}. Ver venleg og prøv igjen.",
-    "multiple_services_title": "<strong>{{name}}</strong> ber om følgande tenester:"
+    "batch_partial_error": "Kunne ikkje behandle følgande førespurnader: {{resources}}. Ver venleg og prøv igjen.",
+    "multiple_services_title": "<strong>{{name}}</strong> ber om følgande tenester:",
+    "multiple_packages_title": "<strong>{{name}}</strong> ber om følgande tilgangspakkar:"
   },
   "add_altinn2_account_page": {
     "page_title": "Legg til konto - Altinn",

--- a/src/rtk/features/requestApi.ts
+++ b/src/rtk/features/requestApi.ts
@@ -25,6 +25,12 @@ export interface EnrichedPackageRequest extends RequestDto {
   package: AccessPackage;
 }
 
+export type EnrichedRequest = EnrichedResourceRequest | EnrichedPackageRequest;
+
+export const isEnrichedPackageRequest = (
+  request: EnrichedRequest,
+): request is EnrichedPackageRequest => request.type === 'package';
+
 const baseUrl = `${import.meta.env.BASE_URL}accessmanagement/api/v1/request`;
 
 export const requestApi = createApi({
@@ -201,7 +207,7 @@ export const requestApi = createApi({
     }),
 
     // draft request page query
-    getEnrichedDraftRequest: builder.query<EnrichedResourceRequest, { id: string }>({
+    getEnrichedDraftRequest: builder.query<EnrichedRequest, { id: string }>({
       query: ({ id }) => {
         return `draft/${id}`;
       },


### PR DESCRIPTION

Oppdaterer siden for bekreftelse av draft-forespørsler til også å støtte tilgangspakker
- Draft-endepunktet returnerer nå `EnrichedResourceRequest | EnrichedPackageRequest`.
- Enkeltvisningen viser pakker med de felles `PackageHeader`/`PackageMeta`-komponentene.
- multivisningen har fått en egen pakkeseksjon med «Se detaljer»-rader, og godkjenn/avvis alle
- `GET request/draft/{id}` beriker nå ut fra forespørselstypen og returnerer riktig modell.

<img width="1080" height="630" alt="Skjermbilde 2026-07-20 kl  16 10 08" src="https://github.com/user-attachments/assets/85ae492c-c41d-4a04-b722-82f2e94c6052" />

Test med mock aktivert (`MockSettings.Request: true`):
- Pakke: https://am.ui.at22.altinn.cloud/accessmanagement/ui/requests/resource?requestId=44444444-4444-4444-4444-444444444442
- Tjeneste: https://am.ui.at22.altinn.cloud/accessmanagement/ui/requests/resource?requestId=44444444-4444-4444-4444-444444444444
- Flere/blandet: https://am.ui.at22.altinn.cloud/accessmanagement/ui/requests/resource?requestId=44444444-4444-4444-4444-444444444444&requestId=44444444-4444-4444-4444-444444444443&requestId=44444444-4444-4444-4444-444444444442
- Feil ved `draft/confirm`: https://am.ui.at22.altinn.cloud/accessmanagement/ui/requests/resource?requestId=44444444-4444-4444-4444-444444444444&requestId=44444444-4444-4444-4444-444444444443&requestId=44444444-4444-4444-4444-444444444442&requestId=44444444-4444-4444-4444-444444444440

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/2927

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)



## Summary by CodeRabbit

* **New Features**
  * Draft access requests now support both individual services and access packages.
  * Multiple-request screens can display and act on mixed service + package draft requests, including package-specific listing and details.
* **Bug Fixes**
  * Batch failure messaging and request-not-found feedback now cover both services and access packages more accurately.
* **Localization**
  * Updated English and Norwegian text for draft access proposals and batch wording, and added strings for multiple access package requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->