### PR TITLE
fix some easy sonarcloud warnings: remove unused DI and fix argument names

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/AccessPackageService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/AccessPackageService.cs
@@ -1,8 +1,5 @@
-﻿using System.Reflection.Metadata.Ecma335;
-using System.Text.Json;
-using Altinn.AccessManagement.UI.Core.ClientInterfaces;
+﻿using Altinn.AccessManagement.UI.Core.ClientInterfaces;
 using Altinn.AccessManagement.UI.Core.Helpers;
-using Altinn.AccessManagement.UI.Core.Models;
 using Altinn.AccessManagement.UI.Core.Models.AccessPackage;
 using Altinn.AccessManagement.UI.Core.Models.AccessPackage.Frontend;
 using Altinn.AccessManagement.UI.Core.Models.Common;
@@ -13,25 +10,15 @@ namespace Altinn.AccessManagement.UI.Core.Services
     /// <inheritdoc />
     public class AccessPackageService : IAccessPackageService
     {
-        private readonly IAccessManagementClient _accessManagementClient;
         private readonly IAccessPackageClient _accessPackageClient;
-        private readonly ILookupService _lookupService;
-        private readonly JsonSerializerOptions options = new JsonSerializerOptions
-        {
-            PropertyNameCaseInsensitive = true,
-        };
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SingleRightService"/> class.
         /// </summary>
-        /// <param name="accessManagementClient">The access management client.</param>
         /// <param name="accessPackageClient">The access package client.</param>
-        /// <param name="lookupService">The lookup service.</param>
-        public AccessPackageService(IAccessManagementClient accessManagementClient, IAccessPackageClient accessPackageClient, ILookupService lookupService)
+        public AccessPackageService(IAccessPackageClient accessPackageClient)
         {
-            _accessManagementClient = accessManagementClient;
             _accessPackageClient = accessPackageClient;
-            _lookupService = lookupService;
         }
 
         /// <inheritdoc />

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/AltinnCdnService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/AltinnCdnService.cs
@@ -1,15 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http;
-using System.Text.Json;
-using System.Threading.Tasks;
 using Altinn.AccessManagement.UI.Core.ClientInterfaces;
-using Altinn.AccessManagement.UI.Core.Models;
 using Altinn.AccessManagement.UI.Core.Models.Common;
 using Altinn.AccessManagement.UI.Core.Services.Interfaces;
 using Microsoft.Extensions.Caching.Memory;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Altinn.AccessManagement.UI.Core.Services
@@ -19,7 +11,6 @@ namespace Altinn.AccessManagement.UI.Core.Services
     /// </summary>
     public class AltinnCdnService : IAltinnCdnService
     {
-        private readonly HttpClient _httpClient;
         private readonly IMemoryCache _cache;
         private readonly ILogger<AltinnCdnService> _logger;
         private readonly IAltinnCdnClient _altinnCdnClient;
@@ -31,13 +22,11 @@ namespace Altinn.AccessManagement.UI.Core.Services
         /// Initializes a new instance of the <see cref="AltinnCdnService"/> class.
         /// </summary>
         /// <param name="altinnCdnClient">The client used to fetch organization data from Altinn CDN.</param>
-        /// <param name="httpClient">The HTTP client used to fetch organization logo data.</param>
         /// <param name="cache">The memory cache for storing logo mappings.</param>
         /// <param name="logger">The logger instance for logging errors and information.</param>
-        public AltinnCdnService(IAltinnCdnClient altinnCdnClient, HttpClient httpClient, IMemoryCache cache, ILogger<AltinnCdnService> logger)
+        public AltinnCdnService(IAltinnCdnClient altinnCdnClient, IMemoryCache cache, ILogger<AltinnCdnService> logger)
         {
             _altinnCdnClient = altinnCdnClient;
-            _httpClient = httpClient;
             _cache = cache;
             _logger = logger;
         }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/DelegationExportService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/DelegationExportService.cs
@@ -9,7 +9,6 @@ using Altinn.AccessManagement.UI.Core.Models.InstanceDelegation.Frontend;
 using Altinn.AccessManagement.UI.Core.Models.Role;
 using Altinn.AccessManagement.UI.Core.Models.SingleRight;
 using Altinn.AccessManagement.UI.Core.Services.Interfaces;
-using Microsoft.Extensions.Logging;
 
 namespace Altinn.AccessManagement.UI.Core.Services
 {
@@ -27,8 +26,7 @@ namespace Altinn.AccessManagement.UI.Core.Services
         private readonly IAccessPackageService _accessPackageService;
         private readonly ISingleRightService _singleRightService;
         private readonly IInstanceService _instanceService;
-        private readonly ILogger<DelegationExportService> _logger;
-
+        
         /// <summary>
         /// Initializes a new instance of the <see cref="DelegationExportService"/> class.
         /// </summary>
@@ -37,15 +35,13 @@ namespace Altinn.AccessManagement.UI.Core.Services
             IRoleService roleService,
             IAccessPackageService accessPackageService,
             ISingleRightService singleRightService,
-            IInstanceService instanceService,
-            ILogger<DelegationExportService> logger)
+            IInstanceService instanceService)
         {
             _userService = userService;
             _roleService = roleService;
             _accessPackageService = accessPackageService;
             _singleRightService = singleRightService;
             _instanceService = instanceService;
-            _logger = logger;
         }
 
         /// <inheritdoc />

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/SingleRightService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/SingleRightService.cs
@@ -1,36 +1,26 @@
-using System.Text.Json;
 using Altinn.AccessManagement.UI.Core.ClientInterfaces;
 using Altinn.AccessManagement.UI.Core.Models.ResourceRegistry.Frontend;
 using Altinn.AccessManagement.UI.Core.Models.ResourceRegistry.ResourceOwner;
 using Altinn.AccessManagement.UI.Core.Models.SingleRight;
 using Altinn.AccessManagement.UI.Core.Services.Interfaces;
-using Altinn.Register.Contracts;
 
 namespace Altinn.AccessManagement.UI.Core.Services
 {
     /// <inheritdoc />
     public class SingleRightService : ISingleRightService
     {
-        private readonly IAccessManagementClient _accessManagementClient;
         private readonly IResourceService _resourceService;
         private readonly IResourceRegistryClient _resourceRegistryClient;
         private readonly ISingleRightClient _singleRightClient;
 
-        private readonly JsonSerializerOptions options = new JsonSerializerOptions
-        {
-            PropertyNameCaseInsensitive = true,
-        };
-
         /// <summary>
         /// Initializes a new instance of the <see cref="SingleRightService"/> class.
         /// </summary>
-        /// <param name="accessManagementClient">The access management client.</param>
         /// <param name="resourceService">The resource service.</param>
         /// <param name="resourceRegistryClient">The resource registry client.</param>
         /// <param name="singleRightClient">The single rights client.</param>
-        public SingleRightService(IAccessManagementClient accessManagementClient, IResourceService resourceService, IResourceRegistryClient resourceRegistryClient, ISingleRightClient singleRightClient)
+        public SingleRightService(IResourceService resourceService, IResourceRegistryClient resourceRegistryClient, ISingleRightClient singleRightClient)
         {
-            _accessManagementClient = accessManagementClient;
             _resourceService = resourceService;
             _resourceRegistryClient = resourceRegistryClient;
             _singleRightClient = singleRightClient;

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/UserService.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Services/UserService.cs
@@ -5,7 +5,6 @@ using Altinn.AccessManagement.UI.Core.Models.AccessManagement;
 using Altinn.AccessManagement.UI.Core.Models.Profile;
 using Altinn.AccessManagement.UI.Core.Models.User;
 using Altinn.AccessManagement.UI.Core.Services.Interfaces;
-using Microsoft.Extensions.Logging;
 
 namespace Altinn.AccessManagement.UI.Core.Services
 {
@@ -14,7 +13,6 @@ namespace Altinn.AccessManagement.UI.Core.Services
     /// </summary>
     public class UserService : IUserService
     {
-        private readonly ILogger _logger;
         private readonly IProfileClient _profileClient;
         private readonly IAccessManagementClient _accessManagementClient;
         private readonly IAccessManagementClientV0 _accessManagementClientV0;
@@ -23,19 +21,16 @@ namespace Altinn.AccessManagement.UI.Core.Services
         /// <summary>
         /// Initializes a new instance of the <see cref="UserService"/> class.
         /// </summary>
-        /// <param name="logger">handler for logger</param>
         /// <param name="profileClient">handler for profile client</param>
         /// <param name="accessManagementClient">handler for AM client</param>
         /// <param name="accessManagementClientV0">handler for old AM client</param>
         /// <param name="connectionClient">handler for right holder client</param>
         public UserService(
-            ILogger<UserService> logger,
             IProfileClient profileClient,
             IAccessManagementClient accessManagementClient,
             IAccessManagementClientV0 accessManagementClientV0,
             IConnectionClient connectionClient)
         {
-            _logger = logger;
             _profileClient = profileClient;
             _accessManagementClient = accessManagementClient;
             _accessManagementClientV0 = accessManagementClientV0;
@@ -113,9 +108,9 @@ namespace Altinn.AccessManagement.UI.Core.Services
         }
 
         /// <inheritdoc/>
-        public async Task<List<User>> GetReporteeList(Guid partyUuid)
+        public async Task<List<User>> GetReporteeList(Guid userId)
         {
-            List<AuthorizedParty> rightOwners = await _accessManagementClient.GetReporteeList(partyUuid);
+            List<AuthorizedParty> rightOwners = await _accessManagementClient.GetReporteeList(userId);
 
             return rightOwners.Select(party => new User(party)).ToList();
         }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/AccessPackageClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/AccessPackageClient.cs
@@ -6,7 +6,6 @@ using Altinn.AccessManagement.UI.Core.Extensions;
 using Altinn.AccessManagement.UI.Core.Helpers;
 using Altinn.AccessManagement.UI.Core.Models.AccessPackage;
 using Altinn.AccessManagement.UI.Core.Models.Common;
-using Altinn.AccessManagement.UI.Core.Services.Interfaces;
 using Altinn.AccessManagement.UI.Integration.Configuration;
 using Altinn.AccessManagement.UI.Integration.Util;
 using Microsoft.AspNetCore.Http;
@@ -24,7 +23,6 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
         private readonly HttpClient _client;
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly PlatformSettings _platformSettings;
-        private readonly IAccessTokenProvider _accessTokenProvider;
         private readonly JsonSerializerOptions _serializerOptions = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
 
         /// <summary>
@@ -34,13 +32,11 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
         /// <param name="logger">the handler for logger service</param>
         /// <param name="httpContextAccessor">the handler for httpcontextaccessor service</param>
         /// <param name="platformSettings"> platform settings configuration</param>
-        /// <param name="accessTokenProvider">the handler for access token generator</param>
         public AccessPackageClient(
             HttpClient httpClient,
             ILogger<AccessPackageClient> logger,
             IHttpContextAccessor httpContextAccessor,
-            IOptions<PlatformSettings> platformSettings,
-            IAccessTokenProvider accessTokenProvider)
+            IOptions<PlatformSettings> platformSettings)
         {
             _logger = logger;
             _platformSettings = platformSettings.Value;
@@ -48,7 +44,6 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
             httpClient.DefaultRequestHeaders.Add(_platformSettings.SubscriptionKeyHeaderName, _platformSettings.SubscriptionKey);
             _client = httpClient;
             _httpContextAccessor = httpContextAccessor;
-            _accessTokenProvider = accessTokenProvider;
         }
 
         /// <inheritdoc />

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/RoleClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/RoleClient.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using Altinn.AccessManagement.UI.Core.ClientInterfaces;
 using Altinn.AccessManagement.UI.Core.Extensions;
 using Altinn.AccessManagement.UI.Core.Helpers;
@@ -26,7 +23,6 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
         private readonly HttpClient _client;
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly PlatformSettings _platformSettings;
-        private readonly IAccessTokenProvider _accessTokenProvider;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AccessPackageClient"/> class
@@ -35,13 +31,11 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
         /// <param name="logger">the handler for logger service</param>
         /// <param name="httpContextAccessor">the handler for httpcontextaccessor service</param>
         /// <param name="platformSettings"> platform settings configuration</param>
-        /// <param name="accessTokenProvider">the handler for access token generator</param>
         public RoleClient(
             HttpClient httpClient,
             ILogger<RoleClient> logger,
             IHttpContextAccessor httpContextAccessor,
-            IOptions<PlatformSettings> platformSettings,
-            IAccessTokenProvider accessTokenProvider)
+            IOptions<PlatformSettings> platformSettings)
         {
             _logger = logger;
             _platformSettings = platformSettings.Value;
@@ -49,7 +43,6 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
             httpClient.DefaultRequestHeaders.Add(_platformSettings.SubscriptionKeyHeaderName, _platformSettings.SubscriptionKey);
             _client = httpClient;
             _httpContextAccessor = httpContextAccessor;
-            _accessTokenProvider = accessTokenProvider;
         }
 
         /// <inheritdoc />

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/AccessPackageClientMock.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Mocks/Mocks/AccessPackageClientMock.cs
@@ -143,11 +143,11 @@ namespace Altinn.AccessManagement.UI.Mocks.Mocks
         }
 
         /// <inheritdoc />
-        public async Task<HttpResponseMessage> RevokeAccessPackage(Guid from, Guid to, Guid party, string resourceId)
+        public async Task<HttpResponseMessage> RevokeAccessPackage(Guid from, Guid to, Guid party, string packageId)
         {
             string dataPath = Path.Combine(dataFolder, "AccessPackage", "RevokeDelegation");
 
-            var mockResponse = await Util.GetMockedHttpResponse(dataPath, resourceId);
+            var mockResponse = await Util.GetMockedHttpResponse(dataPath, packageId);
             if (mockResponse.IsSuccessStatusCode)
             {
                 return new HttpResponseMessage(HttpStatusCode.NoContent);

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/AccessPackageController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/AccessPackageController.cs
@@ -1,16 +1,11 @@
 ﻿using System.Net;
-using System.Net.Http.Json;
-using System.Security;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Altinn.AccessManagement.UI.Core.Helpers;
-using Altinn.AccessManagement.UI.Core.Models;
 using Altinn.AccessManagement.UI.Core.Models.AccessPackage;
 using Altinn.AccessManagement.UI.Core.Models.AccessPackage.Frontend;
-using Altinn.AccessManagement.UI.Core.Services;
 using Altinn.AccessManagement.UI.Core.Services.Interfaces;
 using Altinn.Authorization.ProblemDetails;
-using Altinn.Platform.Register.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -24,17 +19,15 @@ namespace Altinn.AccessManagement.UI.Controllers
     {
         private readonly IAccessPackageService _accessPackageService;
         private readonly IHttpContextAccessor _httpContextAccessor;
-        private readonly ILogger _logger;
         private readonly JsonSerializerOptions _serializerOptions = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AccessPackageController"/> class
         /// </summary>
-        public AccessPackageController(IAccessPackageService accessPackageService, IHttpContextAccessor httpContextAccessor, ILogger<AccessPackageController> logger)
+        public AccessPackageController(IAccessPackageService accessPackageService, IHttpContextAccessor httpContextAccessor)
         {
             _accessPackageService = accessPackageService;
             _httpContextAccessor = httpContextAccessor;
-            _logger = logger;
             _serializerOptions.Converters.Add(new JsonStringEnumConverter());
         }
 


### PR DESCRIPTION
## Description
Fix for some easy SonarCloud warnings:
- remove several unused dependency injection
- change some method argument names to match the interface definition

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal service and controller configuration by removing unused dependencies.
  * Improved JSON handling consistency for access package data.
  * Maintained existing organization data caching and service behavior.
  * Clarified parameter naming for user and access package operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->