### PR TITLE
Vis pakker bruker ikke har ved søk på brukersiden

### DIFF
--- a/src/features/amUI/common/AccessPackageList/AccessPackageList.module.css
+++ b/src/features/amUI/common/AccessPackageList/AccessPackageList.module.css
@@ -13,6 +13,16 @@
   height: 90%;
 }
 
+.subListHeading {
+  margin-bottom: var(--ds-spacing-2);
+}
+.otherListDivider {
+  border: 0;
+  border-top: 1px solid var(--ds-color-neutral-border-subtle);
+  margin-top: var(--ds-spacing-11);
+  margin-bottom: var(--ds-spacing-8);
+}
+
 .loadingSpinner {
   display: flex;
   align-items: center;

--- a/src/features/amUI/common/AccessPackageList/AccessPackageList.tsx
+++ b/src/features/amUI/common/AccessPackageList/AccessPackageList.tsx
@@ -154,8 +154,8 @@ export const AccessPackageList = ({
     ? combinedAreas
     : [...combinedAreas].sort((a, b) => a.name.localeCompare(b.name));
 
-  const areasAssignablePackages = combinedAreas.filter((x) => x.packages.assigned.length > 0);
-  const areasUnassignablePackages = combinedAreas.filter((x) => x.packages.assigned.length === 0);
+  const areasWithActiveMatches = combinedAreas.filter((x) => x.packages.assigned.length > 0);
+  const areasWithoutActiveMatches = combinedAreas.filter((x) => x.packages.assigned.length === 0);
 
   const renderAccessPackageList = (items: ExtendedAccessArea[]) => {
     return (
@@ -238,14 +238,14 @@ export const AccessPackageList = ({
           >
             {t('access_packages.search_active_matches')}:
           </DsHeading>
-          {areasAssignablePackages.length === 0 ? (
+          {areasWithActiveMatches.length === 0 ? (
             <DsParagraph className={classes.noAccessPackages}>
               {t('access_packages.search_no_active_matches')}
             </DsParagraph>
           ) : (
-            renderAccessPackageList(areasAssignablePackages)
+            renderAccessPackageList(areasWithActiveMatches)
           )}
-          {areasUnassignablePackages.length > 0 && (
+          {areasWithoutActiveMatches.length > 0 && (
             <>
               <hr className={classes.otherListDivider} />
               <DsHeading
@@ -255,7 +255,7 @@ export const AccessPackageList = ({
               >
                 {t('access_packages.search_other_matches')}:
               </DsHeading>
-              {renderAccessPackageList(areasUnassignablePackages)}
+              {renderAccessPackageList(areasWithoutActiveMatches)}
             </>
           )}
         </>

--- a/src/features/amUI/common/AccessPackageList/AccessPackageList.tsx
+++ b/src/features/amUI/common/AccessPackageList/AccessPackageList.tsx
@@ -39,7 +39,7 @@ interface AccessPackageListProps {
   packageAs?: React.ElementType;
   noPackagesText?: string;
   filterByType?: boolean;
-  areaHeadingLevel?: 2 | 3;
+  firstHeadingLevel?: 2 | 3;
   showUnassignedAvailableAreas?: boolean;
 }
 
@@ -62,7 +62,7 @@ export const AccessPackageList = ({
   packageAs,
   noPackagesText,
   filterByType = true,
-  areaHeadingLevel = 3,
+  firstHeadingLevel = 3,
   showUnassignedAvailableAreas = false,
 }: AccessPackageListProps) => {
   const { t } = useTranslation();
@@ -157,7 +157,7 @@ export const AccessPackageList = ({
   const areasWithActiveMatches = combinedAreas.filter((x) => x.packages.assigned.length > 0);
   const areasWithoutActiveMatches = combinedAreas.filter((x) => x.packages.assigned.length === 0);
 
-  const renderAccessPackageList = (items: ExtendedAccessArea[]) => {
+  const renderAccessPackageList = (items: ExtendedAccessArea[], headingLevel: 2 | 3 | 4) => {
     return (
       <List>
         {items.map((area) => {
@@ -174,7 +174,7 @@ export const AccessPackageList = ({
               showPackagesCount={showPackagesCount}
               showPermissions={showPermissions}
               partyType={areaPartyType}
-              headingLevel={areaHeadingLevel}
+              headingLevel={headingLevel}
             >
               <AreaItemContent
                 area={area}
@@ -192,7 +192,7 @@ export const AccessPackageList = ({
                 showPermissions={showPermissions}
                 packageAs={packageAs}
                 partyType={areaPartyType}
-                headingLevel={areaHeadingLevel === 2 ? 3 : 4}
+                headingLevel={(headingLevel + 1) as 3 | 4 | 5}
               />
             </AreaItem>
           );
@@ -230,7 +230,7 @@ export const AccessPackageList = ({
       {showUnassignedAvailableAreas ? (
         <>
           <DsHeading
-            level={2}
+            level={firstHeadingLevel}
             data-size='xs'
             className={classes.subListHeading}
           >
@@ -241,7 +241,7 @@ export const AccessPackageList = ({
               {t('access_packages.search_no_active_matches')}
             </DsParagraph>
           ) : (
-            renderAccessPackageList(areasWithActiveMatches)
+            renderAccessPackageList(areasWithActiveMatches, (firstHeadingLevel + 1) as 3 | 4)
           )}
           {areasWithoutActiveMatches.length > 0 && (
             <>
@@ -253,12 +253,12 @@ export const AccessPackageList = ({
               >
                 {t('access_packages.search_other_matches')}:
               </DsHeading>
-              {renderAccessPackageList(areasWithoutActiveMatches)}
+              {renderAccessPackageList(areasWithoutActiveMatches, (firstHeadingLevel + 1) as 3 | 4)}
             </>
           )}
         </>
       ) : (
-        <>{renderAccessPackageList(displayAreas)}</>
+        <>{renderAccessPackageList(displayAreas, firstHeadingLevel)}</>
       )}
     </div>
   );

--- a/src/features/amUI/common/AccessPackageList/AccessPackageList.tsx
+++ b/src/features/amUI/common/AccessPackageList/AccessPackageList.tsx
@@ -204,9 +204,7 @@ export const AccessPackageList = ({
   if (
     searchString &&
     searchString.length > 0 &&
-    (allPackageAreas === undefined ||
-      allPackageAreas.length === 0 ||
-      (!showAllAreas && displayAreas.length === 0))
+    (allPackageAreas === undefined || allPackageAreas.length === 0 || displayAreas.length === 0)
   ) {
     return (
       <div className={classes.accessAreaList}>

--- a/src/features/amUI/common/AccessPackageList/AccessPackageList.tsx
+++ b/src/features/amUI/common/AccessPackageList/AccessPackageList.tsx
@@ -1,4 +1,4 @@
-import { DsAlert, DsParagraph, DsSpinner, List } from '@altinn/altinn-components';
+import { DsAlert, DsHeading, DsParagraph, DsSpinner, List } from '@altinn/altinn-components';
 import { useTranslation } from 'react-i18next';
 
 import type { Party } from '@/rtk/features/lookupApi';
@@ -8,7 +8,7 @@ import type { ActionError } from '@/resources/hooks/useActionError';
 import type { DelegationAction } from '../DelegationModal/EditModal';
 
 import classes from './AccessPackageList.module.css';
-import { useAreaPackageList } from './useAreaPackageList';
+import { ExtendedAccessArea, useAreaPackageList } from './useAreaPackageList';
 import { useAccessPackageActions } from './useAccessPackageActions';
 import { SkeletonAccessPackageList } from './SkeletonAccessPackageList';
 import { AreaItem } from './AreaItem';
@@ -40,6 +40,7 @@ interface AccessPackageListProps {
   noPackagesText?: string;
   filterByType?: boolean;
   areaHeadingLevel?: 2 | 3;
+  showUnassignedAvailableAreas?: boolean;
 }
 
 export const AccessPackageList = ({
@@ -62,6 +63,7 @@ export const AccessPackageList = ({
   noPackagesText,
   filterByType = true,
   areaHeadingLevel = 3,
+  showUnassignedAvailableAreas = false,
 }: AccessPackageListProps) => {
   const { t } = useTranslation();
 
@@ -152,6 +154,53 @@ export const AccessPackageList = ({
     ? combinedAreas
     : [...combinedAreas].sort((a, b) => a.name.localeCompare(b.name));
 
+  const areasAssignablePackages = combinedAreas.filter((x) => x.packages.assigned.length > 0);
+  const areasUnassignablePackages = combinedAreas.filter((x) => x.packages.assigned.length === 0);
+
+  const renderAccessPackageList = (items: ExtendedAccessArea[]) => {
+    return (
+      <List>
+        {items.map((area) => {
+          const areaPartyType =
+            area.typeName === 'Person' ? PartyType.Person : PartyType.Organization;
+
+          const expanded = (searchString && searchString.length > 2) || isExpanded(area.id);
+          return (
+            <AreaItem
+              key={area.id}
+              area={area}
+              expanded={expanded}
+              toggleExpandedArea={toggleExpandedArea}
+              showPackagesCount={showPackagesCount}
+              showPermissions={showPermissions}
+              partyType={areaPartyType}
+              headingLevel={areaHeadingLevel}
+            >
+              <AreaItemContent
+                area={area}
+                availableActions={availableActions}
+                onSelect={onSelect}
+                onDelegate={onDelegate}
+                onRevoke={onRevoke}
+                onRequest={onRequest}
+                onDeleteRequest={deleteRequest}
+                hasPendingRequest={hasPendingRequest}
+                isLoadingRequest={isLoadingRequest}
+                isActionLoading={isActionLoading}
+                showAvailablePackages={!minimizeAvailablePackages}
+                showAvailableToggle={showAvailableToggle}
+                showPermissions={showPermissions}
+                packageAs={packageAs}
+                partyType={areaPartyType}
+                headingLevel={areaHeadingLevel === 2 ? 3 : 4}
+              />
+            </AreaItem>
+          );
+        })}
+      </List>
+    );
+  };
+
   if (
     searchString &&
     searchString.length > 0 &&
@@ -168,50 +217,50 @@ export const AccessPackageList = ({
     );
   }
 
-  return (
-    <div className={classes.accessAreaList}>
-      {displayAreas.length === 0 && !searchError && !activeDelegationsError ? (
+  if (displayAreas.length === 0 && !searchError && !activeDelegationsError) {
+    return (
+      <div className={classes.accessAreaList}>
         <DsParagraph className={classes.noAccessPackages}>
           {noPackagesText || t('access_packages.no_packages')}
         </DsParagraph>
-      ) : (
-        <List>
-          {displayAreas.map((area) => {
-            const expanded = (searchString && searchString.length > 2) || isExpanded(area.id);
+      </div>
+    );
+  }
 
-            return (
-              <AreaItem
-                key={area.id}
-                area={area}
-                expanded={expanded}
-                toggleExpandedArea={toggleExpandedArea}
-                showPackagesCount={showPackagesCount}
-                showPermissions={showPermissions}
-                partyType={area.typeName === 'Person' ? PartyType.Person : PartyType.Organization}
-                headingLevel={areaHeadingLevel}
+  return (
+    <div className={classes.accessAreaList}>
+      {showUnassignedAvailableAreas ? (
+        <>
+          <DsHeading
+            level={2}
+            data-size='xs'
+            className={classes.subListHeading}
+          >
+            {t('access_packages.search_active_matches')}:
+          </DsHeading>
+          {areasAssignablePackages.length === 0 ? (
+            <DsParagraph className={classes.noAccessPackages}>
+              {t('access_packages.search_no_active_matches')}
+            </DsParagraph>
+          ) : (
+            renderAccessPackageList(areasAssignablePackages)
+          )}
+          {areasUnassignablePackages.length > 0 && (
+            <>
+              <hr className={classes.otherListDivider} />
+              <DsHeading
+                level={2}
+                data-size='xs'
+                className={classes.subListHeading}
               >
-                <AreaItemContent
-                  area={area}
-                  availableActions={availableActions}
-                  onSelect={onSelect}
-                  onDelegate={onDelegate}
-                  onRevoke={onRevoke}
-                  onRequest={onRequest}
-                  onDeleteRequest={deleteRequest}
-                  hasPendingRequest={hasPendingRequest}
-                  isLoadingRequest={isLoadingRequest}
-                  isActionLoading={isActionLoading}
-                  showAvailablePackages={!minimizeAvailablePackages}
-                  showAvailableToggle={showAvailableToggle}
-                  showPermissions={showPermissions}
-                  packageAs={packageAs}
-                  partyType={area.typeName === 'Person' ? PartyType.Person : PartyType.Organization}
-                  headingLevel={areaHeadingLevel === 2 ? 3 : 4}
-                />
-              </AreaItem>
-            );
-          })}
-        </List>
+                {t('access_packages.search_other_matches')}:
+              </DsHeading>
+              {renderAccessPackageList(areasUnassignablePackages)}
+            </>
+          )}
+        </>
+      ) : (
+        <>{renderAccessPackageList(displayAreas)}</>
       )}
     </div>
   );

--- a/src/features/amUI/common/AccessPackageList/AreaItem.tsx
+++ b/src/features/amUI/common/AccessPackageList/AreaItem.tsx
@@ -16,7 +16,7 @@ interface AreaItemProps {
   showPackagesCount?: boolean;
   showPermissions?: boolean;
   partyType: PartyType;
-  headingLevel?: 2 | 3;
+  headingLevel?: 2 | 3 | 4;
 }
 
 export const AreaItem = ({
@@ -67,7 +67,7 @@ export const AreaItem = ({
         ) : undefined
       }
       expanded={expanded}
-      titleAs={headingLevel === 2 ? 'h2' : 'h3'}
+      titleAs={`h${headingLevel}` as 'h2' | 'h3' | 'h4'}
       onClick={() => toggleExpandedArea(area.id)}
       size='lg'
       border='solid'

--- a/src/features/amUI/common/AccessPackageList/AreaItem.tsx
+++ b/src/features/amUI/common/AccessPackageList/AreaItem.tsx
@@ -27,7 +27,7 @@ export const AreaItem = ({
   showPackagesCount,
   showPermissions,
   partyType,
-  headingLevel,
+  headingLevel = 3,
 }: AreaItemProps) => {
   const { t } = useTranslation();
   const isSm = useIsMobileOrSmaller();

--- a/src/features/amUI/common/AccessPackageList/AreaItemContent.tsx
+++ b/src/features/amUI/common/AccessPackageList/AreaItemContent.tsx
@@ -38,7 +38,7 @@ interface AreaItemContentProps {
   showPermissions?: boolean;
   packageAs?: React.ElementType;
   partyType: PartyType;
-  headingLevel: 3 | 4;
+  headingLevel: 3 | 4 | 5;
 }
 
 export const AreaItemContent = ({

--- a/src/features/amUI/common/AccessPackageList/useAreaPackageList.ts
+++ b/src/features/amUI/common/AccessPackageList/useAreaPackageList.ts
@@ -151,8 +151,11 @@ export const useAreaPackageList = ({
               acc.assignedAreas.push({ ...area, packages: pkgs });
             }
           } else if (showAllAreas) {
+            // filter away empty areas for different partyType
             const assignablePackages = area.accessPackages.filter(
-              (pkg) => pkg.isAssignable !== false,
+              (pkg) =>
+                pkg.isAssignable !== false &&
+                area.typeName.toLowerCase() === typeName?.toLowerCase(),
             );
             // Skip the area when none of its packages can be delegated — otherwise it would render empty.
             if (assignablePackages.length > 0) {

--- a/src/features/amUI/common/AccessPackageList/useAreaPackageList.ts
+++ b/src/features/amUI/common/AccessPackageList/useAreaPackageList.ts
@@ -177,6 +177,7 @@ export const useAreaPackageList = ({
     allPackageAreas,
     activeDelegations,
     fromParty,
+    filterByType,
     showAllAreas,
     showAllPackages,
     showOnlyGuardianships,

--- a/src/features/amUI/common/AccessPackageList/useAreaPackageList.ts
+++ b/src/features/amUI/common/AccessPackageList/useAreaPackageList.ts
@@ -152,9 +152,10 @@ export const useAreaPackageList = ({
             }
           } else if (showAllAreas) {
             // filter away empty areas for different partyType
-            const assignablePackages = area.accessPackages.filter(
-              (pkg) => pkg.isAssignable !== false && area.typeName === typeName,
-            );
+            const matchesPartyType = !filterByType || area.typeName === typeName;
+            const assignablePackages = matchesPartyType
+              ? area.accessPackages.filter((pkg) => pkg.isAssignable !== false)
+              : [];
             // Skip the area when none of its packages can be delegated — otherwise it would render empty.
             if (assignablePackages.length > 0) {
               acc.availableAreas.push({

--- a/src/features/amUI/common/AccessPackageList/useAreaPackageList.ts
+++ b/src/features/amUI/common/AccessPackageList/useAreaPackageList.ts
@@ -54,8 +54,8 @@ export const useAreaPackageList = ({
   const { fromParty, toParty, actingParty } = usePartyRepresentation();
   const typeName = fromParty
     ? fromParty?.partyTypeName === PartyType.Organization
-      ? 'organisasjon'
-      : 'person'
+      ? 'Organisasjon'
+      : 'Person'
     : undefined;
 
   const {
@@ -153,9 +153,7 @@ export const useAreaPackageList = ({
           } else if (showAllAreas) {
             // filter away empty areas for different partyType
             const assignablePackages = area.accessPackages.filter(
-              (pkg) =>
-                pkg.isAssignable !== false &&
-                area.typeName.toLowerCase() === typeName?.toLowerCase(),
+              (pkg) => pkg.isAssignable !== false && area.typeName === typeName,
             );
             // Skip the area when none of its packages can be delegated — otherwise it would render empty.
             if (assignablePackages.length > 0) {
@@ -195,7 +193,6 @@ export const useAreaPackageList = ({
     activeDelegations,
     searchError,
     activeDelegationsError,
-    partyType: typeName === 'person' ? PartyType.Person : PartyType.Organization,
   };
 };
 

--- a/src/features/amUI/common/AccessPackageList/useAreaPackageList.ts
+++ b/src/features/amUI/common/AccessPackageList/useAreaPackageList.ts
@@ -152,7 +152,7 @@ export const useAreaPackageList = ({
             }
           } else if (showAllAreas) {
             // filter away empty areas for different partyType
-            const matchesPartyType = !filterByType || area.typeName === typeName;
+            const matchesPartyType = area.typeName === typeName;
             const assignablePackages = matchesPartyType
               ? area.accessPackages.filter((pkg) => pkg.isAssignable !== false)
               : [];

--- a/src/features/amUI/poaOverview/AccessPackagePermissions.tsx
+++ b/src/features/amUI/poaOverview/AccessPackagePermissions.tsx
@@ -47,7 +47,7 @@ export const AccessPackagePermissions = () => {
           );
         }}
         noPackagesText={t('access_packages.no_packages')}
-        areaHeadingLevel={2}
+        firstHeadingLevel={2}
       />
     </>
   );

--- a/src/features/amUI/poaOverview/GuardianshipPermissions.tsx
+++ b/src/features/amUI/poaOverview/GuardianshipPermissions.tsx
@@ -36,7 +36,7 @@ export const GuardianshipPermissions = () => {
           );
         }}
         noPackagesText={t('access_packages.no_packages')}
-        areaHeadingLevel={2}
+        firstHeadingLevel={2}
       />
     </>
   );

--- a/src/features/amUI/userRightsPage/AccessPackageSection/ActiveDelegations.tsx
+++ b/src/features/amUI/userRightsPage/AccessPackageSection/ActiveDelegations.tsx
@@ -38,6 +38,8 @@ export const ActiveDelegations = ({ searchString }: ActiveDelegationsProps) => {
           isLoading={isLoading}
           showPackagesCount
           showAllPackages
+          showAllAreas={!!searchString}
+          showUnassignedAvailableAreas={!!searchString}
           minimizeAvailablePackages={!searchString}
           searchString={searchString}
           onSelect={(accessPackage) => {

--- a/src/localizations/en.json
+++ b/src/localizations/en.json
@@ -252,6 +252,9 @@
     "user_has_no_packages": "This user has no access packages.",
     "no_packages": "No access packages available.",
     "no_matching_search": "No matches for your search",
+    "search_active_matches": "Matches in active powers of attorney",
+    "search_no_active_matches": "No matches in active powers of attorney",
+    "search_other_matches": "Other matches",
     "info_alert_text": "Access packages replace today's Altinn roles. Read more on the <a href='https://info.altinn.no/en/help/ny-tilgangsstyring/'>help pages</a>.",
     "delegation_check": {
       "delegation_check_error_heading": "Technical error",

--- a/src/localizations/no_nb.json
+++ b/src/localizations/no_nb.json
@@ -249,6 +249,9 @@
     "user_has_no_packages": "Denne brukeren har ingen tilgangspakker.",
     "no_packages": "Ingen tilgangspakker er tilgjengelige.",
     "no_matching_search": "Ingen treff på søket",
+    "search_active_matches": "Treff i aktive fullmakter",
+    "search_no_active_matches": "Ingen treff i aktive fullmakter",
+    "search_other_matches": "Andre treff",
     "info_alert_text": "Tilgangspakker erstatter dagens Altinn-roller. Les mer om dette på <a href='https://info.altinn.no/hjelp/ny-tilgangsstyring/'>hjelpesidene</a>.",
     "delegation_check": {
       "delegation_check_error_heading": "Teknisk feil",

--- a/src/localizations/no_nn.json
+++ b/src/localizations/no_nn.json
@@ -248,6 +248,9 @@
     "user_has_no_packages": "Denne brukeren har ingen tilgangspakkar.",
     "no_packages": "Ingen tilgangspakkar tilgjengelege.",
     "no_matching_search": "Ingen treff på søket",
+    "search_active_matches": "Treff i aktive fullmakter",
+    "search_no_active_matches": "Ingen treff i aktive fullmakter",
+    "search_other_matches": "Andre treff",
     "info_alert_text": "Tilgangspakkar erstattar dagens Altinn-roller. Les meir om dette på <a href='https://info.altinn.no/nn/hjelp/ny-tilgangsstyring/'>hjelpesidene</a>.",
     "delegation_check": {
       "delegation_check_error_heading": "Teknisk feil",


### PR DESCRIPTION
## Description
- Ved søk i tilgangspakker på brukersiden, vis pakker som matcher søket også i områder der brukeren ikke har pakker fra før
- Dette gjelder også søk i tilgangspakker for brukere på "Fullmakter hos andre"-siden
- "Andre treff"-seksjonen vises kun dersom det er et eller flere treff. "Treff i aktive fullmakter" vises alltid, med egen melding hvis det ikke er treff i noen aktive fullmakter
<img width="1048" height="893" alt="image" src="https://github.com/user-attachments/assets/e9f99846-ce34-4ad2-bf9d-54f7c10eaae4" />
<img width="1053" height="885" alt="image" src="https://github.com/user-attachments/assets/0b900519-e430-4f47-807a-2f0bf14fdd35" />
<img width="1054" height="465" alt="image" src="https://github.com/user-attachments/assets/37092628-c278-4836-8b42-cb3c74666b14" />


## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/3393

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an option to show unassigned available areas, presenting results as “active matches” and “other matches” with headings and a divider.
  - Updated the user rights access package section so the split view is controlled by the current search input.
  - Added localized search result labels for active matches, no active matches, and other matches (English and Norwegian).
- **Bug Fixes**
  - Improved result accuracy by filtering assignable packages by the area’s party type.
  - Refined empty/no-matching-search states so the correct “no packages” messaging is shown reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->