### PR TITLE
reuse empty text component in from client list

### DIFF
--- a/src/features/amUI/agentDetails/AgentDetails.tsx
+++ b/src/features/amUI/agentDetails/AgentDetails.tsx
@@ -144,38 +144,32 @@ export const AgentDetails = () => {
             >
               {t('client_administration_page.agent_has_clients_tab')}
             </DsHeading>
-            {clientsWithAgentAccess.length > 0 ? (
-              <AgentDetailsClientsList
-                clients={clientsWithAgentAccess}
-                agentAccessPackages={agentAccessPackages ?? []}
-                isLoading={isAddingAgentAccessPackages || isRemovingAgentAccessPackages}
-                toPartyUuid={toPartyUuid}
-                actingPartyUuid={actingPartyUuid}
-                addAgentAccessPackages={addAgentAccessPackages}
-                removeAgentAccessPackages={removeAgentAccessPackages}
-                searchString={searchString}
-              />
-            ) : (
-              <DsParagraph>{t('client_administration_page.no_delegations')}</DsParagraph>
-            )}
+            <AgentDetailsClientsList
+              clients={clientsWithAgentAccess}
+              agentAccessPackages={agentAccessPackages ?? []}
+              isLoading={isAddingAgentAccessPackages || isRemovingAgentAccessPackages}
+              toPartyUuid={toPartyUuid}
+              actingPartyUuid={actingPartyUuid}
+              addAgentAccessPackages={addAgentAccessPackages}
+              removeAgentAccessPackages={removeAgentAccessPackages}
+              searchString={searchString}
+              emptyText={t('client_administration_page.no_delegations')}
+            />
             <ClientAdminDetails
               heading={t('client_administration_page.agent_can_get_clients_tab')}
               searchString={searchString}
             >
-              {clientsWithoutAgentAccess.length > 0 ? (
-                <AgentDetailsClientsList
-                  clients={clientsWithoutAgentAccess}
-                  agentAccessPackages={agentAccessPackages ?? []}
-                  toPartyUuid={toPartyUuid}
-                  actingPartyUuid={actingPartyUuid}
-                  isLoading={isAddingAgentAccessPackages || isRemovingAgentAccessPackages}
-                  addAgentAccessPackages={addAgentAccessPackages}
-                  removeAgentAccessPackages={removeAgentAccessPackages}
-                  searchString={searchString}
-                />
-              ) : (
-                <DsParagraph>{t('client_administration_page.no_clients')}</DsParagraph>
-              )}
+              <AgentDetailsClientsList
+                clients={clientsWithoutAgentAccess}
+                agentAccessPackages={agentAccessPackages ?? []}
+                toPartyUuid={toPartyUuid}
+                actingPartyUuid={actingPartyUuid}
+                isLoading={isAddingAgentAccessPackages || isRemovingAgentAccessPackages}
+                addAgentAccessPackages={addAgentAccessPackages}
+                removeAgentAccessPackages={removeAgentAccessPackages}
+                searchString={searchString}
+                emptyText={t('client_administration_page.no_clients')}
+              />
             </ClientAdminDetails>
           </>
         )}

--- a/src/features/amUI/agentDetails/AgentDetailsClientsList.tsx
+++ b/src/features/amUI/agentDetails/AgentDetailsClientsList.tsx
@@ -21,6 +21,7 @@ type AgentDetailsClientsListProps = {
   addAgentAccessPackages: AddAgentAccessPackagesFn;
   removeAgentAccessPackages: RemoveAgentAccessPackagesFn;
   searchString?: string;
+  emptyText?: string;
 };
 
 export const AgentDetailsClientsList = ({
@@ -32,6 +33,7 @@ export const AgentDetailsClientsList = ({
   addAgentAccessPackages,
   removeAgentAccessPackages,
   searchString,
+  emptyText,
 }: AgentDetailsClientsListProps) => {
   const delegateDisabled = isLoading || !toPartyUuid || !actingPartyUuid;
   const removeDisabled = isLoading || !toPartyUuid || !actingPartyUuid;
@@ -55,6 +57,7 @@ export const AgentDetailsClientsList = ({
       addDisabled={delegateDisabled}
       removeDisabled={removeDisabled}
       searchString={searchString}
+      emptyText={emptyText}
       onAddAccessPackage={(
         { clientId, roleCode, packageId, accessPackageName },
         onSuccess?: () => void,

--- a/src/features/amUI/common/ClientAccessList/ClientAccessList.tsx
+++ b/src/features/amUI/common/ClientAccessList/ClientAccessList.tsx
@@ -53,6 +53,7 @@ type ClientAccessListProps = {
   ) => void | Promise<void>;
   requireDelegableForActions?: boolean;
   emptyAccessText?: string;
+  emptyText?: string;
   searchString?: string;
 };
 
@@ -74,6 +75,7 @@ export const ClientAccessList = ({
   onRemoveAccessPackage,
   requireDelegableForActions = true,
   emptyAccessText,
+  emptyText,
   searchString,
 }: ClientAccessListProps) => {
   const { t } = useTranslation();
@@ -255,6 +257,7 @@ export const ClientAccessList = ({
     <>
       <UserListItems
         items={userListItems}
+        emptyText={emptyText}
         searchString={searchString}
       />
       <ClientPackageInfoModal


### PR DESCRIPTION
## Description
- Reuse empty text display in client list.

before:
<img width="430" height="346" alt="image" src="https://github.com/user-attachments/assets/b4f64d3c-aec8-4535-81b4-58c9cde95724" />

after:
<img width="433" height="410" alt="image" src="https://github.com/user-attachments/assets/d7441a12-2fcf-4b3f-b2a7-2a3212a4b402" />


## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved empty-state handling in agent client lists.
  * Added clear messages when no delegated clients or available clients are present.
  * Preserved loading and client access management actions while displaying empty states consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->