### PR TITLE
sonarcloud fix: forward cancellationToken to httpClient where it was missing

### DIFF
--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Extensions/HttpClientExtension.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Core/Extensions/HttpClientExtension.cs
@@ -50,8 +50,9 @@ namespace Altinn.AccessManagement.UI.Core.Extensions
         /// <param name="requestUri">The request Uri.</param>
         /// <param name="content">The http content.</param>
         /// <param name="platformAccessToken">The platformAccess tokens.</param>
+        /// <param name="cancellationToken">The cancellation tokens.</param>
         /// <returns>A HttpResponseMessage.</returns>
-        public static Task<HttpResponseMessage> PutAsync(this HttpClient httpClient, string authorizationToken, string requestUri, HttpContent content, string platformAccessToken = null)
+        public static Task<HttpResponseMessage> PutAsync(this HttpClient httpClient, string authorizationToken, string requestUri, HttpContent content, string platformAccessToken = null, CancellationToken cancellationToken = default)
         {
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Put, requestUri);
             request.Headers.Add("Authorization", "Bearer " + authorizationToken);
@@ -61,7 +62,7 @@ namespace Altinn.AccessManagement.UI.Core.Extensions
                 request.Headers.Add("PlatformAccessToken", platformAccessToken);
             }
 
-            return httpClient.SendAsync(request, CancellationToken.None);
+            return httpClient.SendAsync(request, cancellationToken);
         }
 
         /// <summary>
@@ -134,8 +135,9 @@ namespace Altinn.AccessManagement.UI.Core.Extensions
         /// <param name="authorizationToken">the authorization token (jwt).</param>
         /// <param name="requestUri">The request Uri.</param>
         /// <param name="platformAccessToken">The platformAccess tokens.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>A HttpResponseMessage.</returns>
-        public static Task<HttpResponseMessage> DeleteAsync(this HttpClient httpClient, string authorizationToken, string requestUri, string platformAccessToken = null)
+        public static Task<HttpResponseMessage> DeleteAsync(this HttpClient httpClient, string authorizationToken, string requestUri, string platformAccessToken = null, CancellationToken cancellationToken = default)
         {
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Delete, requestUri);
             request.Headers.Add("Authorization", "Bearer " + authorizationToken);
@@ -144,7 +146,7 @@ namespace Altinn.AccessManagement.UI.Core.Extensions
                 request.Headers.Add("PlatformAccessToken", platformAccessToken);
             }
 
-            return httpClient.SendAsync(request, CancellationToken.None);
+            return httpClient.SendAsync(request, cancellationToken);
         }
 
         /// <summary>
@@ -155,8 +157,9 @@ namespace Altinn.AccessManagement.UI.Core.Extensions
         /// <param name="requestUri">The request Uri.</param>
         /// <param name="content">The http content.</param>
         /// <param name="platformAccessToken">The platformAccess tokens.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>A HttpResponseMessage.</returns>
-        public static Task<HttpResponseMessage> DeleteAsync(this HttpClient httpClient, string authorizationToken, string requestUri, HttpContent content, string platformAccessToken = null)
+        public static Task<HttpResponseMessage> DeleteAsync(this HttpClient httpClient, string authorizationToken, string requestUri, HttpContent content, string platformAccessToken = null, CancellationToken cancellationToken = default)
         {
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Delete, requestUri);
             request.Headers.Add("Authorization", "Bearer " + authorizationToken);
@@ -166,7 +169,7 @@ namespace Altinn.AccessManagement.UI.Core.Extensions
                 request.Headers.Add("PlatformAccessToken", platformAccessToken);
             }
 
-            return httpClient.SendAsync(request, CancellationToken.None);
+            return httpClient.SendAsync(request, cancellationToken);
         }
     }
 }

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/ClientDelegationClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/ClientDelegationClient.cs
@@ -60,7 +60,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
 
             string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
 
-            HttpResponseMessage response = await _client.GetAsync(token, endpointUrl);
+            HttpResponseMessage response = await _client.GetAsync(token, endpointUrl, cancellationToken);
             PaginatedResult<MyClientDelegation> clients =
                 await ClientUtils.DeserializeIfSuccessfullStatusCode<PaginatedResult<MyClientDelegation>>(response, _logger, "ClientDelegationClient.GetMyClients");
 
@@ -78,7 +78,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
             string endpointUrl = $"enduser/clientdelegations/my/clientproviders?provider={provider}";
             string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
 
-            HttpResponseMessage response = await _client.DeleteAsync(token, endpointUrl);
+            HttpResponseMessage response = await _client.DeleteAsync(token, endpointUrl, null, cancellationToken);
             if (response.IsSuccessStatusCode)
             {
                 return;
@@ -96,7 +96,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
             string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
 
             StringContent requestBody = new StringContent(JsonSerializer.Serialize(payload, _serializerOptions), Encoding.UTF8, "application/json");
-            HttpResponseMessage response = await _client.DeleteAsync(token, endpointUrl, requestBody);
+            HttpResponseMessage response = await _client.DeleteAsync(token, endpointUrl, requestBody, null, cancellationToken);
             string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
             if (response.IsSuccessStatusCode)
             {
@@ -125,7 +125,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
             
             string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
 
-            HttpResponseMessage response = await _client.GetAsync(token, endpointUrl);
+            HttpResponseMessage response = await _client.GetAsync(token, endpointUrl, cancellationToken);
             PaginatedResult<ClientDelegation> clients =
                 await ClientUtils.DeserializeIfSuccessfullStatusCode<PaginatedResult<ClientDelegation>>(response, _logger, "ClientDelegationClient.GetClients");
 
@@ -143,7 +143,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
             string endpointUrl = $"enduser/clientdelegations/agents?party={party}";
             string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
 
-            HttpResponseMessage response = await _client.GetAsync(token, endpointUrl);
+            HttpResponseMessage response = await _client.GetAsync(token, endpointUrl, cancellationToken);
             PaginatedResult<AgentDelegation> agents =
                 await ClientUtils.DeserializeIfSuccessfullStatusCode<PaginatedResult<AgentDelegation>>(response, _logger, "ClientDelegationClient.GetAgents");
 
@@ -161,7 +161,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
             string endpointUrl = $"enduser/clientdelegations/agents/accesspackages?party={party}&to={to}";
             string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
 
-            HttpResponseMessage response = await _client.GetAsync(token, endpointUrl);
+            HttpResponseMessage response = await _client.GetAsync(token, endpointUrl, cancellationToken);
             PaginatedResult<ClientDelegation> clients =
                 await ClientUtils.DeserializeIfSuccessfullStatusCode<PaginatedResult<ClientDelegation>>(response, _logger, "ClientDelegationClient.GetAgentAccessPackages");
 
@@ -179,7 +179,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
             string endpointUrl = $"enduser/clientdelegations/clients/accesspackages?party={party}&from={from}";
             string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
 
-            HttpResponseMessage response = await _client.GetAsync(token, endpointUrl);
+            HttpResponseMessage response = await _client.GetAsync(token, endpointUrl, cancellationToken);
             PaginatedResult<AgentDelegation> agents =
                 await ClientUtils.DeserializeIfSuccessfullStatusCode<PaginatedResult<AgentDelegation>>(response, _logger, "ClientDelegationClient.GetClientAccessPackages");
 
@@ -198,7 +198,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
             string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
 
             StringContent requestBody = new StringContent(JsonSerializer.Serialize(payload, _serializerOptions), Encoding.UTF8, "application/json");
-            HttpResponseMessage response = await _client.PostAsync(token, endpointUrl, requestBody);
+            HttpResponseMessage response = await _client.PostAsync(token, endpointUrl, requestBody, cancellationToken);
             string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
 
             if (!response.IsSuccessStatusCode)
@@ -218,7 +218,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
             string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
 
             StringContent requestBody = new StringContent(JsonSerializer.Serialize(payload, _serializerOptions), Encoding.UTF8, "application/json");
-            HttpResponseMessage response = await _client.DeleteAsync(token, endpointUrl, requestBody);
+            HttpResponseMessage response = await _client.DeleteAsync(token, endpointUrl, requestBody, null, cancellationToken);
             string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
             if (response.IsSuccessStatusCode)
             {
@@ -237,7 +237,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
 
             StringContent requestBody = personInput != null ? new StringContent(JsonSerializer.Serialize(personInput, _serializerOptions), Encoding.UTF8, "application/json") : null;
 
-            var httpResponse = await _client.PostAsync(token, endpointUrl, requestBody);
+            var httpResponse = await _client.PostAsync(token, endpointUrl, requestBody, cancellationToken);
 
             var content = await httpResponse.Content.ReadAsStringAsync();
 
@@ -257,7 +257,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
             string endpointUrl = $"enduser/clientdelegations/agents?party={party}&to={to}&cascade=true";
             string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
 
-            HttpResponseMessage response = await _client.DeleteAsync(token, endpointUrl);
+            HttpResponseMessage response = await _client.DeleteAsync(token, endpointUrl, null, cancellationToken);
             if (response.IsSuccessStatusCode)
             {
                 return;

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/ConsentClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/ConsentClient.cs
@@ -59,7 +59,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
                 string endpointUrl = $"bff/consentrequests/{consentRequestId}";
 
-                HttpResponseMessage response = await _httpClient.GetAsync(token, endpointUrl);
+                HttpResponseMessage response = await _httpClient.GetAsync(token, endpointUrl, cancellationToken);
                 string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
 
                 if (response.IsSuccessStatusCode)
@@ -86,7 +86,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
                 string endpointUrl = $"bff/consentrequests/{consentRequestId}/reject";
 
-                HttpResponseMessage response = await _httpClient.PostAsync(token, endpointUrl, null);
+                HttpResponseMessage response = await _httpClient.PostAsync(token, endpointUrl, null, cancellationToken);
                 string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
 
                 if (response.IsSuccessStatusCode)
@@ -114,7 +114,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
                 string endpointUrl = $"bff/consentrequests/{consentRequestId}/accept";
                 var content = JsonContent.Create(context);
 
-                HttpResponseMessage response = await _httpClient.PostAsync(token, endpointUrl, content);
+                HttpResponseMessage response = await _httpClient.PostAsync(token, endpointUrl, content, cancellationToken);
                 string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
 
                 if (response.IsSuccessStatusCode)
@@ -161,7 +161,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
                 string endpointUrl = $"bff/consentrequests/list/{partyId}";
 
-                HttpResponseMessage response = await _httpClient.GetAsync(token, endpointUrl);
+                HttpResponseMessage response = await _httpClient.GetAsync(token, endpointUrl, cancellationToken);
                 string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
 
                 if (response.IsSuccessStatusCode)
@@ -188,7 +188,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
                 string endpointUrl = $"bff/consents/{consentId}";
 
-                HttpResponseMessage response = await _httpClient.GetAsync(token, endpointUrl);
+                HttpResponseMessage response = await _httpClient.GetAsync(token, endpointUrl, cancellationToken);
                 string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
 
                 if (response.IsSuccessStatusCode)
@@ -215,7 +215,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
                 string endpointUrl = $"bff/consents/{consentId}/revoke";
 
-                HttpResponseMessage response = await _httpClient.PostAsync(token, endpointUrl, null);
+                HttpResponseMessage response = await _httpClient.PostAsync(token, endpointUrl, null, cancellationToken);
                 string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
 
                 if (response.IsSuccessStatusCode)
@@ -242,7 +242,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
                 string endpointUrl = $"bff/consentrequests/count/{partyId}?status={status}";
 
-                HttpResponseMessage response = await _httpClient.GetAsync(token, endpointUrl);
+                HttpResponseMessage response = await _httpClient.GetAsync(token, endpointUrl, cancellationToken);
                 string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
 
                 if (response.IsSuccessStatusCode)

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/RequestClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/RequestClient.cs
@@ -69,7 +69,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
                 string endpointUrl = QueryHelpers.AddQueryString("enduser/request/sent", queryParams.Concat(statusParams));
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
 
-                var httpResponse = await _client.GetAsync(token, endpointUrl);
+                var httpResponse = await _client.GetAsync(token, endpointUrl, cancellationToken);
                 return await ClientUtils.DeserializeIfSuccessfullStatusCode<PaginatedResult<Request>>(httpResponse);
             }
             catch (Exception ex)
@@ -104,7 +104,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
                 string endpointUrl = QueryHelpers.AddQueryString("enduser/request/received", queryParams.Concat(statusParams));
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
 
-                var httpResponse = await _client.GetAsync(token, endpointUrl);
+                var httpResponse = await _client.GetAsync(token, endpointUrl, cancellationToken);
                 return await ClientUtils.DeserializeIfSuccessfullStatusCode<PaginatedResult<Request>>(httpResponse);
             }
             catch (Exception ex)
@@ -122,7 +122,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
                 string endpointUrl = QueryHelpers.AddQueryString($"enduser/request/{id}", "party", party.ToString());
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
 
-                var httpResponse = await _client.GetAsync(token, endpointUrl);
+                var httpResponse = await _client.GetAsync(token, endpointUrl, cancellationToken);
                 return await ClientUtils.DeserializeIfSuccessfullStatusCode<Request>(httpResponse);
             }
             catch (Exception ex)
@@ -140,7 +140,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
                 string endpointUrl = $"enduser/request/draft?id={id}";
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
 
-                var httpResponse = await _client.GetAsync(token, endpointUrl);
+                var httpResponse = await _client.GetAsync(token, endpointUrl, cancellationToken);
                 return await ClientUtils.DeserializeIfSuccessfullStatusCode<Request>(httpResponse);
             }
             catch (Exception ex)
@@ -158,7 +158,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
                 string endpointUrl = $"enduser/request/resource?party={party}&to={to}&resource={resource}";
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
 
-                var httpResponse = await _client.PostAsync(token, endpointUrl, null);
+                var httpResponse = await _client.PostAsync(token, endpointUrl, null, cancellationToken);
                 return await ClientUtils.DeserializeIfSuccessfullStatusCode<Request>(httpResponse);
             }
             catch (Exception ex)
@@ -176,7 +176,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
                 string endpointUrl = $"enduser/request/package?party={party}&to={to}&package={package}";
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
 
-                var httpResponse = await _client.PostAsync(token, endpointUrl, null);
+                var httpResponse = await _client.PostAsync(token, endpointUrl, null, cancellationToken);
                 return await ClientUtils.DeserializeIfSuccessfullStatusCode<Request>(httpResponse);
             }
             catch (Exception ex)
@@ -194,7 +194,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
                 string endpointUrl = $"enduser/request/sent/withdraw?party={party}&id={id}";
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
 
-                var httpResponse = await _client.PutAsync(token, endpointUrl, null);
+                var httpResponse = await _client.PutAsync(token, endpointUrl, null, null, cancellationToken);
                 return await ClientUtils.DeserializeIfSuccessfullStatusCode<Request>(httpResponse);
             }
             catch (Exception ex)
@@ -212,7 +212,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
                 string endpointUrl = $"enduser/request/draft/confirm?party={party}&id={id}";
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
 
-                var httpResponse = await _client.PutAsync(token, endpointUrl, null);
+                var httpResponse = await _client.PutAsync(token, endpointUrl, null, null, cancellationToken);
                 return await ClientUtils.DeserializeIfSuccessfullStatusCode<Request>(httpResponse);
             }
             catch (Exception ex)
@@ -230,7 +230,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
                 string endpointUrl = $"enduser/request/received/reject?party={party}&id={id}";
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
 
-                var httpResponse = await _client.PutAsync(token, endpointUrl, null);
+                var httpResponse = await _client.PutAsync(token, endpointUrl, null, null, cancellationToken);
                 return await ClientUtils.DeserializeIfSuccessfullStatusCode<Request>(httpResponse);
             }
             catch (Exception ex)
@@ -248,7 +248,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
                 string endpointUrl = $"enduser/request/received/approve?party={party}&id={id}";
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
 
-                var httpResponse = await _client.PutAsync(token, endpointUrl, null);
+                var httpResponse = await _client.PutAsync(token, endpointUrl, null, null, cancellationToken);
                 return await ClientUtils.DeserializeIfSuccessfullStatusCode<Request>(httpResponse);
             }
             catch (Exception ex)
@@ -278,7 +278,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
                 string endpointUrl = QueryHelpers.AddQueryString("enduser/request/sent/count", queryParams.Concat(statusParams));
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
 
-                var httpResponse = await _client.GetAsync(token, endpointUrl);
+                var httpResponse = await _client.GetAsync(token, endpointUrl, cancellationToken);
                 return await ClientUtils.DeserializeIfSuccessfullStatusCode<int>(httpResponse);
             }
             catch (Exception ex)
@@ -308,7 +308,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
                 string endpointUrl = QueryHelpers.AddQueryString("enduser/request/received/count", queryParams.Concat(statusParams));
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
 
-                var httpResponse = await _client.GetAsync(token, endpointUrl);
+                var httpResponse = await _client.GetAsync(token, endpointUrl, cancellationToken);
                 return await ClientUtils.DeserializeIfSuccessfullStatusCode<int>(httpResponse);
             }
             catch (Exception ex)

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/SystemUserAgentRequestClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/SystemUserAgentRequestClient.cs
@@ -54,7 +54,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
             {
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
                 string endpoint = $"systemuser/request/agent/{agentRequestId}";
-                HttpResponseMessage response = await _httpClient.GetAsync(token, endpoint);
+                HttpResponseMessage response = await _httpClient.GetAsync(token, endpoint, cancellationToken);
                 
                 if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
                 {
@@ -85,7 +85,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
             {
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
                 string endpoint = $"systemuser/request/agent/{partyId}/{agentRequestId}/approve";
-                HttpResponseMessage response = await _httpClient.PostAsync(token, endpoint, null);
+                HttpResponseMessage response = await _httpClient.PostAsync(token, endpoint, null, cancellationToken);
                 string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);    
                 
                 if (response.IsSuccessStatusCode) 
@@ -110,7 +110,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
             {
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
                 string endpoint = $"systemuser/request/agent/{partyId}/{agentRequestId}/reject";
-                HttpResponseMessage response = await _httpClient.PostAsync(token, endpoint, null);
+                HttpResponseMessage response = await _httpClient.PostAsync(token, endpoint, null, cancellationToken);
                 string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);    
                 
                 if (response.IsSuccessStatusCode) 
@@ -135,7 +135,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
             {
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
                 string endpoint = $"systemuser/request/agent/{partyId}/{orgNo}/pending";
-                HttpResponseMessage response = await _httpClient.GetAsync(token, endpoint);
+                HttpResponseMessage response = await _httpClient.GetAsync(token, endpoint, cancellationToken);
                 string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
 
                 if (response.IsSuccessStatusCode) 
@@ -160,7 +160,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
             {
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
                 string endpoint = $"systemuser/request/agent/{partyId}/{agentRequestId}/escalate";
-                HttpResponseMessage response = await _httpClient.PostAsync(token, endpoint, null);
+                HttpResponseMessage response = await _httpClient.PostAsync(token, endpoint, null, cancellationToken);
                 string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
 
                 if (response.IsSuccessStatusCode)

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/SystemUserChangeRequestClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/SystemUserChangeRequestClient.cs
@@ -54,7 +54,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
             {
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
                 string endpoint = $"systemuser/changerequest/{changeRequestId}";
-                HttpResponseMessage response = await _httpClient.GetAsync(token, endpoint);
+                HttpResponseMessage response = await _httpClient.GetAsync(token, endpoint, cancellationToken);
 
                 if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
                 {
@@ -85,7 +85,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
             {
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
                 string endpoint = $"systemuser/changerequest/{partyId}/{changeRequestId}/approve";
-                HttpResponseMessage response = await _httpClient.PostAsync(token, endpoint, null);
+                HttpResponseMessage response = await _httpClient.PostAsync(token, endpoint, null, cancellationToken);
                 string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);    
                 
                 if (response.IsSuccessStatusCode) 
@@ -110,7 +110,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
             {
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
                 string endpoint = $"systemuser/changerequest/{partyId}/{changeRequestId}/reject";
-                HttpResponseMessage response = await _httpClient.PostAsync(token, endpoint, null);
+                HttpResponseMessage response = await _httpClient.PostAsync(token, endpoint, null, cancellationToken);
                 string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);    
                 
                 if (response.IsSuccessStatusCode) 

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/SystemUserClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/SystemUserClient.cs
@@ -54,7 +54,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
                 string endpointUrl = $"systemuser/{partyId}/{id}";
 
-                HttpResponseMessage response = await _httpClient.GetAsync(token, endpointUrl);
+                HttpResponseMessage response = await _httpClient.GetAsync(token, endpointUrl, cancellationToken);
                 string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
 
                 if (response.IsSuccessStatusCode)
@@ -81,7 +81,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
                 string endpointUrl = $"systemuser/{partyId}/create";
 
                 var content = JsonContent.Create(newSystemUser);
-                HttpResponseMessage response = await _httpClient.PostAsync(token, endpointUrl, content);
+                HttpResponseMessage response = await _httpClient.PostAsync(token, endpointUrl, content, cancellationToken);
                 string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
             
                 if (response.IsSuccessStatusCode) 
@@ -107,7 +107,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
                 string endpointUrl = $"systemuser/{partyId}/{id}";
 
-                HttpResponseMessage response = await _httpClient.DeleteAsync(token, endpointUrl);
+                HttpResponseMessage response = await _httpClient.DeleteAsync(token, endpointUrl, null, cancellationToken);
                 string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
                 
                 if (response.IsSuccessStatusCode)
@@ -133,7 +133,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
                 string endpointUrl = $"systemuser/{partyId}";
 
-                HttpResponseMessage response = await _httpClient.GetAsync(token, endpointUrl);
+                HttpResponseMessage response = await _httpClient.GetAsync(token, endpointUrl, cancellationToken);
                 string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
 
                 if (response.IsSuccessStatusCode)
@@ -159,7 +159,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
                 string endpointUrl = $"systemuser/{partyId}/{id}";
 
-                HttpResponseMessage response = await _httpClient.GetAsync(token, endpointUrl);
+                HttpResponseMessage response = await _httpClient.GetAsync(token, endpointUrl, cancellationToken);
                 string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
 
                 if (response.IsSuccessStatusCode)
@@ -185,7 +185,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
                 string endpointUrl = $"systemuser/agent/{partyId}";
 
-                HttpResponseMessage response = await _httpClient.GetAsync(token, endpointUrl);
+                HttpResponseMessage response = await _httpClient.GetAsync(token, endpointUrl, cancellationToken);
                 string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
 
                 if (response.IsSuccessStatusCode)
@@ -211,7 +211,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
                 string endpointUrl = $"systemuser/agent/{partyId}/{systemUserId}?facilitatorId={facilitatorId}";
 
-                HttpResponseMessage response = await _httpClient.DeleteAsync(token, endpointUrl);
+                HttpResponseMessage response = await _httpClient.DeleteAsync(token, endpointUrl, null, cancellationToken);
                 string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
                 
                 if (response.IsSuccessStatusCode)
@@ -238,7 +238,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
                 string endpointUrl = $"systemuser/agent/{partyId}/clients?facilitator={facilitatorId}{packageQuery}";
 
-                HttpResponseMessage response = await _httpClient.GetAsync(token, endpointUrl);
+                HttpResponseMessage response = await _httpClient.GetAsync(token, endpointUrl, cancellationToken);
                 string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
                 
                 if (response.IsSuccessStatusCode)
@@ -264,7 +264,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
                 string endpointUrl = $"systemuser/{partyId}/{systemuserId}/delegations";
 
-                HttpResponseMessage response = await _httpClient.GetAsync(token, endpointUrl);
+                HttpResponseMessage response = await _httpClient.GetAsync(token, endpointUrl, cancellationToken);
                 string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
 
                 if (response.IsSuccessStatusCode)

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/SystemUserRequestClient.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI.Integration/Clients/SystemUserRequestClient.cs
@@ -54,7 +54,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
             {
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
                 string endpoint = $"systemuser/request/{requestId}";
-                HttpResponseMessage response = await _httpClient.GetAsync(token, endpoint);
+                HttpResponseMessage response = await _httpClient.GetAsync(token, endpoint, cancellationToken);
 
                 if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
                 {
@@ -85,7 +85,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
             {
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
                 string endpoint = $"systemuser/request/{partyId}/{requestId}/approve";
-                HttpResponseMessage response = await _httpClient.PostAsync(token, endpoint, null);
+                HttpResponseMessage response = await _httpClient.PostAsync(token, endpoint, null, cancellationToken);
                 string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);    
                 
                 if (response.IsSuccessStatusCode) 
@@ -110,7 +110,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
             {
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
                 string endpoint = $"systemuser/request/{partyId}/{requestId}/reject";
-                HttpResponseMessage response = await _httpClient.PostAsync(token, endpoint, null);
+                HttpResponseMessage response = await _httpClient.PostAsync(token, endpoint, null, cancellationToken);
                 string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);    
                 
                 if (response.IsSuccessStatusCode) 
@@ -135,7 +135,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
             {
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
                 string endpoint = $"systemuser/request/{partyId}/{orgNo}/pending";
-                HttpResponseMessage response = await _httpClient.GetAsync(token, endpoint);
+                HttpResponseMessage response = await _httpClient.GetAsync(token, endpoint, cancellationToken);
                 string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
 
                 if (response.IsSuccessStatusCode) 
@@ -160,7 +160,7 @@ namespace Altinn.AccessManagement.UI.Integration.Clients
             {
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
                 string endpoint = $"systemuser/request/{partyId}/{requestId}/escalate";
-                HttpResponseMessage response = await _httpClient.PostAsync(token, endpoint, null);
+                HttpResponseMessage response = await _httpClient.PostAsync(token, endpoint, null, cancellationToken);
                 string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
 
                 if (response.IsSuccessStatusCode)

--- a/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/ClientController.cs
+++ b/backend/src/Altinn.AccessManagement.UI/Altinn.AccessManagement.UI/Controllers/ClientController.cs
@@ -395,7 +395,7 @@ namespace Altinn.AccessManagement.UI.Controllers
             {
                 try
                 {
-                    personInput = await HttpContext.Request.ReadFromJsonAsync<PersonInput>();
+                    personInput = await HttpContext.Request.ReadFromJsonAsync<PersonInput>(cancellationToken);
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
## Description
- Forward `cancellationToken` to httpClient where it was missing
- Extend some httpClient override methods to support cancellationToken

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation support for outbound access-management requests.
  * Cancelling an operation now also cancels related HTTP calls and response processing.
  * Request-body JSON reading now respects cancellation requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->