### PR TITLE
Read feature flags from Azure App Configuration

### DIFF
--- a/.github/workflows/template-deploy-container.yml
+++ b/.github/workflows/template-deploy-container.yml
@@ -41,11 +41,23 @@ jobs:
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
     - uses: azure/CLI@9f7ce6f37c31b777ec6c6b6d1dfe7db79f497956 # v2
       name: Update Container App
+      env:
+        # Environments with the APP_CONFIGURATION_LABEL variable set read feature flags
+        # from Azure App Configuration; environments without it use appsettings values.
+        APP_CONFIGURATION_LABEL: ${{ vars.APP_CONFIGURATION_LABEL }}
       with:
         inlineScript: |
           az config set extension.use_dynamic_install=yes_without_prompt
+          appconfig_args=()
+          if [ -n "$APP_CONFIGURATION_LABEL" ]; then
+            appconfig_args=(--set-env-vars \
+              "Altinn__AppConfiguration__Endpoint=https://appconfaltinnauth001hub.azconfig.io" \
+              "Altinn__AppConfiguration__Label=$APP_CONFIGURATION_LABEL" \
+              "Altinn__AppConfiguration__FeatureFlags__Enable=true")
+          fi
           az containerapp update \
             --name ${{ vars.CONTAINER_APP_NAME }} \
             --container-name ${{ env.CONTAINER_APP_CONTAINER_NAME }} \
             --resource-group ${{ vars.CONTAINER_APP_RESOURCE_GROUP_NAME }} \
-            --image ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.tag }}
+            --image ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.tag }} \
+            "${appconfig_args[@]}"

--- a/.github/workflows/template-deploy-container.yml
+++ b/.github/workflows/template-deploy-container.yml
@@ -49,11 +49,19 @@ jobs:
         inlineScript: |
           az config set extension.use_dynamic_install=yes_without_prompt
           appconfig_args=()
+          # Endpoint/Label control whether the BFF connects to Azure App Configuration at all.
+          # FeatureFlags__Enable additionally loads flags from Azure's dedicated "Feature manager"
+          # Variables mirrors the "tmp monorepo" feature flag setup
           if [ -n "$APP_CONFIGURATION_LABEL" ]; then
             appconfig_args=(--set-env-vars \
               "Altinn__AppConfiguration__Endpoint=https://appconfaltinnauth001hub.azconfig.io" \
               "Altinn__AppConfiguration__Label=$APP_CONFIGURATION_LABEL" \
               "Altinn__AppConfiguration__FeatureFlags__Enable=true")
+          else
+            appconfig_args=(--remove-env-vars \
+              "Altinn__AppConfiguration__Endpoint" \
+              "Altinn__AppConfiguration__Label" \
+              "Altinn__AppConfiguration__FeatureFlags__Enable")
           fi
           az containerapp update \
             --name ${{ vars.CONTAINER_APP_NAME }} \

--- a/README.md
+++ b/README.md
@@ -258,6 +258,23 @@ Since most of the mocked data is generated from static files, a lot of the funct
   - Partial data coverage (only new amUI)
   - Is DAGL for Sta Tom Tiger AS (313160300)
 
+## Feature flags 🚩
+
+Feature flags let us turn functionality on and off per environment without changing code. The BFF reads them through `IFeatureManager` ([Microsoft.FeatureManagement](https://learn.microsoft.com/en-us/azure/azure-app-configuration/feature-management-dotnet-reference)), and the source depends on where the app runs:
+
+- **Locally**: the `FeatureManagement` section in `appsettings.Development.json`. The file is hot-reloaded, so you can flip a flag while the BFF is running and just refresh the page.
+- **Deployed environments**: the shared Azure App Configuration store `appconfaltinnauth001hub` (owned by the authorization backend team), where our flags live under the label `{environment}-access-management-ui`. The BFF polls the store every minute, so flags can be toggled in the Azure portal (the store's _Feature manager_ blade) without a redeploy. This requires the `Altinn__AppConfiguration__*` environment variables to be set on the container app — if they are not, the app falls back to the values in appsettings. The deploy workflow sets them automatically for environments that have the `APP_CONFIGURATION_LABEL` GitHub environment variable defined (the value is the label, e.g. `at22-access-management-ui`), so enabling Azure App Configuration for an environment is a matter of adding that variable — no code change needed.
+
+### Adding a new feature flag
+
+1. Add a constant in `Altinn.AccessManagement.UI.Core/Configuration/FeatureFlags.cs`. Flag names use the `AccessManagementUI.` prefix followed by a PascalCase name, e.g. `AccessManagementUI.UseNewSingleRightsClientDelegation`.
+2. Add the flag with its default value (usually `false`) to the `FeatureManagement` section in `appsettings.json` and `appsettings.Development.json`.
+3. The flag is automatically exposed to the frontend as `window.featureFlags.<name>`, where `<name>` is the camelCased flag name without the prefix (e.g. `useNewSingleRightsClientDelegation`). Add it to the `featureFlags` type in `src/global.d.ts` so it can be used with type support.
+4. To read the flag in the BFF, inject `IFeatureManager` and call `IsEnabledAsync(FeatureFlags.YourFlag)`.
+5. To make the flag toggleable in deployed environments, it must also be defined in the Terraform in [altinn-authorization-tmp](https://github.com/Altinn/altinn-authorization-tmp) (the `infra/modules/appsettings` module) with the `{environment}-access-management-ui` label. Terraform only owns the flag's existence and description — the on/off state is controlled in the Azure portal.
+
+When a feature becomes permanent, remove the flag again: the constant, the appsettings entries, the `global.d.ts` entry, all usages, and the Terraform definition.
+
 # Build, Deploy and Release
 
 ## Building and deploying 🚚

--- a/README.md
+++ b/README.md
@@ -275,6 +275,8 @@ Feature flags let us turn functionality on and off per environment without chang
 
 When a feature becomes permanent, remove the flag again: the constant, the appsettings entries, the `global.d.ts` entry, all usages, and the Terraform definition.
 
+**⚠️ Deploy ordering in altinn-authorization-tmp:** the Terraform pipeline there applies the configuration of the commit that triggered each run, and runs are approved manually per environment — nothing enforces ordering. If an older run is approved _after_ a newer one, the older configuration wins and recently added flags are **deleted** from the store, losing their toggle state; the next up-to-date run recreates them disabled. If our flags unexpectedly disappear or reset in the portal, re-run the newest "CD: Apps" run in that repo and re-toggle the flags.
+
 # Build, Deploy and Release
 
 ## Building and deploying 🚚

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Altinn.AccessManagement.UI.Core.csproj
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Altinn.AccessManagement.UI.Core.csproj
@@ -22,6 +22,7 @@
 		<PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.10" />
 		<PackageReference Include="Microsoft.Bcl.Cryptography" Version="9.0.16" />
 		<PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.16" />
+		<PackageReference Include="Microsoft.FeatureManagement" Version="4.5.0" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Configuration/FeatureFlags.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Configuration/FeatureFlags.cs
@@ -1,14 +1,21 @@
 namespace Altinn.AccessManagement.UI.Core.Configuration
 {
     /// <summary>
-    /// Feature flags configuration settings
-    /// For use in turning off an on features in different envs
+    /// Feature flag names for use in turning off an on features in different envs.
+    /// Flag values are read through <see cref="Microsoft.FeatureManagement.IFeatureManager" />, sourced from
+    /// Azure App Configuration in deployed environments and from the FeatureManagement
+    /// section in appsettings when running locally.
     /// </summary>
-    public class FeatureFlags
+    public static class FeatureFlags
     {
         /// <summary>
         /// Whether or not to only display popular SingleRights services
         /// </summary>
-        public bool DisplayPopularSingleRightsServices { get; set; }
+        public const string DisplayPopularSingleRightsServices = "AccessManagementUI.DisplayPopularSingleRightsServices";
+
+        /// <summary>
+        /// Whether or not to use the new version of client delegation for single rights services
+        /// </summary>
+        public const string UseNewSingleRightsClientDelegation = "AccessManagementUI.UseNewSingleRightsClientDelegation";
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Configuration/FeatureFlags.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Configuration/FeatureFlags.cs
@@ -1,7 +1,7 @@
 namespace Altinn.AccessManagement.UI.Core.Configuration
 {
     /// <summary>
-    /// Feature flag names for use in turning off an on features in different envs.
+    /// Feature flag names for use in turning features off and on in different envs.
     /// Flag values are read through <see cref="Microsoft.FeatureManagement.IFeatureManager" />, sourced from
     /// Azure App Configuration in deployed environments and from the FeatureManagement
     /// section in appsettings when running locally.

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/ResourceService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/ResourceService.cs
@@ -11,6 +11,7 @@ using Altinn.AccessManagement.UI.Core.Services.Interfaces;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.FeatureManagement;
 
 namespace Altinn.AccessManagement.UI.Core.Services
 {
@@ -21,7 +22,7 @@ namespace Altinn.AccessManagement.UI.Core.Services
         private readonly ILogger<IResourceService> _logger;
         private readonly IMemoryCache _memoryCache;
         private readonly IResourceRegistryClient _resourceRegistryClient;
-        private readonly FeatureFlags _featureFlags;
+        private readonly IFeatureManager _featureManager;
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="ResourceService" /> class for testing purposes.
@@ -37,19 +38,19 @@ namespace Altinn.AccessManagement.UI.Core.Services
         /// <param name="resourceRegistryClient">the handler for resource registry client</param>
         /// <param name="cacheConfig">the handler for cache configuration</param>
         /// <param name="memoryCache">the handler for cache</param>
-        /// <param name="featureFlags">the handler for env spesific logic flags</param>
+        /// <param name="featureManager">the feature manager holding the current feature flag values</param>
         public ResourceService(
             ILogger<IResourceService> logger,
             IResourceRegistryClient resourceRegistryClient,
             IMemoryCache memoryCache,
             IOptions<CacheConfig> cacheConfig,
-            IOptions<FeatureFlags> featureFlags)
+            IFeatureManager featureManager)
         {
             _logger = logger;
             _resourceRegistryClient = resourceRegistryClient;
             _memoryCache = memoryCache;
             _cacheConfig = cacheConfig.Value;
-            _featureFlags = featureFlags.Value;
+            _featureManager = featureManager;
         }
 
         /// <inheritdoc />
@@ -61,7 +62,7 @@ namespace Altinn.AccessManagement.UI.Core.Services
                 List<ServiceResource> resourceList = resources.FindAll(r => IncludeInSearch(r, searchParams, resourceTypes));
                 List<ServiceResourceFE> resourcesFE = MapResourceToFrontendModel(resourceList, languageCode);
 
-                bool displayPopularServicesOnly = _featureFlags.DisplayPopularSingleRightsServices;
+                bool displayPopularServicesOnly = await _featureManager.IsEnabledAsync(FeatureFlags.DisplayPopularSingleRightsServices);
                 if (string.IsNullOrEmpty(searchParams.SearchString) &&
                     (searchParams.ROFilters == null || searchParams.ROFilters.Length == 0) &&
                     displayPopularServicesOnly &&

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Altinn.AccessManagement.UI.Tests.csproj
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Altinn.AccessManagement.UI.Tests.csproj
@@ -9,6 +9,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.16" />
+        <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.9.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="xunit" Version="2.9.3" />

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Configuration/RefreshAppConfigurationHostedServiceTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Configuration/RefreshAppConfigurationHostedServiceTest.cs
@@ -1,0 +1,85 @@
+using Altinn.AccessManagement.Configuration;
+using Microsoft.Extensions.Configuration.AzureAppConfiguration;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+
+namespace Altinn.AccessManagement.UI.Tests.Configuration
+{
+    /// <summary>
+    /// Test class for <see cref="RefreshAppConfigurationHostedService"/>
+    /// </summary>
+    public class RefreshAppConfigurationHostedServiceTest
+    {
+        private readonly Mock<IConfigurationRefresher> _refresher1 = NewRefresher();
+        private readonly Mock<IConfigurationRefresher> _refresher2 = NewRefresher();
+        private readonly FakeTimeProvider _timeProvider = new FakeTimeProvider();
+        private readonly RefreshAppConfigurationHostedService _service;
+
+        public RefreshAppConfigurationHostedServiceTest()
+        {
+            Mock<IConfigurationRefresherProvider> refresherProvider = new Mock<IConfigurationRefresherProvider>();
+            refresherProvider.Setup(p => p.Refreshers).Returns(new[] { _refresher1.Object, _refresher2.Object });
+            _service = new RefreshAppConfigurationHostedService(refresherProvider.Object, _timeProvider);
+        }
+
+        /// <summary>
+        /// Test case: The service runs while time passes
+        /// Expected: All refreshers are refreshed once per interval
+        /// </summary>
+        [Fact]
+        public async Task ExecuteAsync_RefreshesAllRefreshersOnEachTick()
+        {
+            await _service.StartAsync(CancellationToken.None);
+
+            await AdvanceTimeUntilInvocationsAsync(_refresher1, 1);
+
+            _refresher1.Verify(r => r.TryRefreshAsync(It.IsAny<CancellationToken>()), Times.Once);
+            _refresher2.Verify(r => r.TryRefreshAsync(It.IsAny<CancellationToken>()), Times.Once);
+
+            await AdvanceTimeUntilInvocationsAsync(_refresher1, 2);
+
+            _refresher1.Verify(r => r.TryRefreshAsync(It.IsAny<CancellationToken>()), Times.Exactly(2));
+            _refresher2.Verify(r => r.TryRefreshAsync(It.IsAny<CancellationToken>()), Times.Exactly(2));
+
+            await _service.StopAsync(CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Test case: The service is stopped before the first interval has passed
+        /// Expected: No refreshes are triggered when time passes after the stop
+        /// </summary>
+        [Fact]
+        public async Task ExecuteAsync_DoesNotRefreshAfterStop()
+        {
+            await _service.StartAsync(CancellationToken.None);
+            await _service.StopAsync(CancellationToken.None);
+
+            _timeProvider.Advance(RefreshAppConfigurationHostedService.RefreshInterval);
+
+            _refresher1.Verify(r => r.TryRefreshAsync(It.IsAny<CancellationToken>()), Times.Never);
+            _refresher2.Verify(r => r.TryRefreshAsync(It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        private static Mock<IConfigurationRefresher> NewRefresher()
+        {
+            Mock<IConfigurationRefresher> refresher = new Mock<IConfigurationRefresher>();
+            refresher.Setup(r => r.TryRefreshAsync(It.IsAny<CancellationToken>())).ReturnsAsync(true);
+            return refresher;
+        }
+
+        /// <summary>
+        /// Advances fake time one refresh interval at a time until the refresher has been invoked
+        /// the expected number of times, yielding between advances so the service's timer loop
+        /// (which runs as background continuations) gets to both arm the timer and process ticks.
+        /// </summary>
+        private async Task AdvanceTimeUntilInvocationsAsync(Mock<IConfigurationRefresher> refresher, int expectedCount)
+        {
+            DateTime deadline = DateTime.UtcNow.AddSeconds(5);
+            while (refresher.Invocations.Count < expectedCount && DateTime.UtcNow < deadline)
+            {
+                _timeProvider.Advance(RefreshAppConfigurationHostedService.RefreshInterval);
+                await Task.Delay(10);
+            }
+        }
+    }
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Configuration/RefreshAppConfigurationHostedServiceTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Configuration/RefreshAppConfigurationHostedServiceTest.cs
@@ -12,7 +12,7 @@ namespace Altinn.AccessManagement.UI.Tests.Configuration
     {
         private readonly Mock<IConfigurationRefresher> _refresher1 = NewRefresher();
         private readonly Mock<IConfigurationRefresher> _refresher2 = NewRefresher();
-        private readonly FakeTimeProvider _timeProvider = new FakeTimeProvider();
+        private readonly TimerTrackingFakeTimeProvider _timeProvider = new TimerTrackingFakeTimeProvider();
         private readonly RefreshAppConfigurationHostedService _service;
 
         public RefreshAppConfigurationHostedServiceTest()
@@ -31,33 +31,21 @@ namespace Altinn.AccessManagement.UI.Tests.Configuration
         {
             await _service.StartAsync(CancellationToken.None);
 
-            await AdvanceTimeUntilInvocationsAsync(_refresher1, 1);
+            // StartAsync queues ExecuteAsync without running it (as of .NET 10), so wait for the
+            // service to arm its timer; from then on each advance fires exactly one tick.
+            await _timeProvider.TimerCreated.WaitAsync(TimeSpan.FromSeconds(5));
+
+            await AdvanceOneIntervalAsync();
 
             _refresher1.Verify(r => r.TryRefreshAsync(It.IsAny<CancellationToken>()), Times.Once);
             _refresher2.Verify(r => r.TryRefreshAsync(It.IsAny<CancellationToken>()), Times.Once);
 
-            await AdvanceTimeUntilInvocationsAsync(_refresher1, 2);
+            await AdvanceOneIntervalAsync();
 
             _refresher1.Verify(r => r.TryRefreshAsync(It.IsAny<CancellationToken>()), Times.Exactly(2));
             _refresher2.Verify(r => r.TryRefreshAsync(It.IsAny<CancellationToken>()), Times.Exactly(2));
 
             await _service.StopAsync(CancellationToken.None);
-        }
-
-        /// <summary>
-        /// Test case: The service is stopped before the first interval has passed
-        /// Expected: No refreshes are triggered when time passes after the stop
-        /// </summary>
-        [Fact]
-        public async Task ExecuteAsync_DoesNotRefreshAfterStop()
-        {
-            await _service.StartAsync(CancellationToken.None);
-            await _service.StopAsync(CancellationToken.None);
-
-            _timeProvider.Advance(RefreshAppConfigurationHostedService.RefreshInterval);
-
-            _refresher1.Verify(r => r.TryRefreshAsync(It.IsAny<CancellationToken>()), Times.Never);
-            _refresher2.Verify(r => r.TryRefreshAsync(It.IsAny<CancellationToken>()), Times.Never);
         }
 
         private static Mock<IConfigurationRefresher> NewRefresher()
@@ -68,17 +56,39 @@ namespace Altinn.AccessManagement.UI.Tests.Configuration
         }
 
         /// <summary>
-        /// Advances fake time one refresh interval at a time until the refresher has been invoked
-        /// the expected number of times, yielding between advances so the service's timer loop
-        /// (which runs as background continuations) gets to both arm the timer and process ticks.
+        /// Advances fake time by one refresh interval and waits until both refreshers have processed
+        /// the resulting tick, which happens asynchronously as the service's timer loop continuations
+        /// run. Time is only ever advanced here, one interval at a time with the timer already armed,
+        /// so exactly one tick fires per call and the exact-count verifications are race free.
         /// </summary>
-        private async Task AdvanceTimeUntilInvocationsAsync(Mock<IConfigurationRefresher> refresher, int expectedCount)
+        private async Task AdvanceOneIntervalAsync()
         {
+            int expected1 = _refresher1.Invocations.Count + 1;
+            int expected2 = _refresher2.Invocations.Count + 1;
+            _timeProvider.Advance(RefreshAppConfigurationHostedService.RefreshInterval);
+
             DateTime deadline = DateTime.UtcNow.AddSeconds(5);
-            while (refresher.Invocations.Count < expectedCount && DateTime.UtcNow < deadline)
+            while ((_refresher1.Invocations.Count < expected1 || _refresher2.Invocations.Count < expected2) && DateTime.UtcNow < deadline)
             {
-                _timeProvider.Advance(RefreshAppConfigurationHostedService.RefreshInterval);
                 await Task.Delay(10);
+            }
+        }
+
+        /// <summary>
+        /// Fake time provider that additionally exposes when the service under test has created
+        /// (armed) its refresh timer, so tests know when advancing time will produce ticks.
+        /// </summary>
+        private sealed class TimerTrackingFakeTimeProvider : FakeTimeProvider
+        {
+            private readonly TaskCompletionSource _timerCreated = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public Task TimerCreated => _timerCreated.Task;
+
+            public override ITimer CreateTimer(TimerCallback callback, object state, TimeSpan dueTime, TimeSpan period)
+            {
+                ITimer timer = base.CreateTimer(callback, state, dueTime, period);
+                _timerCreated.TrySetResult();
+                return timer;
             }
         }
     }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/ConnectionControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/ConnectionControllerTest.cs
@@ -44,7 +44,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         public ConnectionControllerTest(CustomWebApplicationFactory<ConnectionController> factory)
         {
             _factory = factory;
-            _client = SetupUtils.GetTestClient(factory, null);
+            _client = SetupUtils.GetTestClient(factory);
             _testDataFolder = Path.GetDirectoryName(new Uri(typeof(ConnectionControllerTest).Assembly.Location).LocalPath);
 
             // Reset the static counter in RegisterClientMock to avoid test interference

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/HomeControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/HomeControllerTest.cs
@@ -71,6 +71,29 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         }
 
         /// <summary>
+        /// Test case: Index renders the app view for an authenticated user
+        /// Expected: All feature flags are exposed on window.featureFlags, keyed by the camel cased
+        /// flag name without the AccessManagementUI prefix
+        /// </summary>
+        [Fact]
+        public async Task Index_Authenticated_ExposesFeatureFlagsToFrontend()
+        {
+            HttpClient client = SetupUtils.GetTestClient(_factory, false);
+            string token = PrincipalUtil.GetAccessToken("sbl.authorization");
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+            // Act
+            HttpResponseMessage response = await client.GetAsync($"accessmanagement/");
+            string body = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Contains("window.featureFlags", body);
+            Assert.Contains("\"displayPopularSingleRightsServices\":false", body);
+            Assert.Contains("\"useNewSingleRightsClientDelegation\":false", body);
+        }
+
+        /// <summary>
         /// Test case: Checks if the user is redirected to authentication when not authenticated
         /// Expected: User is redirected to authentication
         /// </summary>

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/HomeControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/HomeControllerTest.cs
@@ -71,29 +71,6 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         }
 
         /// <summary>
-        /// Test case: Index renders the app view for an authenticated user
-        /// Expected: All feature flags are exposed on window.featureFlags, keyed by the camel cased
-        /// flag name without the AccessManagementUI prefix
-        /// </summary>
-        [Fact]
-        public async Task Index_Authenticated_ExposesFeatureFlagsToFrontend()
-        {
-            HttpClient client = SetupUtils.GetTestClient(_factory, false);
-            string token = PrincipalUtil.GetAccessToken("sbl.authorization");
-            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-
-            // Act
-            HttpResponseMessage response = await client.GetAsync($"accessmanagement/");
-            string body = await response.Content.ReadAsStringAsync();
-
-            // Assert
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.Contains("window.featureFlags", body);
-            Assert.Contains("\"displayPopularSingleRightsServices\":false", body);
-            Assert.Contains("\"useNewSingleRightsClientDelegation\":false", body);
-        }
-
-        /// <summary>
         /// Test case: Checks if the user is redirected to authentication when not authenticated
         /// Expected: User is redirected to authentication
         /// </summary>

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/HomeControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/HomeControllerTest.cs
@@ -71,6 +71,35 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         }
 
         /// <summary>
+        /// Test case: Index renders the app view for an authenticated user, with mock feature flags
+        /// registered under the AccessManagementUI prefix (not real, application-defined flags -
+        /// this verifies the exposure mechanism itself, independent of which flags currently exist)
+        /// Expected: The mock flags are exposed on window.featureFlags, keyed by the camel cased
+        /// flag name without the AccessManagementUI prefix
+        /// </summary>
+        [Fact]
+        public async Task Index_Authenticated_ExposesFeatureFlagsToFrontend()
+        {
+            HttpClient client = SetupUtils.GetTestClient(_factory, false, new Dictionary<string, bool>
+            {
+                ["AccessManagementUI.MockFeatureAlpha"] = true,
+                ["AccessManagementUI.MockFeatureBeta"] = false,
+            });
+            string token = PrincipalUtil.GetAccessToken("sbl.authorization");
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+            // Act
+            HttpResponseMessage response = await client.GetAsync("accessmanagement/");
+            string body = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Contains("window.featureFlags", body);
+            Assert.Contains("\"mockFeatureAlpha\":true", body);
+            Assert.Contains("\"mockFeatureBeta\":false", body);
+        }
+
+        /// <summary>
         /// Test case: Checks if the user is redirected to authentication when not authenticated
         /// Expected: User is redirected to authentication
         /// </summary>

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/ResourceControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/ResourceControllerTest.cs
@@ -4,6 +4,7 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using Altinn.AccessManagement.UI.Controllers;
 using Altinn.AccessManagement.UI.Core.ClientInterfaces;
+using Altinn.AccessManagement.UI.Core.Configuration;
 using Altinn.AccessManagement.UI.Core.Enums;
 using Altinn.AccessManagement.UI.Core.Models.ResourceRegistry;
 using Altinn.AccessManagement.UI.Core.Models.ResourceRegistry.Frontend;
@@ -120,6 +121,33 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             Assert.Equal(expectedResult.Page, actualResources.Page);
             Assert.Equal(expectedResult.NumEntriesTotal, actualResources.NumEntriesTotal);
             AssertionUtil.AssertCollections(expectedResult.PageList, actualResources.PageList, AssertionUtil.AssertEqual);
+        }
+
+        /// <summary>
+        ///     Test case: PaginatedSearch with no search string or filters while the DisplayPopularSingleRightsServices
+        ///     feature flag is enabled
+        ///     Expected: PaginatedSearch returns only the selection of popular services instead of the full resource list
+        ///     (none of the resources in the mock data are part of the popular selection, so the result is empty)
+        /// </summary>
+        [Fact]
+        public async Task GetSingleRightsSearch_popularServicesFlagEnabled_ReturnsOnlyPopularServices()
+        {
+            // Arrange
+            HttpClient client = GetTestClient(featureFlags: new Dictionary<string, bool>
+            {
+                [FeatureFlags.DisplayPopularSingleRightsServices] = true,
+            });
+            string token = PrincipalUtil.GetToken(1337, 501337);
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+            // Act
+            HttpResponseMessage response = await client.GetAsync("accessmanagement/api/v1/resources/search?ResultsPerPage=7&Page=1");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            PaginatedList<ServiceResourceFE> actualResources = JsonSerializer.Deserialize<PaginatedList<ServiceResourceFE>>(await response.Content.ReadAsStringAsync(), options);
+            Assert.Empty(actualResources.PageList);
         }
 
 
@@ -478,11 +506,16 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             return httpContextAccessorMock.Object;
         }
 
-        private HttpClient GetTestClient(IHttpContextAccessor httpContextAccessor = null)
+        private HttpClient GetTestClient(IHttpContextAccessor httpContextAccessor = null, Dictionary<string, bool> featureFlags = null)
         {
             httpContextAccessor ??= new HttpContextAccessor();
             HttpClient client = _factory.WithWebHostBuilder(builder =>
             {
+                if (featureFlags != null)
+                {
+                    SetupUtils.SetFeatureFlags(builder, featureFlags);
+                }
+
                 builder.ConfigureTestServices(services =>
                 {
                     services.AddSingleton<IProfileClient, ProfileClientMock>();

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/RoleControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/RoleControllerTest.cs
@@ -42,7 +42,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         public RoleControllerTest(CustomWebApplicationFactory<RoleController> factory)
         {
             _factory = factory;
-            _client = SetupUtils.GetTestClient(factory, new FeatureFlags());
+            _client = SetupUtils.GetTestClient(factory);
             string token = PrincipalUtil.GetAccessToken("sbl.authorization");
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
             _client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/UserControllerTest.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Controllers/UserControllerTest.cs
@@ -41,7 +41,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
         {
             _factory = factory;
             _profileClient = Mock.Of<IProfileClient>();
-            _client = SetupUtils.GetTestClient(factory, null);
+            _client = SetupUtils.GetTestClient(factory);
             _testDataFolder = Path.GetDirectoryName(new Uri(typeof(UserControllerTest).Assembly.Location).LocalPath);
 
         }
@@ -792,9 +792,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             var httpContextAccessor = new HttpContextAccessor { HttpContext = httpContext };
             var userServiceMock = new Mock<IUserService>();
             var loggerMock = new Mock<ILogger<UserController>>();
-            var featureFlags = Options.Create(new FeatureFlags());
-
-            var controller = new UserController(userServiceMock.Object, httpContextAccessor, loggerMock.Object, featureFlags)
+            var controller = new UserController(userServiceMock.Object, httpContextAccessor, loggerMock.Object)
             {
                 ControllerContext = new ControllerContext { HttpContext = httpContext }
             };
@@ -885,9 +883,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             var httpContextAccessor = new HttpContextAccessor { HttpContext = httpContext };
             var userServiceMock = new Mock<IUserService>();
             var loggerMock = new Mock<ILogger<UserController>>();
-            var featureFlags = Options.Create(new FeatureFlags());
-
-            var controller = new UserController(userServiceMock.Object, httpContextAccessor, loggerMock.Object, featureFlags)
+            var controller = new UserController(userServiceMock.Object, httpContextAccessor, loggerMock.Object)
             {
                 ControllerContext = new ControllerContext { HttpContext = httpContext }
             };
@@ -1002,9 +998,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             var httpContextAccessor = new HttpContextAccessor { HttpContext = httpContext };
             var userServiceMock = new Mock<IUserService>();
             var loggerMock = new Mock<ILogger<UserController>>();
-            var featureFlags = Options.Create(new FeatureFlags());
-
-            var controller = new UserController(userServiceMock.Object, httpContextAccessor, loggerMock.Object, featureFlags)
+            var controller = new UserController(userServiceMock.Object, httpContextAccessor, loggerMock.Object)
             {
                 ControllerContext = new ControllerContext { HttpContext = httpContext }
             };
@@ -1050,9 +1044,7 @@ namespace Altinn.AccessManagement.UI.Tests.Controllers
             var httpContextAccessor = new HttpContextAccessor { HttpContext = httpContext };
             var userServiceMock = new Mock<IUserService>();
             var loggerMock = new Mock<ILogger<UserController>>();
-            var featureFlags = Options.Create(new FeatureFlags());
-
-            var controller = new UserController(userServiceMock.Object, httpContextAccessor, loggerMock.Object, featureFlags)
+            var controller = new UserController(userServiceMock.Object, httpContextAccessor, loggerMock.Object)
             {
                 ControllerContext = new ControllerContext { HttpContext = httpContext }
             };

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Utils/SetupUtils.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Utils/SetupUtils.cs
@@ -5,6 +5,7 @@ using Altinn.AccessManagement.UI.Core.Services.Interfaces;
 using Altinn.AccessManagement.UI.Core.Services;
 using Altinn.AccessManagement.UI.Mocks.Mocks;
 using AltinnCore.Authentication.JwtCookie;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
@@ -18,6 +19,20 @@ namespace Altinn.AccessManagement.UI.Tests.Utils
     /// </summary>
     public static class SetupUtils
     {
+        /// <summary>
+        ///     Overrides feature flag values for a test client, taking precedence over the
+        ///     FeatureManagement section in appsettings
+        /// </summary>
+        /// <param name="builder">Web host builder for the test server</param>
+        /// <param name="featureFlags">Flag values keyed by flag name (see <see cref="FeatureFlags" />)</param>
+        public static void SetFeatureFlags(IWebHostBuilder builder, Dictionary<string, bool> featureFlags)
+        {
+            foreach ((string flag, bool enabled) in featureFlags)
+            {
+                builder.UseSetting($"FeatureManagement:{flag}", enabled.ToString());
+            }
+        }
+
         /// <summary>
         ///     Gets a HttpClient for unittests testing
         /// </summary>

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Utils/SetupUtils.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Utils/SetupUtils.cs
@@ -442,11 +442,17 @@ namespace Altinn.AccessManagement.UI.Tests.Utils
         /// </summary>
         /// <param name="customFactory">Web app factory to configure test services for</param>
         /// <param name="allowRedirect">allow redirect flag</param>
+        /// <param name="featureFlags">Override feature flag values (see <see cref="FeatureFlags" />)</param>
         /// <returns>HttpClient</returns>
-        public static HttpClient GetTestClient(CustomWebApplicationFactory<HomeController> customFactory, bool allowRedirect = false)
+        public static HttpClient GetTestClient(CustomWebApplicationFactory<HomeController> customFactory, bool allowRedirect = false, Dictionary<string, bool> featureFlags = null)
         {
             WebApplicationFactory<HomeController> factory = customFactory.WithWebHostBuilder(builder =>
             {
+                if (featureFlags != null)
+                {
+                    SetFeatureFlags(builder, featureFlags);
+                }
+
                 builder.ConfigureTestServices(services =>
                 {
                     services.AddTransient<IResourceRegistryClient, ResourceRegistryClientMock>();

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Utils/SetupUtils.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Tests/Utils/SetupUtils.cs
@@ -80,9 +80,8 @@ namespace Altinn.AccessManagement.UI.Tests.Utils
         ///     Gets a HttpClient for unittests testing
         /// </summary>
         /// <param name="customFactory">Web app factory to configure test services for UserController tests</param>
-        /// <param name="flags">Override featureFlags in the client. Defaults to true if not set</param>
         /// <returns>HttpClient</returns>
-        public static HttpClient GetTestClient(CustomWebApplicationFactory<UserController> customFactory, FeatureFlags flags)
+        public static HttpClient GetTestClient(CustomWebApplicationFactory<UserController> customFactory)
         {
             WebApplicationFactory<UserController> factory = customFactory.WithWebHostBuilder(builder =>
             {
@@ -102,9 +101,8 @@ namespace Altinn.AccessManagement.UI.Tests.Utils
         ///     Gets a HttpClient for unittests testing
         /// </summary>
         /// <param name="customFactory">Web app factory to configure test services for ConnectionController tests</param>
-        /// <param name="flags">Override featureFlags in the client. Defaults to true if not set</param>
         /// <returns>HttpClient</returns>
-        public static HttpClient GetTestClient(CustomWebApplicationFactory<ConnectionController> customFactory, FeatureFlags flags)
+        public static HttpClient GetTestClient(CustomWebApplicationFactory<ConnectionController> customFactory)
         {
             WebApplicationFactory<ConnectionController> factory = customFactory.WithWebHostBuilder(builder =>
             {
@@ -123,10 +121,9 @@ namespace Altinn.AccessManagement.UI.Tests.Utils
         /// <summary>
         ///     Gets a HttpClient for unittests testing
         /// </summary>
-        /// <param name="customFactory">Web app factory to configure test services for UserController tests</param>
-        /// <param name="flags">Override featureFlags in the client. Defaults to true if not set</param>
+        /// <param name="customFactory">Web app factory to configure test services for RoleController tests</param>
         /// <returns>HttpClient</returns>
-        public static HttpClient GetTestClient(CustomWebApplicationFactory<RoleController> customFactory, FeatureFlags flags)
+        public static HttpClient GetTestClient(CustomWebApplicationFactory<RoleController> customFactory)
         {
             WebApplicationFactory<RoleController> factory = customFactory.WithWebHostBuilder(builder =>
            {

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.csproj
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.csproj
@@ -17,9 +17,8 @@
     <PackageReference Include="JWTCookieAuthentication" Version="4.0.4" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.16" />
-    <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="8.5.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="8.5.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.23.0" />
-    <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="4.5.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.csproj
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.csproj
@@ -17,7 +17,9 @@
     <PackageReference Include="JWTCookieAuthentication" Version="4.0.4" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.16" />
+    <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="8.5.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.23.0" />
+    <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="4.5.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Configuration/RefreshAppConfigurationHostedService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Configuration/RefreshAppConfigurationHostedService.cs
@@ -1,0 +1,40 @@
+using Microsoft.Extensions.Configuration.AzureAppConfiguration;
+
+namespace Altinn.AccessManagement.Configuration
+{
+    /// <summary>
+    /// Periodically refreshes configuration and feature flags from Azure App Configuration,
+    /// so that changes made in Azure take effect without a redeploy.
+    /// </summary>
+    public sealed class RefreshAppConfigurationHostedService : BackgroundService
+    {
+        /// <summary>
+        /// How often configuration is refreshed from Azure App Configuration.
+        /// </summary>
+        public static readonly TimeSpan RefreshInterval = TimeSpan.FromMinutes(1);
+
+        private readonly IConfigurationRefresherProvider _refresherProvider;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RefreshAppConfigurationHostedService" /> class.
+        /// </summary>
+        /// <param name="refresherProvider">provider of the configuration refreshers to trigger</param>
+        public RefreshAppConfigurationHostedService(IConfigurationRefresherProvider refresherProvider)
+        {
+            _refresherProvider = refresherProvider;
+        }
+
+        /// <inheritdoc />
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            using PeriodicTimer timer = new PeriodicTimer(RefreshInterval);
+            while (await timer.WaitForNextTickAsync(stoppingToken))
+            {
+                foreach (IConfigurationRefresher refresher in _refresherProvider.Refreshers)
+                {
+                    await refresher.TryRefreshAsync(stoppingToken);
+                }
+            }
+        }
+    }
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Configuration/RefreshAppConfigurationHostedService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Configuration/RefreshAppConfigurationHostedService.cs
@@ -14,20 +14,23 @@ namespace Altinn.AccessManagement.Configuration
         public static readonly TimeSpan RefreshInterval = TimeSpan.FromMinutes(1);
 
         private readonly IConfigurationRefresherProvider _refresherProvider;
+        private readonly TimeProvider _timeProvider;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RefreshAppConfigurationHostedService" /> class.
         /// </summary>
         /// <param name="refresherProvider">provider of the configuration refreshers to trigger</param>
-        public RefreshAppConfigurationHostedService(IConfigurationRefresherProvider refresherProvider)
+        /// <param name="timeProvider">time provider driving the refresh timer</param>
+        public RefreshAppConfigurationHostedService(IConfigurationRefresherProvider refresherProvider, TimeProvider timeProvider)
         {
             _refresherProvider = refresherProvider;
+            _timeProvider = timeProvider;
         }
 
         /// <inheritdoc />
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
-            using PeriodicTimer timer = new PeriodicTimer(RefreshInterval);
+            using PeriodicTimer timer = new PeriodicTimer(RefreshInterval, _timeProvider);
             while (await timer.WaitForNextTickAsync(stoppingToken))
             {
                 foreach (IConfigurationRefresher refresher in _refresherProvider.Refreshers)

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/ConnectionController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/ConnectionController.cs
@@ -1,5 +1,4 @@
 ﻿using System.Net;
-using Altinn.AccessManagement.UI.Core.Configuration;
 using Altinn.AccessManagement.UI.Core.Helpers;
 using Altinn.AccessManagement.UI.Core.Models.Connections;
 using Altinn.AccessManagement.UI.Core.Models.User;
@@ -7,7 +6,6 @@ using Altinn.AccessManagement.UI.Core.Services.Interfaces;
 using Altinn.AccessManagement.UI.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Options;
 
 namespace Altinn.AccessManagement.UI.Controllers
 {
@@ -20,7 +18,6 @@ namespace Altinn.AccessManagement.UI.Controllers
         private readonly IConnectionService _connectionService;
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly ILogger _logger;
-        private readonly FeatureFlags _featureFlags;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ConnectionController"/> class
@@ -28,13 +25,11 @@ namespace Altinn.AccessManagement.UI.Controllers
         public ConnectionController(
             IConnectionService connectionService,
             IHttpContextAccessor httpContextAccessor,
-            ILogger<ConnectionController> logger,
-            IOptions<FeatureFlags> featureFlags)
+            ILogger<ConnectionController> logger)
         {
             _connectionService = connectionService;
             _httpContextAccessor = httpContextAccessor;
             _logger = logger;
-            _featureFlags = featureFlags.Value;
         }
 
         /// <summary>

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/HomeController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/HomeController.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.FeatureManagement;
 
 namespace Altinn.AccessManagement.UI.Controllers
 {
@@ -22,7 +23,7 @@ namespace Altinn.AccessManagement.UI.Controllers
         private readonly IAntiforgery _antiforgery;
         private readonly IWebHostEnvironment _env;
         private readonly GeneralSettings _generalSettings;
-        private readonly FeatureFlags _featureFlags;
+        private readonly IFeatureManager _featureManager;
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly PlatformSettings _platformSettings;
         private readonly IUserService _userService;
@@ -37,7 +38,7 @@ namespace Altinn.AccessManagement.UI.Controllers
         /// <param name="env">the current environment</param>
         /// <param name="httpContextAccessor">http context</param>
         /// <param name="generalSettings">general settings</param>
-        /// <param name="featureFlags">feature flags</param>
+        /// <param name="featureManager">the feature manager holding the current feature flag values</param>
         /// <param name="userService">user service to look up things about the user</param>
         /// <param name="logger">the logger</param>
         public HomeController(
@@ -47,7 +48,7 @@ namespace Altinn.AccessManagement.UI.Controllers
             IWebHostEnvironment env,
             IHttpContextAccessor httpContextAccessor,
             IOptions<GeneralSettings> generalSettings,
-            IOptions<FeatureFlags> featureFlags,
+            IFeatureManager featureManager,
             IUserService userService,
             ILogger<HomeController> logger)
         {
@@ -56,7 +57,7 @@ namespace Altinn.AccessManagement.UI.Controllers
             _env = env;
             _httpContextAccessor = httpContextAccessor;
             _generalSettings = generalSettings.Value;
-            _featureFlags = featureFlags.Value;
+            _featureManager = featureManager;
             _userService = userService;
             _logger = logger;
         }
@@ -90,7 +91,7 @@ namespace Altinn.AccessManagement.UI.Controllers
 
             if (await ShouldShowAppView())
             {
-                ViewBag.featureFlags = _featureFlags;
+                ViewBag.featureFlags = await GetFeatureFlags();
                 return View();
             }
 
@@ -107,6 +108,23 @@ namespace Altinn.AccessManagement.UI.Controllers
             "en" => "en",
             _ => "nb"
         };
+
+        /// <summary>
+        ///     Gets all feature flags as a dictionary exposed to the frontend as window.featureFlags,
+        ///     keyed by the camel cased flag name without its "AccessManagementUI." prefix
+        ///     (e.g. "AccessManagementUI.DisplayPopularSingleRightsServices" => "displayPopularSingleRightsServices")
+        /// </summary>
+        private async Task<Dictionary<string, bool>> GetFeatureFlags()
+        {
+            Dictionary<string, bool> featureFlags = new Dictionary<string, bool>();
+            await foreach (string featureName in _featureManager.GetFeatureNamesAsync())
+            {
+                string flagName = featureName[(featureName.LastIndexOf('.') + 1)..];
+                featureFlags[char.ToLowerInvariant(flagName[0]) + flagName[1..]] = await _featureManager.IsEnabledAsync(featureName);
+            }
+
+            return featureFlags;
+        }
 
         private async Task<string> SetLanguageCookie()
         {

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/HomeController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/HomeController.cs
@@ -1,4 +1,5 @@
-﻿using System.Web;
+﻿using System.Text.Json;
+using System.Web;
 using Altinn.AccessManagement.Models;
 using Altinn.AccessManagement.UI.Core.Configuration;
 using Altinn.AccessManagement.UI.Core.Helpers;
@@ -120,7 +121,7 @@ namespace Altinn.AccessManagement.UI.Controllers
             await foreach (string featureName in _featureManager.GetFeatureNamesAsync())
             {
                 string flagName = featureName[(featureName.LastIndexOf('.') + 1)..];
-                featureFlags[char.ToLowerInvariant(flagName[0]) + flagName[1..]] = await _featureManager.IsEnabledAsync(featureName);
+                featureFlags[JsonNamingPolicy.CamelCase.ConvertName(flagName)] = await _featureManager.IsEnabledAsync(featureName);
             }
 
             return featureFlags;

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/UserController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/UserController.cs
@@ -1,5 +1,4 @@
 ﻿using Altinn.AccessManagement.Core.Constants;
-using Altinn.AccessManagement.UI.Core.Configuration;
 using Altinn.AccessManagement.UI.Core.Helpers;
 using Altinn.AccessManagement.UI.Core.Models;
 using Altinn.AccessManagement.UI.Core.Models.AccessManagement;
@@ -8,7 +7,6 @@ using Altinn.AccessManagement.UI.Core.Models.User;
 using Altinn.AccessManagement.UI.Core.Services.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Options;
 
 namespace Altinn.AccessManagement.UI.Controllers
 {
@@ -21,7 +19,6 @@ namespace Altinn.AccessManagement.UI.Controllers
         private readonly IUserService _userService;
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly ILogger _logger;
-        private readonly FeatureFlags _featureFlags;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UserController"/> class
@@ -29,13 +26,11 @@ namespace Altinn.AccessManagement.UI.Controllers
         public UserController(
             IUserService profileService,
             IHttpContextAccessor httpContextAccessor,
-            ILogger<UserController> logger,
-            IOptions<FeatureFlags> featureFlags)
+            ILogger<UserController> logger)
         {
             _userService = profileService;
             _httpContextAccessor = httpContextAccessor;
             _logger = logger;
-            _featureFlags = featureFlags.Value;
         }
 
         /// <summary>

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Extensions/AppConfigurationExtensions.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Extensions/AppConfigurationExtensions.cs
@@ -21,7 +21,8 @@ namespace Altinn.AccessManagement.UI.Extensions
         /// </summary>
         /// <param name="config">the configuration manager to add the configuration source to</param>
         /// <param name="logger">setup logger</param>
-        public static void AddAltinnAppConfiguration(this ConfigurationManager config, ILogger logger)
+        /// <returns>true if Azure App Configuration was added as a configuration source, false when skipped or unreachable</returns>
+        public static bool AddAltinnAppConfiguration(this ConfigurationManager config, ILogger logger)
         {
             string appConfigurationEndpoint = config["Altinn:AppConfiguration:Endpoint"];
             string appConfigurationLabel = config["Altinn:AppConfiguration:Label"];
@@ -29,7 +30,7 @@ namespace Altinn.AccessManagement.UI.Extensions
             if (string.IsNullOrEmpty(appConfigurationEndpoint) || string.IsNullOrEmpty(appConfigurationLabel))
             {
                 logger.LogInformation("Program // Altinn:AppConfiguration:Endpoint or Label not set - skipping Azure App Configuration");
-                return;
+                return false;
             }
 
             ChainedTokenCredential credential = new ChainedTokenCredential(new ManagedIdentityCredential(ManagedIdentityId.SystemAssigned), new AzureCliCredential());
@@ -59,7 +60,10 @@ namespace Altinn.AccessManagement.UI.Extensions
             catch (Exception appConfigurationException)
             {
                 logger.LogError(appConfigurationException, "Program // Unable to connect to Azure App Configuration - falling back to appsettings values");
+                return false;
             }
+
+            return true;
         }
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Extensions/AppConfigurationExtensions.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Extensions/AppConfigurationExtensions.cs
@@ -1,0 +1,58 @@
+using System.Diagnostics.CodeAnalysis;
+using Altinn.AccessManagement.Configuration;
+using Azure.Identity;
+using Microsoft.Extensions.Configuration.AzureAppConfiguration;
+
+namespace Altinn.AccessManagement.UI.Extensions
+{
+    /// <summary>
+    /// Configuration of Azure App Configuration as a configuration source, providing feature flags
+    /// and key-values labeled for this application. Mirrors AddAltinnAppConfiguration in
+    /// Altinn.Authorization.ServiceDefaults (same configuration keys), so this setup can be
+    /// replaced by that package once the repos are merged.
+    /// </summary>
+    [ExcludeFromCodeCoverage] // Configuration wiring only - connecting requires a live App Configuration endpoint
+    public static class AppConfigurationExtensions
+    {
+        /// <summary>
+        /// Adds Azure App Configuration as a configuration source when Altinn:AppConfiguration:Endpoint
+        /// and Altinn:AppConfiguration:Label are set. When they are not (e.g. locally), the app runs on
+        /// appsettings values alone.
+        /// </summary>
+        /// <param name="config">the configuration manager to add the configuration source to</param>
+        /// <param name="logger">setup logger</param>
+        public static void AddAltinnAppConfiguration(this ConfigurationManager config, ILogger logger)
+        {
+            string appConfigurationEndpoint = config["Altinn:AppConfiguration:Endpoint"];
+            string appConfigurationLabel = config["Altinn:AppConfiguration:Label"];
+
+            if (string.IsNullOrEmpty(appConfigurationEndpoint) || string.IsNullOrEmpty(appConfigurationLabel))
+            {
+                logger.LogInformation("Program // Altinn:AppConfiguration:Endpoint or Label not set - skipping Azure App Configuration");
+                return;
+            }
+
+            ChainedTokenCredential credential = new ChainedTokenCredential(new ManagedIdentityCredential(ManagedIdentityId.SystemAssigned), new AzureCliCredential());
+
+            config.AddAzureAppConfiguration(options =>
+            {
+                options.Connect(new Uri(appConfigurationEndpoint), credential);
+                options.Select(KeyFilter.Any, appConfigurationLabel);
+                options.ConfigureRefresh(refresh =>
+                {
+                    refresh.RegisterAll();
+                    refresh.SetRefreshInterval(RefreshAppConfigurationHostedService.RefreshInterval);
+                });
+
+                if (config.GetValue("Altinn:AppConfiguration:FeatureFlags:Enable", false))
+                {
+                    options.UseFeatureFlags(featureFlagOptions =>
+                    {
+                        featureFlagOptions.Select(KeyFilter.Any, appConfigurationLabel);
+                        featureFlagOptions.SetRefreshInterval(RefreshAppConfigurationHostedService.RefreshInterval);
+                    });
+                }
+            });
+        }
+    }
+}

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Extensions/AppConfigurationExtensions.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Extensions/AppConfigurationExtensions.cs
@@ -34,25 +34,32 @@ namespace Altinn.AccessManagement.UI.Extensions
 
             ChainedTokenCredential credential = new ChainedTokenCredential(new ManagedIdentityCredential(ManagedIdentityId.SystemAssigned), new AzureCliCredential());
 
-            config.AddAzureAppConfiguration(options =>
+            try
             {
-                options.Connect(new Uri(appConfigurationEndpoint), credential);
-                options.Select(KeyFilter.Any, appConfigurationLabel);
-                options.ConfigureRefresh(refresh =>
+                config.AddAzureAppConfiguration(options =>
                 {
-                    refresh.RegisterAll();
-                    refresh.SetRefreshInterval(RefreshAppConfigurationHostedService.RefreshInterval);
-                });
-
-                if (config.GetValue("Altinn:AppConfiguration:FeatureFlags:Enable", false))
-                {
-                    options.UseFeatureFlags(featureFlagOptions =>
+                    options.Connect(new Uri(appConfigurationEndpoint), credential);
+                    options.Select(KeyFilter.Any, appConfigurationLabel);
+                    options.ConfigureRefresh(refresh =>
                     {
-                        featureFlagOptions.Select(KeyFilter.Any, appConfigurationLabel);
-                        featureFlagOptions.SetRefreshInterval(RefreshAppConfigurationHostedService.RefreshInterval);
+                        refresh.RegisterAll();
+                        refresh.SetRefreshInterval(RefreshAppConfigurationHostedService.RefreshInterval);
                     });
-                }
-            });
+
+                    if (config.GetValue("Altinn:AppConfiguration:FeatureFlags:Enable", false))
+                    {
+                        options.UseFeatureFlags(featureFlagOptions =>
+                        {
+                            featureFlagOptions.Select(KeyFilter.Any, appConfigurationLabel);
+                            featureFlagOptions.SetRefreshInterval(RefreshAppConfigurationHostedService.RefreshInterval);
+                        });
+                    }
+                });
+            }
+            catch (Exception appConfigurationException)
+            {
+                logger.LogError(appConfigurationException, "Program // Unable to connect to Azure App Configuration - falling back to appsettings values");
+            }
         }
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Program.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Program.cs
@@ -41,6 +41,8 @@ string applicationInsightsKeySecretName = "ApplicationInsights--InstrumentationK
 
 string applicationInsightsConnectionString = string.Empty;
 
+bool appConfigurationEnabled = false;
+
 ConfigureSetupLogging();
 
 await SetConfigurationProviders(builder.Configuration);
@@ -171,7 +173,7 @@ async Task SetConfigurationProviders(ConfigurationManager config)
 
     await ConnectToKeyVaultAndSetApplicationInsights(config);
 
-    config.AddAltinnAppConfiguration(logger);
+    appConfigurationEnabled = config.AddAltinnAppConfiguration(logger);
 }
 
 async Task ConnectToKeyVaultAndSetApplicationInsights(ConfigurationManager config)
@@ -218,7 +220,7 @@ void ConfigureServices(IServiceCollection services, IConfiguration config)
     services.AddSingleton(config);
 
     services.AddFeatureManagement();
-    if (!string.IsNullOrEmpty(config["Altinn:AppConfiguration:Endpoint"]) && !string.IsNullOrEmpty(config["Altinn:AppConfiguration:Label"]))
+    if (appConfigurationEnabled)
     {
         services.AddAzureAppConfiguration();
         services.TryAddSingleton(TimeProvider.System);

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Program.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Program.cs
@@ -25,8 +25,10 @@ using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Configuration.AzureAppConfiguration;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging.ApplicationInsights;
+using Microsoft.FeatureManagement;
 using Microsoft.IdentityModel.Logging;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
@@ -169,6 +171,44 @@ async Task SetConfigurationProviders(ConfigurationManager config)
     config.AddCommandLine(args);
 
     await ConnectToKeyVaultAndSetApplicationInsights(config);
+
+    AddAltinnAppConfiguration(config);
+}
+
+// Mirrors AddAltinnAppConfiguration in Altinn.Authorization.ServiceDefaults (same configuration
+// keys), so this setup can be replaced by that package once the repos are merged.
+void AddAltinnAppConfiguration(ConfigurationManager config)
+{
+    string appConfigurationEndpoint = config["Altinn:AppConfiguration:Endpoint"];
+    string appConfigurationLabel = config["Altinn:AppConfiguration:Label"];
+
+    if (string.IsNullOrEmpty(appConfigurationEndpoint) || string.IsNullOrEmpty(appConfigurationLabel))
+    {
+        logger.LogInformation("Program // Altinn:AppConfiguration:Endpoint or Label not set - skipping Azure App Configuration");
+        return;
+    }
+
+    ChainedTokenCredential credential = new ChainedTokenCredential(new ManagedIdentityCredential(ManagedIdentityId.SystemAssigned), new AzureCliCredential());
+
+    config.AddAzureAppConfiguration(options =>
+    {
+        options.Connect(new Uri(appConfigurationEndpoint), credential);
+        options.Select(KeyFilter.Any, appConfigurationLabel);
+        options.ConfigureRefresh(refresh =>
+        {
+            refresh.RegisterAll();
+            refresh.SetRefreshInterval(RefreshAppConfigurationHostedService.RefreshInterval);
+        });
+
+        if (config.GetValue("Altinn:AppConfiguration:FeatureFlags:Enable", false))
+        {
+            options.UseFeatureFlags(featureFlagOptions =>
+            {
+                featureFlagOptions.Select(KeyFilter.Any, appConfigurationLabel);
+                featureFlagOptions.SetRefreshInterval(RefreshAppConfigurationHostedService.RefreshInterval);
+            });
+        }
+    });
 }
 
 async Task ConnectToKeyVaultAndSetApplicationInsights(ConfigurationManager config)
@@ -210,10 +250,16 @@ void ConfigureServices(IServiceCollection services, IConfiguration config)
 
     services.Configure<CacheConfig>(config.GetSection("CacheConfig"));
     services.Configure<GeneralSettings>(config.GetSection("GeneralSettings"));
-    services.Configure<FeatureFlags>(config.GetSection("FeatureFlags"));
     services.Configure<KeyVaultSettings>(config.GetSection("KeyVaultSettings"));
     services.Configure<ClientSettings>(config.GetSection("ClientSettings"));
     services.AddSingleton(config);
+
+    services.AddFeatureManagement();
+    if (!string.IsNullOrEmpty(config["Altinn:AppConfiguration:Endpoint"]) && !string.IsNullOrEmpty(config["Altinn:AppConfiguration:Label"]))
+    {
+        services.AddAzureAppConfiguration();
+        services.AddHostedService<RefreshAppConfigurationHostedService>();
+    }
 
     services.AddHttpClient<IAuthenticationClient, AuthenticationClient>();
     services.AddHttpClient<AuthorizationApiClient>();

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Program.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Program.cs
@@ -25,7 +25,6 @@ using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.Extensions.Configuration.AzureAppConfiguration;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging.ApplicationInsights;
 using Microsoft.FeatureManagement;
@@ -172,43 +171,7 @@ async Task SetConfigurationProviders(ConfigurationManager config)
 
     await ConnectToKeyVaultAndSetApplicationInsights(config);
 
-    AddAltinnAppConfiguration(config);
-}
-
-// Mirrors AddAltinnAppConfiguration in Altinn.Authorization.ServiceDefaults (same configuration
-// keys), so this setup can be replaced by that package once the repos are merged.
-void AddAltinnAppConfiguration(ConfigurationManager config)
-{
-    string appConfigurationEndpoint = config["Altinn:AppConfiguration:Endpoint"];
-    string appConfigurationLabel = config["Altinn:AppConfiguration:Label"];
-
-    if (string.IsNullOrEmpty(appConfigurationEndpoint) || string.IsNullOrEmpty(appConfigurationLabel))
-    {
-        logger.LogInformation("Program // Altinn:AppConfiguration:Endpoint or Label not set - skipping Azure App Configuration");
-        return;
-    }
-
-    ChainedTokenCredential credential = new ChainedTokenCredential(new ManagedIdentityCredential(ManagedIdentityId.SystemAssigned), new AzureCliCredential());
-
-    config.AddAzureAppConfiguration(options =>
-    {
-        options.Connect(new Uri(appConfigurationEndpoint), credential);
-        options.Select(KeyFilter.Any, appConfigurationLabel);
-        options.ConfigureRefresh(refresh =>
-        {
-            refresh.RegisterAll();
-            refresh.SetRefreshInterval(RefreshAppConfigurationHostedService.RefreshInterval);
-        });
-
-        if (config.GetValue("Altinn:AppConfiguration:FeatureFlags:Enable", false))
-        {
-            options.UseFeatureFlags(featureFlagOptions =>
-            {
-                featureFlagOptions.Select(KeyFilter.Any, appConfigurationLabel);
-                featureFlagOptions.SetRefreshInterval(RefreshAppConfigurationHostedService.RefreshInterval);
-            });
-        }
-    });
+    config.AddAltinnAppConfiguration(logger);
 }
 
 async Task ConnectToKeyVaultAndSetApplicationInsights(ConfigurationManager config)
@@ -258,6 +221,7 @@ void ConfigureServices(IServiceCollection services, IConfiguration config)
     if (!string.IsNullOrEmpty(config["Altinn:AppConfiguration:Endpoint"]) && !string.IsNullOrEmpty(config["Altinn:AppConfiguration:Label"]))
     {
         services.AddAzureAppConfiguration();
+        services.TryAddSingleton(TimeProvider.System);
         services.AddHostedService<RefreshAppConfigurationHostedService>();
     }
 

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.AT22.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.AT22.json
@@ -34,5 +34,5 @@
   "KeyVaultSettings": {
     "SecretUri": "https://altinn-at22-am-kv.vault.azure.net/"
   },
-  "FeatureFlags": {}
+  "FeatureManagement": {}
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.AT23.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.AT23.json
@@ -16,5 +16,5 @@
   "KeyVaultSettings": {
     "SecretUri": "https://altinn-at23-am-kv.vault.azure.net/"
   },
-  "FeatureFlags": {}
+  "FeatureManagement": {}
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.AT24.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.AT24.json
@@ -16,5 +16,5 @@
   "KeyVaultSettings": {
     "SecretUri": "https://altinn-at24-am-kv.vault.azure.net/"
   },
-  "FeatureFlags": {}
+  "FeatureManagement": {}
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.Development.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.Development.json
@@ -38,7 +38,8 @@
   "KeyVaultSettings": {
     "SecretUri": "https://altinn-dev-amui-kv.vault.azure.net/"
   },
-  "FeatureFlags": {
-    "DisplayPopularSingleRightsServices": false
+  "FeatureManagement": {
+    "AccessManagementUI.DisplayPopularSingleRightsServices": false,
+    "AccessManagementUI.UseNewSingleRightsClientDelegation": false
   }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.Prod.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.Prod.json
@@ -16,7 +16,7 @@
   "KeyVaultSettings": {
     "SecretUri": "https://altinn-prod-am-kv.vault.azure.net/"
   },
-  "FeatureFlags": {
-    "DisplayPopularSingleRightsServices": true
+  "FeatureManagement": {
+    "AccessManagementUI.DisplayPopularSingleRightsServices": true
   }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.TT02.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.TT02.json
@@ -16,7 +16,7 @@
   "KeyVaultSettings": {
     "SecretUri": "https://altinn-tt02-am-kv.vault.azure.net/"
   },
-  "FeatureFlags": {
-    "DisplayPopularSingleRightsServices": true
+  "FeatureManagement": {
+    "AccessManagementUI.DisplayPopularSingleRightsServices": true
   }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.YT01.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.YT01.json
@@ -16,7 +16,7 @@
   "KeyVaultSettings": {
     "SecretUri": "https://altinn-yt01-am-kv.vault.azure.net/"
   },
-  "FeatureFlags": {
-    "DisplayPopularSingleRightsServices": true
+  "FeatureManagement": {
+    "AccessManagementUI.DisplayPopularSingleRightsServices": true
   }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.json
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/appsettings.json
@@ -52,7 +52,8 @@
     "App": "access-management-ui",
     "CertificateName": "JWTCertificate"
   },
-  "FeatureFlags": {
-    "DisplayPopularSingleRightsServices": false
+  "FeatureManagement": {
+    "AccessManagementUI.DisplayPopularSingleRightsServices": false,
+    "AccessManagementUI.UseNewSingleRightsClientDelegation": false
   }
 }

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -4,6 +4,7 @@ declare global {
   interface Window {
     featureFlags: {
       displayPopularSingleRightsServices: boolean;
+      useNewSingleRightsClientDelegation: boolean;
     };
   }
 }


### PR DESCRIPTION
Del av Altinn/altinn-authorization-tmp#2806.

Flytter feature-toggles fra appsettings til azure FeatureManagement appconfaltinnauth001hub. ([her](https://portal.azure.com/#@ai-dev.no/resource/subscriptions/01de49cb-48ef-4494-bc9d-b9e19a90bcd5/resourceGroups/rgaltinnauth001hub/providers/Microsoft.AppConfiguration/configurationStores/appconfaltinnauth001hub/ff))

Vi leser nå toggles fra azure, og henter dem på nytt hvert minutt. Det gjør at vi kan skru på en feature uten å deploye kode. Featuren vil bli aktivert i nettleseren ved neste sidelast.

Vi kan også skru av og på flagg i `appsettings.Development.json`, og de vil aktiveres i BFFen uten at vi trenger å restarte appen.

## Changes

- `AddAltinnAppConfiguration` samme oppsett som `Altinn.Authorization.ServiceDefaults` i tmp-repoet. Kan slettes etter en eventuell flytting av frontend til monorepo.
  - hvis `Altinn:AppConfiguration:Endpoint` eller `Label` ikke er satt, hopper vi over hele `AddAltinnAppConfiguration`. Vi leser da togglene satt i `FeatureManagement` i appsettings. Lokalt vil disse bli "hot-reloaded".
  - det samme gjelder hvis Azure App Configuration er utilgjengelig ved oppstart: feilen logges og BFFen faller tilbake til appsettings-verdiene i stedet for å krasje.
- `RefreshAppConfigurationHostedService` henter feature-toggles hvert minutt, så vi slipper redeploy for aktivering.
- Legger til et nytt flagg for enkelttjenester i klient-delegering som en test: `AccessManagementUI.UseNewSingleRightsClientDelegation`
- Ellers er flyten som før -> flaggene skrives inn i ViewBag i BFFen -> Leses fra `window` i klient-koden.
- Ny seksjon i README om hvordan man legger til og leser Toggles.

For at BFFen skal hente feature-toggles fra Azure, må vi sette APP_CONFIGURATION_LABEL som environment-variabel i GitHub (Settings -> Environments -> Variables (Dette krever ADMIN tilgang i gui!)). Det er labelen den bruker for å hente verdiene. Hvis denne ikke er satt, leser BFFen toggles fra ...appsettings.json

Disse er satt opp slik: `{{miljø}}-access-management-ui`. ...-ui-postfixen gjør at vi ikke leser feature-togglene til backend og vice versa.

ENV | Verdi
-- | --
AT22 | at22-access-management-ui
AT23 | at23-access-management-ui
AT24 | at24-access-management-ui
YT01 | yt01-access-management-ui
TT02 | tt02-access-management-ui  (#2395)
PROD | prod-access-management-ui (#2395)

AT23 har ikke denne variabelen satt enda. Dette er for å teste at fallback-løsningen funker.

## Plan for utrulling
Flagg er deployet til AT-miljøene Altinn/altinn-authorization-tmp#3797, men ikke til TT02 og PROD. På grunn av deploy-frys venter vi med å sette APP_CONFIGURATION_LABEL i TT02 og PROD, slik at vi ikke hindrer at kritiske feil kan deployes til prod.

Issue for oppfølging ligger [her](https://github.com/Altinn/altinn-access-management-frontend/issues/2395)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added centralized feature-flag management backed by Azure App Configuration with periodic runtime refresh.
  - Introduced `UseNewSingleRightsClientDelegation` feature flag and exposed it to the frontend.
- **Documentation**
  - Added a “Feature flags 🚩” section covering local setup, deployment behavior, and flag exposure across layers.
- **Deployment**
  - Updated the deployment workflow to consistently apply or clear Azure App Configuration feature-flag settings based on the provided label.
- **Tests**
  - Expanded automated coverage for feature-flag behavior and configuration refresh scheduling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
